### PR TITLE
Convert all assert calls to a Compadre specific assert

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/cmake/bob.cmake)
 
 bob_begin_package()
 
-
-
+# Set to OFF for significantly faster performance and ON for error tracking
+bob_option(Compadre_DEBUG "Run Compadre Toolkit in DEBUG mode" ON)
 
 ##########
 #
@@ -362,6 +362,7 @@ bob_end_cxx_flags()
 set(Compadre_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 
 set(Compadre_KEY_BOOLS
+    Compadre_DEBUG
     Compadre_USE_CUDA
     Compadre_USE_KokkosCore
     Compadre_USE_LAPACK

--- a/src/Compadre_Evaluator.hpp
+++ b/src/Compadre_Evaluator.hpp
@@ -25,7 +25,7 @@ struct Subview1D {
 
     auto get1DView(const int column_num) -> decltype(Kokkos::subview(_data_in, Kokkos::ALL, column_num)) {
         if (!_scalar_as_vector_if_needed) {
-            assert((column_num<_data_in.dimension_1()) && "Subview asked for column > second dimension of input data.");
+            compadre_assert_debug((column_num<_data_in.dimension_1()) && "Subview asked for column > second dimension of input data.");
         }
         if (column_num<_data_in.dimension_1())
             return Kokkos::subview(_data_in, Kokkos::ALL, column_num);
@@ -61,7 +61,7 @@ struct Subview1D<T, T2, enable_if_t<(T::rank<2)> >
         // to add other logic to the evaluator function calling this so that it knows to do nothing with
         // this data.
         if (!_scalar_as_vector_if_needed) {
-            assert((column_num==0) && "Subview asked for column column_num!=0, but _data_in is rank 1.");
+            compadre_assert_debug((column_num==0) && "Subview asked for column column_num!=0, but _data_in is rank 1.");
         }
         return Kokkos::subview(_data_in, Kokkos::ALL);
     }
@@ -204,7 +204,7 @@ public:
         const int num_targets = neighbor_lists.dimension_0(); // one row for each target
 
         // make sure input and output views have same memory space
-        assert((std::is_same<typename view_type_data_out::memory_space, typename view_type_data_in::memory_space>::value) && 
+        compadre_assert_debug((std::is_same<typename view_type_data_out::memory_space, typename view_type_data_in::memory_space>::value) && 
                 "output_data_single_column view and input_data_single_column view have difference memory spaces.");
 
         bool weight_with_pre_T = (pre_transform_local_index>=0 && pre_transform_global_index>=0) ? true : false;
@@ -336,7 +336,7 @@ public:
                 output_dimensions);
 
         // make sure input and output columns make sense under the target operation
-        assert(((output_dimension_of_operator==1 && output_view_type::rank==1) || output_view_type::rank!=1) && 
+        compadre_assert_debug(((output_dimension_of_operator==1 && output_view_type::rank==1) || output_view_type::rank!=1) && 
                 "Output view is requested as rank 1, but the target requires a rank larger than 1. Try double** as template argument.");
 
         // we need to specialize a template on the rank of the output view type and the input view type

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -18,7 +18,7 @@ void GMLS::generateAlphas() {
     _host_operations = Kokkos::create_mirror_view(_operations);
     
     const int max_num_neighbors = _neighbor_lists.dimension_1()-1;
-    assert((max_num_neighbors >= 0) && "Neighbor lists not set in GMLS class before calling generateAlphas");
+    compadre_assert_release((max_num_neighbors >= 0) && "Neighbor lists not set in GMLS class before calling generateAlphas");
     
     // loop through list of linear reconstruction operations to be performed and set them on the host
     for (int i=0; i<_lro.size(); ++i) _host_operations(i) = _lro[i];
@@ -701,11 +701,11 @@ void GMLS::operator()(const ApplyCurvatureTargets&, const member_type& teamMembe
         double G_determinant;
         if (_dimensions==2) {
             G_determinant = G(0,0);
-            assert((G_determinant!=0) && "Determinant is zero.");
+            compadre_assert_debug((G_determinant!=0) && "Determinant is zero.");
             G_inv(0,0) = 1/G_determinant;
         } else {
             G_determinant = G(0,0)*G(1,1) - G(0,1)*G(1,0); //std::sqrt(G_inv(0,0)*G_inv(1,1) - G_inv(0,1)*G_inv(1,0));
-            assert((G_determinant!=0) && "Determinant is zero.");
+            compadre_assert_debug((G_determinant!=0) && "Determinant is zero.");
             {
                 // inverse of 2x2
                 G_inv(0,0) = G(1,1)/G_determinant;

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -701,11 +701,11 @@ void GMLS::operator()(const ApplyCurvatureTargets&, const member_type& teamMembe
         double G_determinant;
         if (_dimensions==2) {
             G_determinant = G(0,0);
-            compadre_assert_debug((G_determinant!=0) && "Determinant is zero.");
+            compadre_kernel_assert_debug((G_determinant!=0) && "Determinant is zero.");
             G_inv(0,0) = 1/G_determinant;
         } else {
             G_determinant = G(0,0)*G(1,1) - G(0,1)*G(1,0); //std::sqrt(G_inv(0,0)*G_inv(1,1) - G_inv(0,1)*G_inv(1,0));
-            compadre_assert_debug((G_determinant!=0) && "Determinant is zero.");
+            compadre_kernel_assert_debug((G_determinant!=0) && "Determinant is zero.");
             {
                 // inverse of 2x2
                 G_inv(0,0) = G(1,1)/G_determinant;

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -8,9 +8,6 @@
 #include "Compadre_Operators.hpp"
 #include "Compadre_LinearAlgebra_Definitions.hpp"
 
-#define ASSERT_WITH_MESSAGE(condition, message) do { \
-if (!(condition)) { printf((message)); } \
-assert ((condition)); } while(false)
 
 namespace Compadre {
 
@@ -622,7 +619,7 @@ public:
             if (_data_sampling_functional == SamplingFunctional::VectorPointSample)
                 _data_sampling_functional = SamplingFunctional::ManifoldVectorPointSample;
         }
-        assert((SamplingOutputTensorRank[(int)_polynomial_sampling_functional] 
+        compadre_assert_release((SamplingOutputTensorRank[(int)_polynomial_sampling_functional] 
                     == SamplingOutputTensorRank[(int)_polynomial_sampling_functional]) 
                 && "Output rank of polynomial and data sampling functionals must match.");
     };
@@ -820,7 +817,7 @@ public:
             const int output_component_axis_2, const int input_component_axis_1, const int input_component_axis_2) const {
 
         const int lro_number = _lro_lookup[(int)lro];
-        assert((lro_number >= 0) && "getAlphasColumnOffset called for a TargetOperation that was not registered.");
+        compadre_assert_debug((lro_number >= 0) && "getAlphasColumnOffset called for a TargetOperation that was not registered.");
 
         // the target functional input indexing is sized based on the output rank of the sampling
         // functional used, which can not be inferred unless a specification of target functional,
@@ -1127,23 +1124,6 @@ public:
         _host_T = Kokkos::create_mirror_view(_T);
         Kokkos::deep_copy(_host_T, _T);
     }
-
-    ////! Sets orthonormal tangent directions for reconstruction on a manifold. The first rank of this 2D array 
-    ////! corresponds to the target indices, i.e., rows of the neighbor lists 2D array. The second rank is the 
-    ////! ordinal of the tangent direction (spatial dimensions-1 are tangent, last one is normal), and the third 
-    ////! rank is indices into the spatial dimension.
-    //template<typename view_type>
-    //void setTangentDirections(Kokkos::View<double***, Kokkos::DefaultExecutionSpace> tangent_directions) {
-    //    assert((tangent_directions.dimension_0()==_target_coordinates.dimension_0()) && 
-    //            "First rank of tangent_direction has wrong dimension.");
-    //    assert((tangent_directions.dimension_1()==_dimensions) && 
-    //            "Second rank of tangent_direction has wrong dimension.");
-    //    assert((tangent_directions.dimension_2()==_dimensions) && 
-    //            "Third rank of tangent_direction has wrong dimension.");
-    //    // copy smart pointer to view on device
-    //    _T = tangent_directions;
-    //    _orthonormal_tangent_space_provided = true;
-    //}
 
     //! Type for weighting kernel for GMLS problem
     void setWeightingType( const std::string &wt) {

--- a/src/Compadre_GMLS_Quadrature.hpp
+++ b/src/Compadre_GMLS_Quadrature.hpp
@@ -55,7 +55,7 @@ void GMLS::generate1DQuadrature() {
         parameterized_quadrature_sites[4] = 0.5*(1-1./3.*std::sqrt(5+2*std::sqrt(10./7.)));
         break;
     default:
-        ASSERT_WITH_MESSAGE(false, "Unsupported number of quadrature points.");
+        compadre_assert_release(false && "Unsupported number of quadrature points.");
         quadrature_weights[0] = 0.5;
         quadrature_weights[1] = 0.5;
         parameterized_quadrature_sites[0] = 0.5*(1-std::sqrt(1./3.));

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -612,7 +612,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                 }
             }
         } else {
-            assert((false) && "Functionality not yet available.");
+            compadre_assert_release((false) && "Functionality not yet available.");
         }
         } // !operation_handled
     }
@@ -655,7 +655,7 @@ void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_ve
                 }
             });
         } else {
-            assert((false) && "Functionality not yet available.");
+            compadre_assert_release((false) && "Functionality not yet available.");
         }
     }
 }
@@ -1022,17 +1022,17 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                 } else if (_reconstruction_space_rank == 1
                         && _polynomial_sampling_functional 
                             == SamplingFunctional::StaggeredEdgeIntegralSample) {
-                    assert((false) && "Functionality not yet available.");
+                    compadre_assert_release((false) && "Functionality not yet available.");
 
                 // staggered gradient w/ edge integrals known analytically, using a basis
                 // of potentials
                 } else if (_reconstruction_space_rank == 0
                         && _polynomial_sampling_functional 
                             == SamplingFunctional::StaggeredEdgeAnalyticGradientIntegralSample) {
-                    assert((false) && "Functionality not yet available.");
+                    compadre_assert_release((false) && "Functionality not yet available.");
 
                 } else {
-                    assert((false) && "Functionality not yet available.");
+                    compadre_assert_release((false) && "Functionality not yet available.");
                 }
             } else if (_operations(i) == TargetOperation::DivergenceOfVectorPointEvaluation) {
                 // vector basis
@@ -1174,10 +1174,10 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
 
                     });
                 } else {
-                    assert((false) && "Functionality not yet available.");
+                    compadre_assert_release((false) && "Functionality not yet available.");
                 }
             } else {
-                assert((false) && "Functionality not yet available.");
+                compadre_assert_release((false) && "Functionality not yet available.");
             }
         } else if (_dimensions==2) { // 1D manifold in 2D problem
             if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
@@ -1193,7 +1193,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                     }
                 });
             } else {
-                assert((false) && "Functionality not yet available.");
+                compadre_assert_release((false) && "Functionality not yet available.");
             }
         }
         } // !operation_handled

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -612,7 +612,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                 }
             }
         } else {
-            compadre_assert_release((false) && "Functionality not yet available.");
+            compadre_kernel_assert_release((false) && "Functionality not yet available.");
         }
         } // !operation_handled
     }
@@ -655,7 +655,7 @@ void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_ve
                 }
             });
         } else {
-            compadre_assert_release((false) && "Functionality not yet available.");
+            compadre_kernel_assert_release((false) && "Functionality not yet available.");
         }
     }
 }
@@ -1022,17 +1022,17 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                 } else if (_reconstruction_space_rank == 1
                         && _polynomial_sampling_functional 
                             == SamplingFunctional::StaggeredEdgeIntegralSample) {
-                    compadre_assert_release((false) && "Functionality not yet available.");
+                    compadre_kernel_assert_release((false) && "Functionality not yet available.");
 
                 // staggered gradient w/ edge integrals known analytically, using a basis
                 // of potentials
                 } else if (_reconstruction_space_rank == 0
                         && _polynomial_sampling_functional 
                             == SamplingFunctional::StaggeredEdgeAnalyticGradientIntegralSample) {
-                    compadre_assert_release((false) && "Functionality not yet available.");
+                    compadre_kernel_assert_release((false) && "Functionality not yet available.");
 
                 } else {
-                    compadre_assert_release((false) && "Functionality not yet available.");
+                    compadre_kernel_assert_release((false) && "Functionality not yet available.");
                 }
             } else if (_operations(i) == TargetOperation::DivergenceOfVectorPointEvaluation) {
                 // vector basis
@@ -1174,10 +1174,10 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
 
                     });
                 } else {
-                    compadre_assert_release((false) && "Functionality not yet available.");
+                    compadre_kernel_assert_release((false) && "Functionality not yet available.");
                 }
             } else {
-                compadre_assert_release((false) && "Functionality not yet available.");
+                compadre_kernel_assert_release((false) && "Functionality not yet available.");
             }
         } else if (_dimensions==2) { // 1D manifold in 2D problem
             if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
@@ -1193,7 +1193,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                     }
                 });
             } else {
-                compadre_assert_release((false) && "Functionality not yet available.");
+                compadre_kernel_assert_release((false) && "Functionality not yet available.");
             }
         }
         } // !operation_handled

--- a/src/Compadre_LinearAlgebra.cpp
+++ b/src/Compadre_LinearAlgebra.cpp
@@ -171,29 +171,29 @@ void batchSVDFactorize(double *P, int lda, int nda, double *RHS, int ldb, int nd
 
       for (int i=0; i<NUM_STREAMS; ++i) {
           cusolver_stat = cusolverDnCreate(&cusolver_handles[i]);
-          assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "DN Create");
+          compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "DN Create");
           cudaStat1 = cudaStreamCreateWithFlags(&streams[i], cudaStreamNonBlocking);
-          assert(cudaSuccess == cudaStat1 && "Cuda Stream Create");
+          compadre_assert_release(cudaSuccess == cudaStat1 && "Cuda Stream Create");
           cusolver_stat = cusolverDnSetStream(cusolver_handles[i], streams[i]);
-          assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Cuda Set Stream");
+          compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Cuda Set Stream");
       }
 
 
       cusolver_stat = cusolverDnCreateGesvdjInfo(&gesvdj_params);
-      assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Create GesvdjInfo");
+      compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Create GesvdjInfo");
 
       const double tol = 1.e-14;
       const int max_sweeps = 15;
       const int sort_svd  = 1;   /* sort singular values */
 
       cusolver_stat = cusolverDnXgesvdjSetTolerance(gesvdj_params, tol);
-      assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Set Tolerance");
+      compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Set Tolerance");
 
       cusolver_stat = cusolverDnXgesvdjSetMaxSweeps(gesvdj_params, max_sweeps);
-      assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Set Sweeps");
+      compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Set Sweeps");
 
       cusolver_stat = cusolverDnXgesvdjSetSortEig(gesvdj_params, sort_svd);
-      assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Sort SVD");
+      compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Sort SVD");
 
       const cusolverEigMode_t jobz = CUSOLVER_EIG_MODE_VECTOR; /* compute singular vectors */
 
@@ -214,11 +214,11 @@ void batchSVDFactorize(double *P, int lda, int nda, double *RHS, int ldb, int nd
               V.ptr_on_device(), ldv, // V
               &lwork, gesvdj_params, num_matrices
           );
-          assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Get Work Size");
+          compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Get Work Size");
 
           Kokkos::View<double*> work("work for cusolver", lwork);
           cudaStat1 = cudaDeviceSynchronize();
-          assert(cudaSuccess == cudaStat1 && "Device Sync 1");
+          compadre_assert_release(cudaSuccess == cudaStat1 && "Device Sync 1");
         Kokkos::Profiling::popRegion();
 
         Kokkos::Profiling::pushRegion("SVD::Execution");
@@ -233,8 +233,8 @@ void batchSVDFactorize(double *P, int lda, int nda, double *RHS, int ldb, int nd
               devInfo.ptr_on_device(), gesvdj_params, num_matrices
           );
           cudaStat1 = cudaDeviceSynchronize();
-          assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Solver Didn't Succeed");
-          assert(cudaSuccess == cudaStat1 && "Device Sync 2");
+          compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Solver Didn't Succeed");
+          compadre_assert_release(cudaSuccess == cudaStat1 && "Device Sync 2");
         Kokkos::Profiling::popRegion();
 
     } else { // bigger than 32 (batched dgesvdj can only handle 32x32)
@@ -247,7 +247,7 @@ void batchSVDFactorize(double *P, int lda, int nda, double *RHS, int ldb, int nd
   
           //cusolver_stat = cusolverDnDgesvd_bufferSize(
           //    cusolver_handles[0], M, N, &lwork );
-          //assert (cusolver_stat == CUSOLVER_STATUS_SUCCESS && "dgesvd Work Size Failed");
+          //compadre_assert_release (cusolver_stat == CUSOLVER_STATUS_SUCCESS && "dgesvd Work Size Failed");
   
           cusolver_stat = cusolverDnDgesvdj_bufferSize(
               cusolver_handles[0], jobz, econ,
@@ -258,7 +258,7 @@ void batchSVDFactorize(double *P, int lda, int nda, double *RHS, int ldb, int nd
               V.ptr_on_device(), ldv, // V
               &lwork, gesvdj_params
           );
-          assert(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Get Work Size");
+          compadre_assert_release(CUSOLVER_STATUS_SUCCESS == cusolver_stat && "Get Work Size");
   
           Kokkos::View<double*> work("CUDA work space", lwork*num_matrices);
           //Kokkos::View<double*> rwork("CUDA work space", (min_mn-1)*num_matrices);

--- a/src/Compadre_PointCloudSearch.hpp
+++ b/src/Compadre_PointCloudSearch.hpp
@@ -1,6 +1,6 @@
 #include <tpl/nanoflann.hpp>
 #include <Kokkos_Core.hpp>
-#include <assert.h>
+#include "Compadre_Typedefs.hpp"
 
 namespace Compadre {
 
@@ -20,9 +20,9 @@ class PointCloudSearch {
 
         PointCloudSearch(view_type src_pts_view, view_type trg_pts_view) 
                 : _src_pts_view(src_pts_view), _trg_pts_view(trg_pts_view) {
-            assert((std::is_same<typename view_type::memory_space, Kokkos::HostSpace>::value) &&
+            compadre_assert_release((std::is_same<typename view_type::memory_space, Kokkos::HostSpace>::value) &&
                     "Views passed to PointCloudSearch at construction should reside on the host.");
-            assert((src_pts_view.dimension_1()==3 && trg_pts_view.dimension_1()==3) &&
+            compadre_assert_release((src_pts_view.dimension_1()==3 && trg_pts_view.dimension_1()==3) &&
                     "Views passed to PointCloudSearch at construction must have second dimension of 3.");
         };
 
@@ -58,9 +58,9 @@ class PointCloudSearch {
                 epsilons_view_type epsilons, const int neighbors_needed, 
                 const int dimension = 3, const double epsilon_multiplier = 1.2) {
 
-            assert((std::is_same<typename neighbor_lists_view_type::memory_space, Kokkos::HostSpace>::value) &&
+            compadre_assert_release((std::is_same<typename neighbor_lists_view_type::memory_space, Kokkos::HostSpace>::value) &&
                     "Views passed to generateNeighborListsFromKNNSearch should reside on the host.");
-            assert((std::is_same<typename epsilons_view_type::memory_space, Kokkos::HostSpace>::value) &&
+            compadre_assert_release((std::is_same<typename epsilons_view_type::memory_space, Kokkos::HostSpace>::value) &&
                     "Views passed to generateNeighborListsFromKNNSearch should reside on the host.");
 
             // define the cloud_type using this class
@@ -83,10 +83,10 @@ class PointCloudSearch {
             const int num_target_sites = _trg_pts_view.dimension_0();
 
             // allocate neighbor lists and epsilons
-            assert((neighbor_lists.dimension_0()==num_target_sites 
+            compadre_assert_release((neighbor_lists.dimension_0()==num_target_sites 
                         && neighbor_lists.dimension_1()==neighbors_needed+1) 
                         && "neighbor lists View does not have the correct dimensions");
-            assert((epsilons.dimension_0()==num_target_sites)
+            compadre_assert_release((epsilons.dimension_0()==num_target_sites)
                         && "epsilons View does not have the correct dimension");
 
             typedef Kokkos::View<double*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > 

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -40,6 +40,9 @@ typedef typename pool_type::generator_type generator_type;
         throw std::logic_error(_ss_.str());                             \
     }                                                                   \
   } while (0)
+
+//! compadre_kernel_assert_release is similar to compadre_assert_release, but is a call on the device, 
+//! namely inside of a function marked KOKKOS_INLINE_FUNCTION
 # define compadre_kernel_assert_release(condition) do { \
     if ( ! (condition))                         \
       Kokkos::abort(#condition);                \
@@ -64,5 +67,7 @@ typedef typename pool_type::generator_type generator_type;
 #  define compadre_assert_debug(condition)
 #  define compadre_kernel_assert_debug(condition)
 #endif
+//! compadre_kernel_assert_debug is similar to compadre_assert_debug, but is a call on the device, 
+//! namely inside of a function marked KOKKOS_INLINE_FUNCTION
 
 #endif

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -47,7 +47,7 @@ typedef typename pool_type::generator_type generator_type;
 
 //! compadre_assert_debug is used for assertions that are checked in loops, as these significantly
 //! impact performance. When NDEBUG is set, these conditions are not checked.
-#ifndef NDEBUG
+#ifdef COMPADRE_DEBUG
 # define compadre_assert_debug(condition) do {                                \
     if ( ! (condition)) {                                               \
       std::stringstream _ss_;                                           \
@@ -61,8 +61,8 @@ typedef typename pool_type::generator_type generator_type;
       Kokkos::abort(#condition);                \
   } while (0)
 #else
-#  define compadre_assert(condition)
-#  define compadre_kernel_assert(condition)
+#  define compadre_assert_debug(condition)
+#  define compadre_kernel_assert_debug(condition)
 #endif
 
 #endif

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -5,9 +5,9 @@
 
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
-#include <assert.h>
 #include <type_traits>
 #include <vector>
+#include <sstream>
 
 // KOKKOS TYPEDEFS
 
@@ -29,5 +29,40 @@ typedef Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_loc
 
 typedef Kokkos::Random_XorShift64_Pool<> pool_type;
 typedef typename pool_type::generator_type generator_type;
+
+//! compadre_assert_release is used for assertions that should always be checked, but generally 
+//! are not expensive to verify or are not called frequently. 
+# define compadre_assert_release(condition) do {                                \
+    if ( ! (condition)) {                                               \
+      std::stringstream _ss_;                                           \
+      _ss_ << __FILE__ << ":" << __LINE__ << ": FAIL:\n" << #condition  \
+        << "\n";                                                        \
+        throw std::logic_error(_ss_.str());                             \
+    }                                                                   \
+  } while (0)
+# define compadre_kernel_assert_release(condition) do { \
+    if ( ! (condition))                         \
+      Kokkos::abort(#condition);                \
+  } while (0)
+
+//! compadre_assert_debug is used for assertions that are checked in loops, as these significantly
+//! impact performance. When NDEBUG is set, these conditions are not checked.
+#ifndef NDEBUG
+# define compadre_assert_debug(condition) do {                                \
+    if ( ! (condition)) {                                               \
+      std::stringstream _ss_;                                           \
+      _ss_ << __FILE__ << ":" << __LINE__ << ": FAIL:\n" << #condition  \
+        << "\n";                                                        \
+        throw std::logic_error(_ss_.str());                             \
+    }                                                                   \
+  } while (0)
+# define compadre_kernel_assert_debug(condition) do { \
+    if ( ! (condition))                         \
+      Kokkos::abort(#condition);                \
+  } while (0)
+#else
+#  define compadre_assert(condition)
+#  define compadre_kernel_assert(condition)
+#endif
 
 #endif


### PR DESCRIPTION
assert calls are replaced by one of:

compadre_assert_release 
compadre_assert_debug
compadre_kernel_assert_release
compadre_kernel_assert_debug

The difference between **debug** and **release** is that release checks are always performed, so they should not be used inside of compute intense loops. Debug checks are only performed if the CMake variable **Compadre_DEBUG** is set to ON, which it is by default.

compadre_assert... calls are for assertions that are checked on host (CPU) code, while compadre_kernel_assert... calls are for assertions that re checked on the device (GPU) code.

This fixes issue #11 