### PR TITLE
Changed neighbor searches

### DIFF
--- a/examples/GMLS_Device.cpp
+++ b/examples/GMLS_Device.cpp
@@ -94,10 +94,6 @@ bool all_passed = true;
     // minimum neighbors for unisolvency is the same as the size of the polynomial basis 
     const int min_neighbors = Compadre::GMLS::getNP(order, dimension);
     
-    // maximum neighbors calculated to be the minimum number of neighbors needed for unisolvency 
-    // enlarged by some multiplier (generally 10% to 40%, but calculated by GMLS class)
-    const int max_neighbors = Compadre::GMLS::getNN(order, dimension);
-    
     //! [Parse Command Line Arguments]
     Kokkos::Timer timer;
     Kokkos::Profiling::pushRegion("Setup Point Data");
@@ -109,16 +105,6 @@ bool all_passed = true;
     
     // number of source coordinate sites that will fill a box of [-1,1]x[-1,1]x[-1,1] with a spacing approximately h
     const int number_source_coords = std::pow(n_neg1_to_1, dimension);
-    
-    // each row is a neighbor list for a target site, with the first column of each row containing
-    // the number of neighbors for that rows corresponding target site
-    Kokkos::View<int**, Kokkos::DefaultExecutionSpace> neighbor_lists_device("neighbor lists", 
-            number_target_coords, max_neighbors+1); // first column is # of neighbors
-    Kokkos::View<int**>::HostMirror neighbor_lists = Kokkos::create_mirror_view(neighbor_lists_device);
-    
-    // each target site has a window size
-    Kokkos::View<double*, Kokkos::DefaultExecutionSpace> epsilon_device("h supports", number_target_coords);
-    Kokkos::View<double*>::HostMirror epsilon = Kokkos::create_mirror_view(epsilon_device);
     
     // coordinates of source sites
     Kokkos::View<double**, Kokkos::DefaultExecutionSpace> source_coords_device("source coordinates", 
@@ -240,12 +226,26 @@ bool all_passed = true;
     // Point cloud construction for neighbor search
     // CreatePointCloudSearch constructs an object of type PointCloudSearch, but deduces the templates for you
     auto point_cloud_search(CreatePointCloudSearch(source_coords, target_coords));
+
+    // each row is a neighbor list for a target site, with the first column of each row containing
+    // the number of neighbors for that rows corresponding target site
+    double epsilon_multiplier = 1.5;
+    int estimated_upper_bound_number_neighbors = 
+        point_cloud_search.getEstimatedNumberNeighborsUpperBound(min_neighbors, dimension, epsilon_multiplier);
+
+    Kokkos::View<int**, Kokkos::DefaultExecutionSpace> neighbor_lists_device("neighbor lists", 
+            number_target_coords, estimated_upper_bound_number_neighbors); // first column is # of neighbors
+    Kokkos::View<int**>::HostMirror neighbor_lists = Kokkos::create_mirror_view(neighbor_lists_device);
+    
+    // each target site has a window size
+    Kokkos::View<double*, Kokkos::DefaultExecutionSpace> epsilon_device("h supports", number_target_coords);
+    Kokkos::View<double*>::HostMirror epsilon = Kokkos::create_mirror_view(epsilon_device);
     
     // query the point cloud to generate the neighbor lists using a kdtree to produce the n nearest neighbor
-    // to each target site, adding 20% to whatever the distance away the further neighbor used is from
+    // to each target site, adding (epsilon_multiplier-1)*100% to whatever the distance away the further neighbor used is from
     // each target to the view for epsilon
-    point_cloud_search.generateNeighborListsFromKNNSearch(neighbor_lists, epsilon, max_neighbors, dimension, 
-            1.2 /* epsilon multiplier */);
+    point_cloud_search.generateNeighborListsFromKNNSearch(neighbor_lists, epsilon, min_neighbors, dimension, 
+            epsilon_multiplier);
     
     
     //! [Performing Neighbor Search]

--- a/examples/GMLS_Manifold.cpp
+++ b/examples/GMLS_Manifold.cpp
@@ -82,10 +82,6 @@ Kokkos::initialize(argc, args);
     // dimension has one subtracted because it is a D-1 manifold represented in D dimensions
     const int min_neighbors = Compadre::GMLS::getNP(order, dimension-1);
     
-    // maximum neighbors calculated to be the minimum number of neighbors needed for unisolvency 
-    // enlarged by some multiplier (generally 10% to 40%, but calculated by GMLS class)
-    const int max_neighbors = Compadre::GMLS::getNN(order, dimension-1);
-    
     //! [Parse Command Line Arguments]
     Kokkos::Timer timer;
     Kokkos::Profiling::pushRegion("Setup Point Data");
@@ -137,17 +133,6 @@ Kokkos::initialize(argc, args);
     Kokkos::resize(source_coords, number_source_coords, 3);
     Kokkos::resize(source_coords_device, number_source_coords, 3);
 
-
-    // each row is a neighbor list for a target site, with the first column of each row containing
-    // the number of neighbors for that rows corresponding target site
-    Kokkos::View<int**, Kokkos::DefaultExecutionSpace> neighbor_lists_device("neighbor lists", 
-            number_target_coords, max_neighbors+1); // first column is # of neighbors
-    Kokkos::View<int**>::HostMirror neighbor_lists = Kokkos::create_mirror_view(neighbor_lists_device);
-    
-    // each target site has a window size
-    Kokkos::View<double*, Kokkos::DefaultExecutionSpace> epsilon_device("h supports", number_target_coords);
-    Kokkos::View<double*>::HostMirror epsilon = Kokkos::create_mirror_view(epsilon_device);
-    
     // coordinates of target sites
     Kokkos::View<double**, Kokkos::DefaultExecutionSpace> target_coords_device ("target coordinates", 
             number_target_coords, 3);
@@ -247,13 +232,26 @@ Kokkos::initialize(argc, args);
     // Point cloud construction for neighbor search
     // CreatePointCloudSearch constructs an object of type PointCloudSearch, but deduces the templates for you
     auto point_cloud_search(CreatePointCloudSearch(source_coords, target_coords));
+
+    // each row is a neighbor list for a target site, with the first column of each row containing
+    // the number of neighbors for that rows corresponding target site
+    double epsilon_multiplier = 1.9;
+    int estimated_upper_bound_number_neighbors = 
+        point_cloud_search.getEstimatedNumberNeighborsUpperBound(min_neighbors, dimension, epsilon_multiplier);
+
+    Kokkos::View<int**, Kokkos::DefaultExecutionSpace> neighbor_lists_device("neighbor lists", 
+            number_target_coords, estimated_upper_bound_number_neighbors); // first column is # of neighbors
+    Kokkos::View<int**>::HostMirror neighbor_lists = Kokkos::create_mirror_view(neighbor_lists_device);
+    
+    // each target site has a window size
+    Kokkos::View<double*, Kokkos::DefaultExecutionSpace> epsilon_device("h supports", number_target_coords);
+    Kokkos::View<double*>::HostMirror epsilon = Kokkos::create_mirror_view(epsilon_device);
     
     // query the point cloud to generate the neighbor lists using a kdtree to produce the n nearest neighbor
-    // to each target site, adding 20% to whatever the distance away the further neighbor used is from
+    // to each target site, adding (epsilon_multiplier-1)*100% to whatever the distance away the further neighbor used is from
     // each target to the view for epsilon
-    point_cloud_search.generateNeighborListsFromKNNSearch(neighbor_lists, epsilon, max_neighbors, dimension, 
-            1.2 /* epsilon multiplier */);
-    
+    point_cloud_search.generateNeighborListsFromKNNSearch(neighbor_lists, epsilon, min_neighbors, dimension, 
+            epsilon_multiplier);
 
     //! [Performing Neighbor Search]
     

--- a/examples/GMLS_Staggered_Manifold.cpp
+++ b/examples/GMLS_Staggered_Manifold.cpp
@@ -80,11 +80,7 @@ Kokkos::initialize(argc, args);
     
     // minimum neighbors for unisolvency is the same as the size of the polynomial basis 
     // dimension has one subtracted because it is a D-1 manifold represented in D dimensions
-    const int min_neighbors = Compadre::GMLS::getNP(order, dimension-1);
-    
-    // maximum neighbors calculated to be the minimum number of neighbors needed for unisolvency 
-    // enlarged by some multiplier (generally 10% to 40%, but calculated by GMLS class)
-    const int max_neighbors = 1.5*Compadre::GMLS::getNN(order, dimension-1);
+    const int min_neighbors = Compadre::GMLS::getNP(order+1, dimension-1);
     
     //! [Parse Command Line Arguments]
     Kokkos::Timer timer;
@@ -136,16 +132,6 @@ Kokkos::initialize(argc, args);
     Kokkos::resize(source_coords, number_source_coords, 3);
     Kokkos::resize(source_coords_device, number_source_coords, 3);
 
-    // each row is a neighbor list for a target site, with the first column of each row containing
-    // the number of neighbors for that rows corresponding target site
-    Kokkos::View<int**, Kokkos::DefaultExecutionSpace> neighbor_lists_device("neighbor lists", 
-            number_target_coords, max_neighbors+1); // first column is # of neighbors
-    Kokkos::View<int**>::HostMirror neighbor_lists = Kokkos::create_mirror_view(neighbor_lists_device);
-    
-    // each target site has a window size
-    Kokkos::View<double*, Kokkos::DefaultExecutionSpace> epsilon_device("h supports", number_target_coords);
-    Kokkos::View<double*>::HostMirror epsilon = Kokkos::create_mirror_view(epsilon_device);
-    
     // coordinates of target sites
     Kokkos::View<double**, Kokkos::DefaultExecutionSpace> target_coords_device("target coordinates", 
             number_target_coords, 3);
@@ -223,12 +209,26 @@ Kokkos::initialize(argc, args);
     // Point cloud construction for neighbor search
     // CreatePointCloudSearch constructs an object of type PointCloudSearch, but deduces the templates for you
     auto point_cloud_search(CreatePointCloudSearch(source_coords, target_coords));
+
+    // each row is a neighbor list for a target site, with the first column of each row containing
+    // the number of neighbors for that rows corresponding target site
+    double epsilon_multiplier = 1.9;
+    int estimated_upper_bound_number_neighbors = 
+        point_cloud_search.getEstimatedNumberNeighborsUpperBound(min_neighbors, dimension, epsilon_multiplier);
+
+    Kokkos::View<int**, Kokkos::DefaultExecutionSpace> neighbor_lists_device("neighbor lists", 
+            number_target_coords, estimated_upper_bound_number_neighbors); // first column is # of neighbors
+    Kokkos::View<int**>::HostMirror neighbor_lists = Kokkos::create_mirror_view(neighbor_lists_device);
+    
+    // each target site has a window size
+    Kokkos::View<double*, Kokkos::DefaultExecutionSpace> epsilon_device("h supports", number_target_coords);
+    Kokkos::View<double*>::HostMirror epsilon = Kokkos::create_mirror_view(epsilon_device);
     
     // query the point cloud to generate the neighbor lists using a kdtree to produce the n nearest neighbor
-    // to each target site, adding 20% to whatever the distance away the further neighbor used is from
+    // to each target site, adding (epsilon_multiplier-1)*100% to whatever the distance away the further neighbor used is from
     // each target to the view for epsilon
-    point_cloud_search.generateNeighborListsFromKNNSearch(neighbor_lists, epsilon, max_neighbors, dimension, 
-            1.2 /* epsilon multiplier */);
+    point_cloud_search.generateNeighborListsFromKNNSearch(neighbor_lists, epsilon, min_neighbors, dimension, 
+            epsilon_multiplier);
     
 
     //! [Performing Neighbor Search]

--- a/examples/GMLS_Staggered_Manifold.cpp
+++ b/examples/GMLS_Staggered_Manifold.cpp
@@ -80,7 +80,7 @@ Kokkos::initialize(argc, args);
     
     // minimum neighbors for unisolvency is the same as the size of the polynomial basis 
     // dimension has one subtracted because it is a D-1 manifold represented in D dimensions
-    const int min_neighbors = Compadre::GMLS::getNP(order+1, dimension-1);
+    const int min_neighbors = Compadre::GMLS::getNP(order, dimension-1);
     
     //! [Parse Command Line Arguments]
     Kokkos::Timer timer;
@@ -212,7 +212,7 @@ Kokkos::initialize(argc, args);
 
     // each row is a neighbor list for a target site, with the first column of each row containing
     // the number of neighbors for that rows corresponding target site
-    double epsilon_multiplier = 1.9;
+    double epsilon_multiplier = 1.5;
     int estimated_upper_bound_number_neighbors = 
         point_cloud_search.getEstimatedNumberNeighborsUpperBound(min_neighbors, dimension, epsilon_multiplier);
 
@@ -229,7 +229,7 @@ Kokkos::initialize(argc, args);
     // each target to the view for epsilon
     point_cloud_search.generateNeighborListsFromKNNSearch(neighbor_lists, epsilon, min_neighbors, dimension, 
             epsilon_multiplier);
-    
+
 
     //! [Performing Neighbor Search]
     

--- a/examples/Python_3D_Convergence.py.in
+++ b/examples/Python_3D_Convergence.py.in
@@ -65,17 +65,48 @@ def test1(ND):
     source_sites = np.array(t_sites, dtype=np.dtype('d'))
 
 
+    ## neighbor search
+    #my_kdtree = kdtree.KDTree(source_sites, leafsize=10)
+    #neighbor_number_multiplier = (1 + polyOrder)
+    #neighbor_lists = []
+    #epsilons = []
+    #for target_num in range(NT):
+    #    query_result = my_kdtree.query(target_sites[target_num], k=int(neighbor_number_multiplier*GMLS_Module.getNP(polyOrder, dimensions)), eps=0)
+    #    neighbor_lists.append([query_result[1].size,] + list(query_result[1]))
+    #    epsilons.append(query_result[0][-1])
+    #neighbor_lists = np.array(neighbor_lists, dtype=np.dtype(int))
+    #epsilons = np.array(epsilons, dtype=np.dtype('d'))
+
     # neighbor search
     my_kdtree = kdtree.KDTree(source_sites, leafsize=10)
-    neighbor_number_multiplier = (1 + polyOrder)
+    min_neighbors_needed = GMLS_Module.getNP(polyOrder, dimensions);
     neighbor_lists = []
-    epsilons = []
+    temp_neighbor_lists = []
+    epsilons = np.zeros([NT])
+
+    # first pass specifying number of neighbors needed
     for target_num in range(NT):
-        query_result = my_kdtree.query(target_sites[target_num], k=int(neighbor_number_multiplier*GMLS_Module.getNP(polyOrder, dimensions)), eps=0)
-        neighbor_lists.append([query_result[1].size,] + list(query_result[1]))
-        epsilons.append(query_result[0][-1])
-    neighbor_lists = np.array(neighbor_lists, dtype=np.dtype(int))
-    epsilons = np.array(epsilons, dtype=np.dtype('d'))
+        query_result = my_kdtree.query(target_sites[target_num], k=min_neighbors_needed, eps=0)
+        epsilons[target_num] = query_result[0][-1]
+        assert query_result[1].size >= min_neighbors_needed, "Not enough neighbors exist on this process [%d needed, but %d found]."%(min_neighbors_needed,query_results[1].size)
+
+    # enlarge epsilons by 50%
+    # second pass using the enlarged epsilon search
+    max_neighbors = 0
+    for target_num in range(NT):
+        epsilons[target_num] = epsilons[target_num]*1.6;
+        query_result = my_kdtree.query_ball_point(target_sites[target_num], epsilons[target_num], p=2.0, eps=0)
+        max_neighbors = max(max_neighbors, len(query_result)+1)
+        temp_neighbor_lists.append([len(query_result),] + query_result)
+
+    # third pass to pad with 0s
+    for target_num in range(NT):
+        row = temp_neighbor_lists[target_num]
+        row = row + (max_neighbors-len(row))*[0,] # pad with 0s to get the correct dimension
+        temp_neighbor_lists[target_num] = row
+
+    # convert list to 2d array
+    neighbor_lists = np.array(temp_neighbor_lists, dtype=np.dtype(int))
 
     # set data in gmls object
     gmls_obj.setWindowSizes(epsilons)

--- a/src/Compadre_PointCloudSearch.hpp
+++ b/src/Compadre_PointCloudSearch.hpp
@@ -4,6 +4,73 @@
 
 namespace Compadre {
 
+//! Custom RadiusResultSet for nanoflann that uses pre-allocated space for indices and radii
+//! instead of using std::vec for std::pairs
+template <typename _DistanceType, typename _IndexType = size_t>
+class RadiusResultSet {
+
+  public:
+
+    typedef _DistanceType DistanceType;
+    typedef _IndexType IndexType;
+
+    const DistanceType radius;
+    const IndexType max_size;
+    IndexType count;
+    DistanceType* r_dist;
+    IndexType* i_dist;
+
+    inline RadiusResultSet(
+        DistanceType radius_,
+        DistanceType* r_dist_, IndexType* i_dist_, const IndexType max_size_)
+        : radius(radius_), r_dist(r_dist_), i_dist(i_dist_), max_size(max_size_) {
+        count = 0;
+        init();
+    }
+
+    inline void init() {}
+
+    inline void clear() { count = 0; }
+
+    inline size_t size() const { return count; }
+
+    inline bool full() const { return true; }
+
+    inline bool addPoint(DistanceType dist, IndexType index) {
+
+        if (dist < radius) {
+            compadre_kernel_assert_release((count<max_size) && "Neighbors found exceeds space allocated for their storage.");
+            i_dist[count] = index;
+            r_dist[count] = dist;
+            count++;
+        }
+        return true;
+
+    }
+
+    inline DistanceType worstDist() const { return radius; }
+
+    std::pair<IndexType, DistanceType> worst_item() const {
+
+        compadre_kernel_assert_release((count>0) && "Cannot invoke RadiusResultSet::worst_item() on "
+                                                    "an empty list of results.");
+
+        DistanceType worst_distance = std::numeric_limits<DistanceType>::max();
+        IndexType worst_distance_index = 0;
+        for (int i=0; i<=count; ++i) {
+            if (r_dist[i] < worst_distance) {
+                worst_distance = r_dist[i];
+                worst_distance_index = i_dist[i];
+            }
+        }
+
+        auto worst_pair = std::pair<IndexType, DistanceType>(worst_distance_index, worst_distance);
+        return worst_pair;
+
+    }
+};
+
+
 //! PointCloudSearch generates neighbor lists and window sizes for each target site
 template <typename view_type>
 class PointCloudSearch {
@@ -30,7 +97,12 @@ class PointCloudSearch {
     
         ~PointCloudSearch() {};
 
-
+        //! Returns a liberal estimated upper bound on number of neighbors to be returned by a neighbor search
+        //! for a given choice of dimension, basis size, and epsilon_multiplier. Assumes quasiuniform distribution
+        //! of points. This result can be used to size a preallocated neighbor_lists kokkos view.
+        static inline int getEstimatedNumberNeighborsUpperBound(int unisolvency_size, const int dimension, const double epsilon_multiplier) {
+            return 2.0 * unisolvency_size * pow(epsilon_multiplier, dimension) + 1; // +1 is for the number of neighbors entry needed in the first entry of each row
+        }
     
         //! Bounding box query method required by Nanoflann.
         template <class BBOX> bool kdtree_get_bbox(BBOX& bb) const {return false;}
@@ -56,7 +128,7 @@ class PointCloudSearch {
         template <typename neighbor_lists_view_type, typename epsilons_view_type>
         void generateNeighborListsFromKNNSearch(neighbor_lists_view_type neighbor_lists,
                 epsilons_view_type epsilons, const int neighbors_needed, 
-                const int dimension = 3, const double epsilon_multiplier = 1.2) {
+                const int dimension = 3, const double epsilon_multiplier = 1.6, bool max_search_radius = 0.0) {
 
             compadre_assert_release((std::is_same<typename neighbor_lists_view_type::memory_space, Kokkos::HostSpace>::value) &&
                     "Views passed to generateNeighborListsFromKNNSearch should reside on the host.");
@@ -84,8 +156,8 @@ class PointCloudSearch {
 
             // allocate neighbor lists and epsilons
             compadre_assert_release((neighbor_lists.dimension_0()==num_target_sites 
-                        && neighbor_lists.dimension_1()==neighbors_needed+1) 
-                        && "neighbor lists View does not have the correct dimensions");
+                        && neighbor_lists.dimension_1()>=neighbors_needed+1) 
+                        && "neighbor lists View does not have large enough dimensions");
             compadre_assert_release((epsilons.dimension_0()==num_target_sites)
                         && "epsilons View does not have the correct dimension");
 
@@ -100,26 +172,26 @@ class PointCloudSearch {
 
             // determine scratch space size needed
             int team_scratch_size = 0;
-            team_scratch_size += scratch_double_view::shmem_size(neighbors_needed); // distances
-            team_scratch_size += scratch_int_view::shmem_size(neighbors_needed); // indices
+            team_scratch_size += scratch_double_view::shmem_size(neighbor_lists.dimension_1()); // distances
+            team_scratch_size += scratch_int_view::shmem_size(neighbor_lists.dimension_1()); // indices
             team_scratch_size += scratch_double_view::shmem_size(3); // target coordinate
             team_scratch_size += scratch_int_view::shmem_size(1); // neighbors found
 
-            //printf("%d num target sites\n", num_target_sites);
+            // part 1. do knn search for neighbors needed for unisolvency
             // each row of neighbor lists is a neighbor list for the target site corresponding to that row
             Kokkos::parallel_for(loop_policy(num_target_sites, Kokkos::AUTO)
                     .set_scratch_size(0 /*shared memory level*/, Kokkos::PerTeam(team_scratch_size)), 
                     KOKKOS_LAMBDA(const loop_member_type& teamMember) {
 
                 // make unmanaged scratch views
-                scratch_double_view neighbor_distances(teamMember.team_scratch(0 /*shared memory*/), neighbors_needed);
-                scratch_int_view neighbor_indices(teamMember.team_scratch(0 /*shared memory*/), neighbors_needed);
+                scratch_double_view neighbor_distances(teamMember.team_scratch(0 /*shared memory*/), neighbor_lists.dimension_1());
+                scratch_int_view neighbor_indices(teamMember.team_scratch(0 /*shared memory*/), neighbor_lists.dimension_1());
                 scratch_double_view this_target_coord(teamMember.team_scratch(0 /*shared memory*/), 3);
                 scratch_int_view neighbors_found(teamMember.team_scratch(0 /*shared memory*/), 1);
 
                 const int i = teamMember.league_rank();
 
-                Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, neighbors_needed), [=](const int j) {
+                Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, neighbor_lists.dimension_1()), [=](const int j) {
                     neighbor_indices(j) = 0;
                     neighbor_distances(j) = 0;
                 });
@@ -136,20 +208,79 @@ class PointCloudSearch {
             
                     // the number of neighbors is stored in column zero of the neighbor lists 2D array
                     neighbor_lists(i,0) = neighbors_found(0);
+                    compadre_kernel_assert_release((neighbor_lists(i,0)>=neighbors_needed) && "Neighbor search failed to find number of neighbors needed for unisolvency.");
             
                     // scale by epsilon_multiplier to window from location where the last neighbor was found
                     epsilons(i) = std::sqrt(neighbor_distances(neighbors_found(0)-1))*epsilon_multiplier;
+                    compadre_kernel_assert_release((epsilons(i)<=max_search_radius || max_search_radius==0) && "max_search_radius given (generally derived from the size of a halo region), and search radius needed would exceed this max_search_radius.");
                     // neighbor_distances stores squared distances from neighbor to target, as returned by nanoflann
                 });
+            });
+            Kokkos::fence();
+
+            
+
+            // determine scratch space size needed
+            team_scratch_size = 0;
+            team_scratch_size += scratch_double_view::shmem_size(neighbor_lists.dimension_1()); // distances
+            team_scratch_size += scratch_int_view::shmem_size(neighbor_lists.dimension_1()); // indices
+            team_scratch_size += scratch_double_view::shmem_size(3); // target coordinate
+            team_scratch_size += scratch_int_view::shmem_size(1); // neighbors found
+
+            // part 2. do radius search using window size from knn search
+            // each row of neighbor lists is a neighbor list for the target site corresponding to that row
+            Kokkos::parallel_for(loop_policy(num_target_sites, Kokkos::AUTO)
+                    .set_scratch_size(0 /*shared memory level*/, Kokkos::PerTeam(team_scratch_size)), 
+                    KOKKOS_LAMBDA(const loop_member_type& teamMember) {
+
+                // make unmanaged scratch views
+                scratch_double_view neighbor_distances(teamMember.team_scratch(0 /*shared memory*/), neighbor_lists.dimension_1());
+                scratch_int_view neighbor_indices(teamMember.team_scratch(0 /*shared memory*/), neighbor_lists.dimension_1());
+                scratch_double_view this_target_coord(teamMember.team_scratch(0 /*shared memory*/), 3);
+                scratch_int_view neighbors_found(teamMember.team_scratch(0 /*shared memory*/), 1);
+
+                const int i = teamMember.league_rank();
+
+                Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, neighbor_lists.dimension_1()), [=](const int j) {
+                    neighbor_indices(j) = 0;
+                    neighbor_distances(j) = 0;
+                });
+            
+                teamMember.team_barrier();
+
+                auto data_for_search = std::vector<std::pair<unsigned long int, double> >();
+
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
+                    // target_coords is LayoutLeft on device and its HostMirror, so giving a pointer to 
+                    // this data would lead to a wrong result if the device is a GPU
+
+                    for (int j=0; j<3; ++j) this_target_coord(j) = _trg_pts_view(i,j);
+
+                    nanoflann::SearchParams sp; // default parameters
+                    Compadre::RadiusResultSet<double> rrs(epsilons(i)*epsilons(i), neighbor_distances.data(), neighbor_indices.data(), neighbor_lists.dimension_1());
+                    neighbors_found(0) = kd_tree->template radiusSearchCustomCallback<Compadre::RadiusResultSet<double> >(this_target_coord.data(), rrs, sp) ;
+            
+                    // the number of neighbors is stored in column zero of the neighbor lists 2D array
+                    neighbor_lists(i,0) = neighbors_found(0);
+
+                    // epsilons already set by search radius
+                });
+
+                // this is a check to make sure we have enough room to store all of the neighbors found
+                // strictly less than in assertion because we need 1 entry for the total number of neighbors found in addition to their indices
+                compadre_kernel_assert_release((neighbors_found(0)<neighbor_lists.dimension_1()) && "neighbor_lists given to PointCloudSearch has too few columns (second dimension) to hold all neighbors found.");
 
                 teamMember.team_barrier();
+
                 // loop over each neighbor index and fill with a value
                 Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, static_cast<int>(neighbors_found(0))), [&](const int j) {
                     // cast to an whatever data type the 2D array of neighbor lists is using
                     neighbor_lists(i,j+1) = static_cast<typename std::remove_pointer<typename std::remove_pointer<typename neighbor_lists_view_type::data_type>::type>::type>(neighbor_indices(j));
                 });
+
             });
             Kokkos::fence();
+
             // deallocate nanoflann kdtree
             free(kd_tree);
         }

--- a/src/Compadre_PointCloudSearch.hpp
+++ b/src/Compadre_PointCloudSearch.hpp
@@ -68,6 +68,31 @@ class RadiusResultSet {
         return worst_pair;
 
     }
+
+    inline void sort() { 
+        // puts closest neighbor as the first entry in the neighbor list
+
+        if (count > 0) {
+
+            DistanceType worst_distance = std::numeric_limits<DistanceType>::max();
+            IndexType worst_distance_index = 0;
+            IndexType worst_index = 0;
+            for (int i=0; i<=count; ++i) {
+                if (r_dist[i] < worst_distance) {
+                    worst_distance = r_dist[i];
+                    worst_distance_index = i_dist[i];
+                    worst_index = i;
+                }
+            }
+
+            if (worst_index != 0) {
+                auto tmp_ind = i_dist[0];
+                i_dist[0] = worst_distance_index;
+                i_dist[worst_index] = tmp_ind;
+            }
+
+        }
+    }
 };
 
 

--- a/src/tpl/nanoflann.hpp
+++ b/src/tpl/nanoflann.hpp
@@ -1306,6 +1306,8 @@ namespace nanoflann
 		size_t radiusSearchCustomCallback(const ElementType *query_point, SEARCH_CALLBACK &resultSet, const SearchParams& searchParams = SearchParams() ) const
 		{
 			this->findNeighbors(resultSet, query_point, searchParams);
+			if (searchParams.sorted)
+				resultSet.sort();
 			return resultSet.size();
 		}
 


### PR DESCRIPTION
Neighbor search in the Compadre Harness (not the Toolkit, and not publicly available at the moment) is performed in the following way:

1. Perform a radius search (ad-hoc as to how to determine the initial search size), and check whether or not it contains the number of neighbors needed for unisolvency (getNP function from GMLS class). 
2. Get the nth neighbors distance from the target site (call it r_n), where the n is the number of neighbors needed for unisolvency. Multiply this by some amount, generally something around 1.5 (user specified parameter, call it epsilon_multiplier), and set the window size for this target to "epsilon_multiplier * r_n".
3. Perform a new radius neighbor search with the search size of "epsilon_multiplier * r_n" and keep all neighbors that are found.
4. If an MPI problem, check that the search size just used isn't larger than the halo region (distance off-processor that we have point information for)

The PointCloudSearch class now performs a search in exactly the same way, except that step one is replaced with a knn search which prevents us guessing in an ad-hoc way how large the initial radius search should be. Also, in the Python example, there was a kdtree search in Scipy, and this search is now performed in exactly the same way.

This update addresses issue #1 
