### PR TITLE
Added Matlab example which uses the Python interface to the toolkit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ message(STATUS "MPI Enabled: ${MPI_CXX_FOUND}")
 
 #PYTHON
 bob_option(Compadre_USE_PYTHON "Use PYTHON" OFF)
+bob_option(Compadre_USE_MATLAB "Use MATLAB interface for PYTHON" OFF)
 bob_input(PYTHON_PREFIX "" PATH "Path to PYTHON install")
 if (PYTHON_PREFIX)
   set(CMAKE_PREFIX_PATH ${PYTHON_PREFIX} ${CMAKE_PREFIX_PATH})

--- a/doc/Compadre-Install.md
+++ b/doc/Compadre-Install.md
@@ -22,7 +22,7 @@
   >> cd ./build
   >> vi script_you_choose.sh
 ```
-  (make any changes and save)
+  (make any changes and save, [Python Interface and Matlab examples](Python-Interface-Install.md))
   
 ```
   >> ./script_you_choose.sh

--- a/doc/Python-Interface-Install.md
+++ b/doc/Python-Interface-Install.md
@@ -1,0 +1,39 @@
+# Installing the Python interface and/or the Matlab examples which use the Python interface
+Modifying the build script, for instance "script_you_choose.sh", we change or add the following CMake variables:
+```
+-D Compadre_USE_PYTHON:BOOL=ON \
+```
+to enable the Python interface to the toolkit and optionally,
+```
+-D Compadre_USE_MATLAB:BOOL=ON \
+``` 
+to enable to the Matlab examples.
+
+Python must be enabled in order to use the Matlab tests and install scripts. There is no interface from Matlab directly to the C++ code. This only takes place through the Python interface.
+
+
+The CMake build system will attempt to determine which Python executable you are using. If you would like to specify a particular version of Python, set the CMake variable:
+```
+-D PYTHON_EXECUTABLE:FILEPATH='path/to/your/python' \
+``` 
+Otherwise, `which python` will be called and whatever is returned will be used.
+
+
+**Notes:**
+
+Numpy header files are needed in order to build the interface to Python. The PYTHON_EXECUTABLE that you set will be used to attempt to **automatically determine** the location of these files. However, it is possible that this search will fail, in which case y
+ou will need to provide the additional CMake variable:
+
+```
+-D Numpy_INCLUDE_DIRS:PATH='path/to/your/numpy/' \
+``` 
+As an example, the build system will search for /some/path/to/some/files/ending/in/numpy/arrayobject.h and chop off the ending numpy/arrayobject.h, so in this example you would set the variable to:
+```
+-D Numpy_INCLUDE_DIRS:PATH='/some/path/to/some/files/ending/in/' \
+``` 
+
+
+
+The Matlab examples require at least Matlab version 2017a.
+
+Back to [Installation of Compadre Toolkit](Compadre-Install.md)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -81,6 +81,11 @@ if (Compadre_EXAMPLES)
       CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/Python_3D_Convergence.py.in" "${CMAKE_CURRENT_BINARY_DIR}/Python_3D_Convergence.py" @ONLY)
       ADD_TEST(NAME GMLS_Python_Convergence_Test_3d_Point_Reconstruction COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/Python_3D_Convergence.py")
       SET_TESTS_PROPERTIES(GMLS_Python_Convergence_Test_3d_Point_Reconstruction PROPERTIES LABELS "UnitTest;unit;python;kokkos" TIMEOUT 10)
+
+      if (Compadre_USE_MATLAB)
+        ADD_TEST(NAME GMLS_Matlab_Python_Interface_1d_Point_Reconstruction COMMAND "matlab" "-nodisplay" "-nojvm" "-nosplash" "-nodesktop" "-r \"try, run('${SWIG_PREFIX}/Matlab_1D_Using_Python_Interface.m'), catch, exit(1), end, exit(0);\"")
+        SET_TESTS_PROPERTIES(GMLS_Matlab_Python_Interface_1d_Point_Reconstruction PROPERTIES LABELS "UnitTest;unit;python;kokkos;matlab" TIMEOUT 10)
+      endif()
     endif()
 
   endif (Compadre_TESTS)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -110,6 +110,10 @@ bob_export_target(gmls_module)
 
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py.in" "${CMAKE_CURRENT_BINARY_DIR}/__init__.py")
 CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/GMLS_Module.py.in" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Module.py")
+if(Compadre_USE_MATLAB)
+  CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/compadre_py_util.py" "${CMAKE_CURRENT_BINARY_DIR}/compadre_py_util.py" COPYONLY)
+  CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/Matlab_1D_Using_Python_Interface.m" "${CMAKE_CURRENT_BINARY_DIR}/Matlab_1D_Using_Python_Interface.m" COPYONLY)
+endif()
 
 install(FILES ${GMLS_Module_HEADERS} DESTINATION include)
 
@@ -125,7 +129,15 @@ set(GMLS_Module_PYTHON_FILES
   "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"
   )
 
+set(GMLS_Module_MATLAB_FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/compadre_py_util.py"
+  "${CMAKE_CURRENT_BINARY_DIR}/Matlab_1D_Using_Python_Interface.m"
+  )
+
 install(FILES ${GMLS_Module_PYTHON_FILES} DESTINATION "${GMLS_Module_DEST}")
+if(Compadre_USE_MATLAB)
+    install(FILES ${GMLS_Module_MATLAB_FILES} DESTINATION "${GMLS_Module_DEST}")
+endif()
 
 bob_end_subdir()
 

--- a/python/Matlab_1D_Using_Python_Interface.m
+++ b/python/Matlab_1D_Using_Python_Interface.m
@@ -1,3 +1,10 @@
+% check version to see if compatible
+V=regexp(version,'\d*','Match');
+if (str2num(V{length(V)}) < 2017)
+    fprintf('Error: Matlab version is too old to interface correctly to Python. Try Matlab 2017a or newer.')
+    throw()
+end
+
 % add current folder to path
 if count(py.sys.path,'.') == 0  
     insert(py.sys.path,int32(0),'');

--- a/python/Matlab_1D_Using_Python_Interface.m
+++ b/python/Matlab_1D_Using_Python_Interface.m
@@ -1,0 +1,78 @@
+% add current folder to path
+if count(py.sys.path,'.') == 0  
+    insert(py.sys.path,int32(0),'');
+end
+
+% import numpy
+np = py.importlib.import_module('numpy');
+
+% import Compadre Toolkit
+py.importlib.import_module('GMLS_Module');
+
+% initialize Kokkos
+py.GMLS_Module.initializeKokkos();
+
+% set the polynomial order for the basis and the curvature polynomial order
+% (if on a manifold)
+poly_order = py.int(2);
+curvature_poly_order = py.int(2);
+
+dense_solver_type = py.str("QR");
+
+% spatial dimension for polynomial reconstruction
+spatial_dimensions = py.int(1);
+
+% initialize and instance of the GMLS class in Compadre Toolkit
+my_gmls = py.GMLS_Module.GMLS_Python(poly_order, dense_solver_type, curvature_poly_order, spatial_dimensions);
+
+% set the weighting order
+regular_weight = py.int(12);
+my_gmls.setWeightingOrder(regular_weight);
+
+% import the compadre_py_util module which uses kdtree in scipy
+compadre_py_util = py.importlib.import_module('compadre_py_util');
+
+% generate some 1d source points and a single target site
+x=-10:.001:10;
+x=[x' zeros(length(x),2)];
+y=0;
+y=[y' zeros(length(y),2)];
+
+% flatten data to a 1D vector to be compatible with Matlab/Python 2017
+flat_x = x(:)';
+flat_y = y(:)';
+
+% reshape data inside of python
+np_x = compadre_py_util.get_2D_numpy_array(flat_x, py.int(length(flat_x)/3), py.int(3));
+np_y = compadre_py_util.get_2D_numpy_array(flat_y, py.int(length(flat_y)/3), py.int(3));
+
+% returns a dictionary with epsilons and with neighbor_lists
+d = compadre_py_util.get_neighborlist(np_x,np_y,poly_order,spatial_dimensions);
+
+% set source, targets, window sizes, and neighbor lists
+my_gmls.setSourceSites(np_x);
+my_gmls.setTargetSites(np_y);
+my_gmls.setWindowSizes(d{'epsilons'});
+my_gmls.setNeighbors(d{'neighbor_lists'});
+
+% generates stencil
+my_gmls.generatePointEvaluationStencil();
+
+% apply stencil to sample data for all targets
+data_vector = ones(size(x,1),1);
+np_data_vector = np.array(data_vector');
+np_computed_answer = my_gmls.applyStencil(np_data_vector)
+computed_answer = double(py.array.array('d',py.numpy.nditer(np_computed_answer)));
+
+% check that answer is correct
+tolerance = 1e-14;
+assert(abs(computed_answer-1)<tolerance, 'Computed answer should be 1, but it is not')
+
+
+
+% finalize kokkos
+clear my_gmls
+py.GMLS_Module.finalizeKokkos();
+
+
+% if needed, py.reload(compadre_py_util);

--- a/python/compadre_py_util.py
+++ b/python/compadre_py_util.py
@@ -1,0 +1,47 @@
+import numpy as np
+import scipy.spatial.kdtree as kdtree
+import GMLS_Module
+
+
+def get_neighborlist(source_sites, target_sites, polyOrder, dimensions):
+    # neighbor search
+    my_kdtree = kdtree.KDTree(source_sites, leafsize=10)
+    min_neighbors_needed = GMLS_Module.getNP(polyOrder, dimensions);
+    neighbor_lists = []
+    temp_neighbor_lists = [] 
+    NT = target_sites.shape[0]
+    epsilons = np.zeros([NT])
+
+    # first pass specifying number of neighbors needed
+    for target_num in range(NT):
+        query_result = my_kdtree.query(target_sites[target_num], k=min_neighbors_needed, eps=0)
+        epsilons[target_num] = query_result[0][-1]
+        assert query_result[1].size >= min_neighbors_needed, "Not enough neighbors exist on this process [%d needed, but %d found]."%(min_neighbors_needed,query_results[1].size)
+
+    # enlarge epsilons by 50%
+    # second pass using the enlarged epsilon search
+    max_neighbors = 0
+    for target_num in range(NT):
+        epsilons[target_num] = epsilons[target_num]*1.6;
+        query_result = my_kdtree.query_ball_point(target_sites[target_num], epsilons[target_num], p=2.0, eps=0)
+        max_neighbors = max(max_neighbors, len(query_result)+1)
+        temp_neighbor_lists.append([len(query_result),] + query_result)
+
+    # third pass to pad with 0s
+    for target_num in range(NT):
+        row = temp_neighbor_lists[target_num]
+        row = row + (max_neighbors-len(row))*[0,] # pad with 0s to get the correct dimension
+        temp_neighbor_lists[target_num] = row
+
+    # convert list to 2d array
+    neighbor_lists = np.array(temp_neighbor_lists, dtype=np.dtype(int))
+
+    d = dict();
+    d['neighbor_lists'] = neighbor_lists
+    d['epsilons'] = epsilons
+    return d
+
+def get_2D_numpy_array(x, dim_0, dim_1):
+    tmp_array = np.array(x, dtype='d')
+    tmp_array = np.reshape(tmp_array,(dim_0,dim_1),'F')
+    return tmp_array


### PR DESCRIPTION
Only enabled with Compadre_USE_MATLAB:BOOL=ON, but this option is OFF by default.