### PR TITLE
Added interface for extra data to be made available to basis and target operations in toolkit,

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -30,6 +30,7 @@ if (Compadre_EXAMPLES)
   endif()
   add_exe_w_compadre(GMLS_Host_Test GMLS_Host.cpp)
   add_exe_w_compadre(GMLS_Device_Test GMLS_Device.cpp)
+  add_exe_w_compadre(GMLS_Vector_Test GMLS_Vector.cpp)
   add_exe_w_compadre(GMLS_SmallBatchReuse_Device_Test GMLS_SmallBatchReuse_Device.cpp)
   add_exe_w_compadre(GMLS_Manifold_Test GMLS_Manifold.cpp)
   add_exe_w_compadre(GMLS_Staggered_Manifold_Test GMLS_Staggered_Manifold.cpp)
@@ -63,6 +64,16 @@ if (Compadre_EXAMPLES)
     
     ADD_TEST(NAME GMLS_Device_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "1" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Device_Dim1_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
+
+    # Device views tests for GMLS (vector basis)
+    ADD_TEST(NAME GMLS_Vector_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "3" "1" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(GMLS_Vector_Dim3_QR PROPERTIES LABELS "UnitTest;unit;kokkos;vector" TIMEOUT 10)
+    
+    ADD_TEST(NAME GMLS_Vector_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "2" "1" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(GMLS_Vector_Dim2_QR PROPERTIES LABELS "UnitTest;unit;kokkos;vector" TIMEOUT 10)
+    
+    ADD_TEST(NAME GMLS_Vector_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "1" "1" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(GMLS_Vector_Dim1_QR PROPERTIES LABELS "UnitTest;unit;kokkos;vector" TIMEOUT 10)
 
     # Device views tests for small batch GMLS, reusing GMLS class object
     ADD_TEST(NAME GMLS_SmallBatchReuse_Device_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_SmallBatchReuse_Device_Test "4" "200" "2" "1" "--kokkos-threads=2")

--- a/examples/GMLS_Vector.cpp
+++ b/examples/GMLS_Vector.cpp
@@ -1,0 +1,485 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <map>
+#include <stdlib.h> 
+#include <cstdio>
+#include <random>
+
+#include <Compadre_Config.h>
+#include <Compadre_GMLS.hpp>
+#include <Compadre_Evaluator.hpp>
+#include <Compadre_PointCloudSearch.hpp>
+
+#include "GMLS_Tutorial.hpp"
+
+#ifdef COMPADRE_USE_MPI
+#include <mpi.h>
+#endif
+
+#include <Kokkos_Timer.hpp>
+#include <Kokkos_Core.hpp>
+
+using namespace Compadre;
+
+//! [Parse Command Line Arguments]
+
+// called from command line
+int main (int argc, char* args[]) {
+
+// initializes MPI (if available) with command line arguments given
+#ifdef COMPADRE_USE_MPI
+MPI_Init(&argc, &args);
+#endif
+
+// initializes Kokkos with command line arguments given
+Kokkos::initialize(argc, args);
+
+// becomes false if the computed solution not within the failure_threshold of the actual solution
+bool all_passed = true;
+
+// code block to reduce scope for all Kokkos View allocations
+// otherwise, Views may be deallocating when we call Kokkos::finalize() later
+{
+    
+    // check if 5 arguments are given from the command line, the first being the program name
+    //  solver_type used for factorization in solving each GMLS problem:
+    //      0 - SVD used for factorization in solving each GMLS problem
+    //      1 - QR  used for factorization in solving each GMLS problem
+    int solver_type = 1; // QR by default
+    if (argc >= 5) {
+        int arg5toi = atoi(args[4]);
+        if (arg5toi > 0) {
+            solver_type = arg5toi;
+        }
+    }
+    
+    // check if 4 arguments are given from the command line
+    //  dimension for the coordinates and the solution
+    int dimension = 3; // dimension 3 by default
+    if (argc >= 4) {
+        int arg4toi = atoi(args[3]);
+        if (arg4toi > 0) {
+            dimension = arg4toi;
+        }
+    }
+    
+    // check if 3 arguments are given from the command line
+    //  set the number of target sites where we will reconstruct the target functionals at
+    int number_target_coords = 200; // 200 target sites by default
+    if (argc >= 3) {
+        int arg3toi = atoi(args[2]);
+        if (arg3toi > 0) {
+            number_target_coords = arg3toi;
+        }
+    }
+    
+    // check if 2 arguments are given from the command line
+    //  set the number of target sites where we will reconstruct the target functionals at
+    int order = 3; // 3rd degree polynomial basis by default
+    if (argc >= 2) {
+        int arg2toi = atoi(args[1]);
+        if (arg2toi > 0) {
+            order = arg2toi;
+        }
+    }
+    
+    // the functions we will be seeking to reconstruct are in the span of the basis
+    // of the reconstruction space we choose for GMLS, so the error should be very small
+    const double failure_tolerance = 1e-9;
+    
+    // Laplacian is a second order differential operator, which we expect to be slightly less accurate
+    const double laplacian_failure_tolerance = 1e-9;
+    
+    // minimum neighbors for unisolvency is the same as the size of the polynomial basis 
+    const int min_neighbors = Compadre::GMLS::getNP(order, dimension);
+    
+    //! [Parse Command Line Arguments]
+    Kokkos::Timer timer;
+    Kokkos::Profiling::pushRegion("Setup Point Data");
+    //! [Setting Up The Point Cloud]
+    
+    // approximate spacing of source sites
+    double h_spacing = 0.05;
+    int n_neg1_to_1 = 2*(1/h_spacing) + 1; // always odd
+    
+    // number of source coordinate sites that will fill a box of [-1,1]x[-1,1]x[-1,1] with a spacing approximately h
+    const int number_source_coords = std::pow(n_neg1_to_1, dimension);
+    
+    // coordinates of source sites
+    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> source_coords_device("source coordinates", 
+            number_source_coords, 3);
+    Kokkos::View<double**>::HostMirror source_coords = Kokkos::create_mirror_view(source_coords_device);
+    
+    // coordinates of target sites
+    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> target_coords_device ("target coordinates", number_target_coords, 3);
+    Kokkos::View<double**>::HostMirror target_coords = Kokkos::create_mirror_view(target_coords_device);
+    
+    
+    // fill source coordinates with a uniform grid
+    int source_index = 0;
+    double this_coord[3] = {0,0,0};
+    for (int i=-n_neg1_to_1/2; i<n_neg1_to_1/2+1; ++i) {
+        this_coord[0] = i*h_spacing;
+        for (int j=-n_neg1_to_1/2; j<n_neg1_to_1/2+1; ++j) {
+            this_coord[1] = j*h_spacing;
+            for (int k=-n_neg1_to_1/2; k<n_neg1_to_1/2+1; ++k) {
+                this_coord[2] = k*h_spacing;
+                if (dimension==3) {
+                    source_coords(source_index,0) = this_coord[0]; 
+                    source_coords(source_index,1) = this_coord[1]; 
+                    source_coords(source_index,2) = this_coord[2]; 
+                    source_index++;
+                }
+            }
+            if (dimension==2) {
+                source_coords(source_index,0) = this_coord[0]; 
+                source_coords(source_index,1) = this_coord[1]; 
+                source_coords(source_index,2) = 0;
+                source_index++;
+            }
+        }
+        if (dimension==1) {
+            source_coords(source_index,0) = this_coord[0]; 
+            source_coords(source_index,1) = 0;
+            source_coords(source_index,2) = 0;
+            source_index++;
+        }
+    }
+    
+    // fill target coords somewhere inside of [-0.5,0.5]x[-0.5,0.5]x[-0.5,0.5]
+    for(int i=0; i<number_target_coords; i++){
+    
+        // first, we get a uniformly random distributed direction
+        double rand_dir[3] = {0,0,0};
+    
+        for (int j=0; j<dimension; ++j) {
+            // rand_dir[j] is in [-0.5, 0.5]
+            rand_dir[j] = ((double)rand() / (double) RAND_MAX) - 0.5;
+        }
+    
+        // then we get a uniformly random radius
+        for (int j=0; j<dimension; ++j) {
+            target_coords(i,j) = rand_dir[j];
+        }
+    
+    }
+    
+    
+    //! [Setting Up The Point Cloud]
+    
+    Kokkos::Profiling::popRegion();
+    Kokkos::Profiling::pushRegion("Creating Data");
+    
+    //! [Creating The Data]
+    
+    
+    // source coordinates need copied to device before using to construct sampling data
+    Kokkos::deep_copy(source_coords_device, source_coords);
+    
+    // target coordinates copied next, because it is a convenient time to send them to device
+    Kokkos::deep_copy(target_coords_device, target_coords);
+    
+    // need Kokkos View storing true solution
+    Kokkos::View<double*, Kokkos::DefaultExecutionSpace> sampling_data_device("samples of true solution", 
+            source_coords_device.dimension_0());
+    
+    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> gradient_sampling_data_device("samples of true gradient", 
+            source_coords_device.dimension_0(), dimension);
+    
+    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> divergence_sampling_data_device
+            ("samples of true solution for divergence test", source_coords_device.dimension_0(), dimension);
+    
+    Kokkos::parallel_for("Sampling Manufactured Solutions", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>
+            (0,source_coords.dimension_0()), KOKKOS_LAMBDA(const int i) {
+    
+        // coordinates of source site i
+        double xval = source_coords_device(i,0);
+        double yval = (dimension>1) ? source_coords_device(i,1) : 0;
+        double zval = (dimension>2) ? source_coords_device(i,2) : 0;
+    
+        // data for targets with scalar input
+        sampling_data_device(i) = trueSolution(xval, yval, zval, order, dimension);
+    
+        // data for targets with vector input (divergence)
+        double true_grad[3] = {0,0,0};
+        trueGradient(true_grad, xval, yval,zval, order, dimension);
+    
+        for (int j=0; j<dimension; ++j) {
+            gradient_sampling_data_device(i,j) = true_grad[j];
+    
+            // data for target with vector input (curl)
+            divergence_sampling_data_device(i,j) = divergenceTestSamples(xval, yval, zval, j, dimension);
+        }
+    
+    });
+    
+    
+    //! [Creating The Data]
+    
+    Kokkos::Profiling::popRegion();
+    Kokkos::Profiling::pushRegion("Neighbor Search");
+    
+    //! [Performing Neighbor Search]
+    
+    
+    // Point cloud construction for neighbor search
+    // CreatePointCloudSearch constructs an object of type PointCloudSearch, but deduces the templates for you
+    auto point_cloud_search(CreatePointCloudSearch(source_coords));
+
+    // each row is a neighbor list for a target site, with the first column of each row containing
+    // the number of neighbors for that rows corresponding target site
+    double epsilon_multiplier = 1.5;
+    int estimated_upper_bound_number_neighbors = 
+        point_cloud_search.getEstimatedNumberNeighborsUpperBound(min_neighbors, dimension, epsilon_multiplier);
+
+    Kokkos::View<int**, Kokkos::DefaultExecutionSpace> neighbor_lists_device("neighbor lists", 
+            number_target_coords, estimated_upper_bound_number_neighbors); // first column is # of neighbors
+    Kokkos::View<int**>::HostMirror neighbor_lists = Kokkos::create_mirror_view(neighbor_lists_device);
+    
+    // each target site has a window size
+    Kokkos::View<double*, Kokkos::DefaultExecutionSpace> epsilon_device("h supports", number_target_coords);
+    Kokkos::View<double*>::HostMirror epsilon = Kokkos::create_mirror_view(epsilon_device);
+    
+    // query the point cloud to generate the neighbor lists using a kdtree to produce the n nearest neighbor
+    // to each target site, adding (epsilon_multiplier-1)*100% to whatever the distance away the further neighbor used is from
+    // each target to the view for epsilon
+    point_cloud_search.generateNeighborListsFromKNNSearch(target_coords, neighbor_lists, epsilon, min_neighbors, dimension, 
+            epsilon_multiplier);
+    
+    
+    //! [Performing Neighbor Search]
+    
+    Kokkos::Profiling::popRegion();
+    Kokkos::fence(); // let call to build neighbor lists complete before copying back to device
+    timer.reset();
+    
+    //! [Setting Up The GMLS Object]
+    
+    
+    // Copy data back to device (they were filled on the host)
+    // We could have filled Kokkos Views with memory space on the host
+    // and used these instead, and then the copying of data to the device
+    // would be performed in the GMLS class
+    Kokkos::deep_copy(neighbor_lists_device, neighbor_lists);
+    Kokkos::deep_copy(epsilon_device, epsilon);
+    
+    // solver name for passing into the GMLS class
+    std::string solver_name;
+    if (solver_type == 0) { // SVD
+        solver_name = "SVD";
+    } else if (solver_type == 1) { // QR
+        solver_name = "QR";
+    }
+    
+    // initialize an instance of the GMLS class 
+    GMLS my_GMLS(VectorTaylorPolynomial, VectorPointSample, order, solver_name.c_str(), 2 /*manifold order*/, dimension);
+    
+    // pass in neighbor lists, source coordinates, target coordinates, and window sizes
+    //
+    // neighbor lists have the format:
+    //      dimensions: (# number of target sites) X (# maximum number of neighbors for any given target + 1)
+    //                  the first column contains the number of neighbors for that rows corresponding target index
+    //
+    // source coordinates have the format:
+    //      dimensions: (# number of source sites) X (dimension)
+    //                  entries in the neighbor lists (integers) correspond to rows of this 2D array
+    //
+    // target coordinates have the format:
+    //      dimensions: (# number of target sites) X (dimension)
+    //                  # of target sites is same as # of rows of neighbor lists
+    //
+    my_GMLS.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
+    
+    // create a vector of target operations
+    std::vector<TargetOperation> lro(4);
+    lro[0] = ScalarPointEvaluation;
+    lro[1] = DivergenceOfVectorPointEvaluation;
+    lro[2] = CurlOfVectorPointEvaluation;
+    lro[3] = VectorPointEvaluation;
+    
+    // and then pass them to the GMLS class
+    my_GMLS.addTargets(lro);
+    
+    // sets the weighting kernel function from WeightingFunctionType
+    my_GMLS.setWeightingType(WeightingFunctionType::Power);
+    
+    // power to use in that weighting kernel function
+    my_GMLS.setWeightingPower(2);
+    
+    // generate the alphas that to be combined with data for each target operation requested in lro
+    my_GMLS.generateAlphas();
+    
+    
+    //! [Setting Up The GMLS Object]
+    
+    double instantiation_time = timer.seconds();
+    std::cout << "Took " << instantiation_time << "s to complete alphas generation." << std::endl;
+    Kokkos::fence(); // let generateAlphas finish up before using alphas
+    Kokkos::Profiling::pushRegion("Apply Alphas to Data");
+    
+    //! [Apply GMLS Alphas To Data]
+    
+    // it is important to note that if you expect to use the data as a 1D view, then you should use double*
+    // however, if you know that the target operation will result in a 2D view (vector or matrix output),
+    // then you should template with double** as this is something that can not be infered from the input data
+    // or the target operator at compile time. Additionally, a template argument is required indicating either
+    // Kokkos::HostSpace or Kokkos::DefaultExecutionSpace::memory_space() 
+    
+    // The Evaluator class takes care of handling input data views as well as the output data views.
+    // It uses information from the GMLS class to determine how many components are in the input 
+    // as well as output for any choice of target functionals and then performs the contactions
+    // on the data using the alpha coefficients generated by the GMLS class, all on the device.
+    Evaluator gmls_evaluator(&my_GMLS);
+    
+    auto output_value = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double*, Kokkos::HostSpace>
+            (sampling_data_device, ScalarPointEvaluation);
+    
+    auto output_divergence = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double*, Kokkos::HostSpace>
+            (gradient_sampling_data_device, DivergenceOfVectorPointEvaluation, VectorPointSample);
+    
+    auto output_curl = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double**, Kokkos::HostSpace>
+            (divergence_sampling_data_device, CurlOfVectorPointEvaluation);
+
+    auto output_gradient = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double**, Kokkos::HostSpace>
+            (gradient_sampling_data_device, VectorPointEvaluation);
+    
+    // retrieves polynomial coefficients instead of remapped field
+    auto scalar_coefficients = gmls_evaluator.applyFullPolynomialCoefficientsBasisToDataAllComponents<double**, Kokkos::HostSpace>
+            (sampling_data_device, VectorPointSample);
+    
+    //! [Apply GMLS Alphas To Data]
+    
+    Kokkos::fence(); // let application of alphas to data finish before using results
+    Kokkos::Profiling::popRegion();
+    // times the Comparison in Kokkos
+    Kokkos::Profiling::pushRegion("Comparison");
+    
+    //! [Check That Solutions Are Correct]
+    
+    
+    // loop through the target sites
+    for (int i=0; i<number_target_coords; i++) {
+    
+        // load value from output
+        double GMLS_value = output_value(i);
+    
+        // load partial x from gradient
+        // this is a test that the scalar_coefficients 2d array returned hold valid entries
+        // scalar_coefficients(i,1)*1./epsilon(i) is equivalent to the target operation acting 
+        // on the polynomials applied to the polynomial coefficients
+        double GMLS_GradX = output_gradient(i,0);
+    
+        // load partial y from gradient
+        double GMLS_GradY = (dimension>1) ? output_gradient(i,1) : 0;
+    
+        // load partial z from gradient
+        double GMLS_GradZ = (dimension>2) ? output_gradient(i,2) : 0;
+    
+        // load divergence from output
+        double GMLS_Divergence = output_divergence(i);
+    
+        // load curl from output
+        double GMLS_CurlX = (dimension>1) ? output_curl(i,0) : 0;
+        double GMLS_CurlY = (dimension>1) ? output_curl(i,1) : 0;
+        double GMLS_CurlZ = (dimension>2) ? output_curl(i,2) : 0;
+    
+    
+        // target site i's coordinate
+        double xval = target_coords(i,0);
+        double yval = (dimension>1) ? target_coords(i,1) : 0;
+        double zval = (dimension>2) ? target_coords(i,2) : 0;
+    
+        // evaluation of various exact solutions
+        double actual_value = trueSolution(xval, yval, zval, order, dimension);
+    
+        double actual_Gradient[3] = {0,0,0}; // initialized for 3, but only filled up to dimension
+        trueGradient(actual_Gradient, xval, yval, zval, order, dimension);
+    
+        double actual_Divergence;
+        actual_Divergence = trueLaplacian(xval, yval, zval, order, dimension);
+    
+        double actual_Curl[3] = {0,0,0}; // initialized for 3, but only filled up to dimension 
+        // (and not at all for dimimension = 1)
+        if (dimension>1) {
+            actual_Curl[0] = curlTestSolution(xval, yval, zval, 0, dimension);
+            actual_Curl[1] = curlTestSolution(xval, yval, zval, 1, dimension);
+            if (dimension>2) {
+                actual_Curl[2] = curlTestSolution(xval, yval, zval, 2, dimension);
+            }
+        }
+    
+        // check actual function value
+        if(GMLS_value!=GMLS_value || std::abs(actual_value - GMLS_value) > failure_tolerance) {
+            all_passed = false;
+            std::cout << i << " Failed Actual by: " << std::abs(actual_value - GMLS_value) << std::endl;
+        }
+    
+        // check vector (which is the gradient)
+        if(std::abs(actual_Gradient[0] - GMLS_GradX) > failure_tolerance) {
+            all_passed = false;
+            std::cout << i << " Failed GradX by: " << std::abs(actual_Gradient[0] - GMLS_GradX) << std::endl;
+            if (dimension>1) {
+                if(std::abs(actual_Gradient[1] - GMLS_GradY) > failure_tolerance) {
+                    all_passed = false;
+                    std::cout << i << " Failed GradY by: " << std::abs(actual_Gradient[1] - GMLS_GradY) << std::endl;
+                }
+            }
+            if (dimension>2) {
+                if(std::abs(actual_Gradient[2] - GMLS_GradZ) > failure_tolerance) {
+                    all_passed = false;
+                    std::cout << i << " Failed GradZ by: " << std::abs(actual_Gradient[2] - GMLS_GradZ) << std::endl;
+                }
+            }
+        }
+    
+        // check divergence
+        if(std::abs(actual_Divergence - GMLS_Divergence) > failure_tolerance) {
+            all_passed = false;
+            std::cout << i << " Failed Divergence by: " << std::abs(actual_Divergence - GMLS_Divergence) << std::endl;
+        }
+    
+        // check curl
+        if (order > 2) { // reconstructed solution not in basis unless order greater than 2 used
+            double tmp_diff = 0;
+            if (dimension>1)
+                tmp_diff += std::abs(actual_Curl[0] - GMLS_CurlX) + std::abs(actual_Curl[1] - GMLS_CurlY);
+            if (dimension>2)
+                tmp_diff += std::abs(actual_Curl[2] - GMLS_CurlZ);
+            if(std::abs(tmp_diff) > failure_tolerance) {
+                all_passed = false;
+                std::cout << i << " Failed Curl by: " << std::abs(tmp_diff) << std::endl;
+            }
+        }
+    }
+    
+    
+    //! [Check That Solutions Are Correct] 
+    // popRegion hidden from tutorial
+    // stop timing comparison loop
+    Kokkos::Profiling::popRegion();
+    //! [Finalize Program]
+
+
+} // end of code block to reduce scope, causing Kokkos View de-allocations
+// otherwise, Views may be deallocating when we call Kokkos::finalize() later
+
+// finalize Kokkos and MPI (if available)
+Kokkos::finalize();
+#ifdef COMPADRE_USE_MPI
+MPI_Finalize();
+#endif
+
+// output to user that test passed or failed
+if(all_passed) {
+    fprintf(stdout, "Passed test \n");
+    return 0;
+} else {
+    fprintf(stdout, "Failed test \n");
+    return -1;
+}
+
+} // main
+
+
+//! [Finalize Program]

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -69,9 +69,15 @@ void GMLS::generatePolynomialCoefficients() {
     // calculate sampling dimension 
     // this would normally be SamplingOutputTensorRank[_data_sampling_functional], but we also want to handle the
     // case of reconstructions where a scalar basis is reused as a vector, and this handles everything
+
+    // this handles scalars, vectors, and scalars that are reused as vectors
     _sampling_multiplier = std::pow(_local_dimensions, 
             std::min(ActualReconstructionSpaceRank[(int)_reconstruction_space], 
                 SamplingOutputTensorRank[_data_sampling_functional]));
+
+    // effective number of components in the basis
+    _data_sampling_multiplier = std::pow(_local_dimensions, 
+                SamplingOutputTensorRank[_data_sampling_functional]);
 
     // calculate the dimension of the basis (a vector space on a manifold requires two components, for example)
     _basis_multiplier = std::pow(_local_dimensions, ActualReconstructionSpaceRank[(int)_reconstruction_space]);

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -242,6 +242,9 @@ void GMLS::generatePolynomialCoefficients() {
          *    STANDARD GMLS Problems
          */
 
+        // generate quadrature for face normal approach
+        this->generate1DQuadrature();
+
         // assembles the P*sqrt(weights) matrix and constructs sqrt(weights)*Identity
         this->CallFunctorWithTeamThreads<AssembleStandardPsqrtW>(_threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
         Kokkos::fence();

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -60,6 +60,9 @@ protected:
     //! _dimension-1 gradient values for curvature for all problems
     Kokkos::View<double*> _manifold_curvature_gradient;
 
+    //! Extra data available to basis functions and target operations (optional)
+    Kokkos::View<double**> _extra_data;
+
     
     //! contains local IDs of neighbors to get coordinates from _source_coordinates (device)
     Kokkos::View<int**, layout_type> _neighbor_lists; 
@@ -1302,6 +1305,30 @@ public:
         // copy data from device back to host in rearranged format
         _host_ref_N = Kokkos::create_mirror_view(_ref_N);
         Kokkos::deep_copy(_host_ref_N, _ref_N);
+        this->resetCoefficientData();
+    }
+
+    //! (OPTIONAL)
+    //! Sets extra data to be used by sampling functionals and target operations in certain instances.
+    template<typename view_type>
+    void setExtraData(view_type extra_data) {
+
+        // allocate memory on device
+        _extra_data = Kokkos::View<double**>("device extra data", extra_data.extent(0), extra_data.extent(1));
+
+        auto host_extra_data = Kokkos::create_mirror_view(_extra_data);
+        Kokkos::deep_copy(host_extra_data, extra_data);
+        // copy data from host to device
+        Kokkos::deep_copy(_extra_data, host_extra_data);
+        this->resetCoefficientData();
+    }
+
+    //! (OPTIONAL)
+    //! Sets extra data to be used by sampling functionals and target operations in certain instances. (device)
+    template<typename view_type>
+    void setExtraData(Kokkos::View<double**, Kokkos::DefaultExecutionSpace> extra_data) {
+        // allocate memory on device
+        _extra_data = extra_data;
         this->resetCoefficientData();
     }
 

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -13,7 +13,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
             //printf("ps %d, r %d, b %d, p %d, t0 %d, t1 %d, t2 %d, t3 %d, t4 %d\n",SamplingFunctional::PointSample, _reconstruction_space, _basis_multiplier, _polynomial_sampling_functional, _reconstruction_space!=ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, _basis_multiplier!=1, _reconstruction_space==ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial && _polynomial_sampling_functional==SamplingFunctional::PointSample, _reconstruction_space==ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, _polynomial_sampling_functional==SamplingFunctional::PointSample);
             compadre_kernel_assert_debug(
             (_reconstruction_space!=ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial
-                || SamplingOutputTensorRank[_data_sampling_functional]!=0
+                || _data_sampling_multiplier!=0
                 || (_reconstruction_space==ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial 
                         && _polynomial_sampling_functional==SamplingFunctional::PointSample))
             && "_reconstruction_space(VectorOfScalar clones incompatible with scalar output sampling functional which is not a PointSample");
@@ -295,7 +295,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                     for (int e=0; e<num_evaluation_sites; ++e) {
                         this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
                         for (int m=0; m<_sampling_multiplier; ++m) {
-                            auto output_components = std::pow(_local_dimensions, SamplingOutputTensorRank[_data_sampling_functional]);
+                            auto output_components = std::pow(_local_dimensions, _data_sampling_multiplier);
                             for (int c=0; c<output_components; ++c) {
                                 int offset = getTargetOffsetIndexDevice(i, c /*in*/, c /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
                                 for (int j=0; j<target_NP; ++j) {

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -8,6 +8,17 @@ namespace Compadre {
 KOKKOS_INLINE_FUNCTION
 void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_vector_type P_target_row) const {
 
+    // check if VectorOfScalarClonesTaylorPolynomial is used with a scalar sampling functional other than PointSample
+    if (_dimensions > 1) {
+            //printf("ps %d, r %d, b %d, p %d, t0 %d, t1 %d, t2 %d, t3 %d, t4 %d\n",SamplingFunctional::PointSample, _reconstruction_space, _basis_multiplier, _polynomial_sampling_functional, _reconstruction_space!=ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, _basis_multiplier!=1, _reconstruction_space==ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial && _polynomial_sampling_functional==SamplingFunctional::PointSample, _reconstruction_space==ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, _polynomial_sampling_functional==SamplingFunctional::PointSample);
+            compadre_kernel_assert_debug(
+            (_reconstruction_space!=ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial
+                || SamplingOutputTensorRank[_data_sampling_functional]!=0
+                || (_reconstruction_space==ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial 
+                        && _polynomial_sampling_functional==SamplingFunctional::PointSample))
+            && "_reconstruction_space(VectorOfScalar clones incompatible with scalar output sampling functional which is not a PointSample");
+    } 
+
     // determine if additional evaluation sites are requested by user and handled by target operations 
     bool additional_evaluation_sites_need_handled = 
         (_additional_evaluation_coordinates.extent(0) > 0) ? true : false; // additional evaluation sites are specified
@@ -36,309 +47,326 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
         // if the user didn't handle the operation, we pass it along to the toolkit's targets
         if (!operation_handled) {
 
-        if (_operations(i) == TargetOperation::ScalarPointEvaluation || (_operations(i) == TargetOperation::VectorPointEvaluation && _dimensions == 1) /* vector is a scalar in 1D */) {
-            Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                for (int j=0; j<num_evaluation_sites; ++j) { 
-                    this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
-                    int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
-                    for (int k=0; k<target_NP; ++k) {
-                        P_target_row(offset + k) = t1(k);
-                    }
-                }
-                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
-            });
-        } else if (_operations(i) == TargetOperation::VectorPointEvaluation) {
-            additional_evaluation_sites_handled = true; // calcPij can handle non-target site evaluations
-            if (_dimensions == 3) {
-                // vector basis
-                if (_reconstruction_space_rank == 1) {
-                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+        if (_reconstruction_space == ReconstructionSpace::ScalarTaylorPolynomial) {
 
-                        // output component 0
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                            P_target_row(offset + target_NP + j) = 0;
-                            P_target_row(offset + 2*target_NP + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                            P_target_row(offset + 2*target_NP + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                            P_target_row(offset + 2*target_NP + j) = 0;
-                        }
+            /*
+             * Beginning of ScalarTaylorPolynomial basis
+             */
 
-                        // output component 1
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                            P_target_row(offset + 2*target_NP + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = t1(j);
-                            P_target_row(offset + 2*target_NP + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                            P_target_row(offset + 2*target_NP + j) = 0;
-                        }
-
-                        // output component 2
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                            P_target_row(offset + 2*target_NP + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                            P_target_row(offset + 2*target_NP + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                            P_target_row(offset + 2*target_NP + j) = t1(j);
-                        }
-
-                    });
-                // scalar basis times number of components in the vector
-                } else if (_reconstruction_space_rank == 0) {
-                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-
-                        // output component 0
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                        }
-
-                        // output component 1
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                        }
-                        offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                        }
-
-                        // output component 2
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                        }
-
-                    });
-                }
-            } else if (_dimensions == 2) {
-                // vector basis
-                if (_reconstruction_space_rank == 1) {
-                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-
-                        // output component 0
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                            P_target_row(offset + target_NP + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                        }
-
-                        // output component 1
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = t1(j);
-                        }
-
-                    });
-                // scalar basis times number of components in the vector
-                } else if (_reconstruction_space_rank == 0) {
-                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-
-                        // output component 0
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                        }
-
-                        // output component 1
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                        }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                        for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                        }
-
-                    });
-                }
-            }
-        } else if (_operations(i) == TargetOperation::LaplacianOfScalarPointEvaluation) {
-            Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                const int offset = _lro_total_offsets[i]*_basis_multiplier*target_NP;
-                if (_polynomial_sampling_functional == VectorPointSample) {
-                    for (int j=0; j<_dimensions*target_NP; ++j) {
-                        P_target_row(offset + j) = 0;
-                    }
-
-                }
-                for (int j=0; j<target_NP; ++j) {
-                    P_target_row(offset + j) = 0;
-                }
-                switch (_dimensions) {
-                case 3:
-                    P_target_row(offset + 4) = std::pow(_epsilons(target_index), -2);
-                    P_target_row(offset + 6) = std::pow(_epsilons(target_index), -2);
-                    P_target_row(offset + 9) = std::pow(_epsilons(target_index), -2);
-                    break;
-                case 2:
-                    P_target_row(offset + 3) = std::pow(_epsilons(target_index), -2);
-                    P_target_row(offset + 5) = std::pow(_epsilons(target_index), -2);
-                    break;
-                default:
-                    P_target_row(offset + 2) = std::pow(_epsilons(target_index), -2);
-                }
-            });
-        } else if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
-            Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                for (int j=0; j<num_evaluation_sites; ++j) { 
-                    int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
-                    for (int k=0; k<target_NP; ++k) {
-                        P_target_row(offset + k) = 0;
-                    }
-                    //P_target_row(offset + 1) = std::pow(_epsilons(target_index), -1);
-                    this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
-
-                    if (_dimensions>1) {
-                        offset = getTargetOffsetIndexDevice(i, 0, 1, j)*_basis_multiplier*target_NP;
+            if (_operations(i) == TargetOperation::ScalarPointEvaluation || (_operations(i) == TargetOperation::VectorPointEvaluation && _dimensions == 1) /* vector is a scalar in 1D */) {
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
                         for (int k=0; k<target_NP; ++k) {
-                            P_target_row(offset + k) = 0;
+                            P_target_row(offset + k) = t1(k);
                         }
-                        //P_target_row(offset + 2) = std::pow(_epsilons(target_index), -1);
+                    }
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::LaplacianOfScalarPointEvaluation) {
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0)*_basis_multiplier*target_NP;
+                    switch (_dimensions) {
+                    case 3:
+                        P_target_row(offset + 4) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset + 6) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset + 9) = std::pow(_epsilons(target_index), -2);
+                        break;
+                    case 2:
+                        P_target_row(offset + 3) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset + 5) = std::pow(_epsilons(target_index), -2);
+                        break;
+                    default:
+                        P_target_row(offset + 2) = std::pow(_epsilons(target_index), -2);
+                    }
+                });
+            } else if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        for (int d=0; d<_dimensions; ++d) {
+                            int offset = getTargetOffsetIndexDevice(i, 0, d, j)*_basis_multiplier*target_NP;
+                            this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        }
+                    }
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::PartialXOfScalarPointEvaluation) {
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                        this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                    }
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::PartialYOfScalarPointEvaluation) {
+                compadre_kernel_assert_release(_dimensions>1 && "PartialYOfScalarPointEvaluation requested for dim < 2");
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
                         this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                     }
-
-                    if (_dimensions>2) {
-                        offset = getTargetOffsetIndexDevice(i, 0, 2, j)*_basis_multiplier*target_NP;
-                        for (int k=0; k<target_NP; ++k) {
-                            P_target_row(offset + k) = 0;
-                        }
-                        //P_target_row(offset + 3) = std::pow(_epsilons(target_index), -1);
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::PartialZOfScalarPointEvaluation) {
+                compadre_kernel_assert_release(_dimensions>2 && "PartialZOfScalarPointEvaluation requested for dim < 3");
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
                         this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                     }
-                }
-                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
-            });
-        } else if (_operations(i) == TargetOperation::PartialXOfScalarPointEvaluation) {
-            Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                int offset = _lro_total_offsets[i]*_basis_multiplier*target_NP;
-                for (int j=0; j<target_NP; ++j) {
-                    P_target_row(offset + j) = 0;
-                }
-                P_target_row(offset + 1) = std::pow(_epsilons(target_index), -1);
-//                this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
-        } else if (_operations(i) == TargetOperation::PartialYOfScalarPointEvaluation) {
-            if (_dimensions>1) {
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                    int offset = _lro_total_offsets[i]*_basis_multiplier*target_NP;
-                    for (int j=0; j<target_NP; ++j) {
-                        P_target_row(offset + j) = 0;
-                    }
-                    P_target_row(offset + 2) = std::pow(_epsilons(target_index), -1);
-//                    this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
-                });
+            } else {
+                compadre_kernel_assert_release((false) && "Functionality not yet available.");
             }
-        } else if (_operations(i) == TargetOperation::PartialZOfScalarPointEvaluation) {
-            if (_dimensions>2) {
+
+            /*
+             * End of ScalarTaylorPolynomial basis
+             */
+
+        } else if (_reconstruction_space == ReconstructionSpace::VectorTaylorPolynomial) {
+
+            /*
+             * Beginning of VectorTaylorPolynomial basis
+             */
+
+            printf("VectorTaylorPolynomial\n\n");
+            printf("RR: %d\n", _reconstruction_space_rank);
+
+            if (_operations(i) == TargetOperation::ScalarPointEvaluation || (_operations(i) == TargetOperation::VectorPointEvaluation && _dimensions == 1) /* vector is a scalar in 1D */) {
+                // copied from ScalarTaylorPolynomial
                 Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                    int offset = _lro_total_offsets[i]*_basis_multiplier*target_NP;
-                    for (int j=0; j<target_NP; ++j) {
-                        P_target_row(offset + j) = 0;
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                        for (int k=0; k<target_NP; ++k) {
+                            P_target_row(offset + k) = t1(k);
+                        }
                     }
-                    P_target_row(offset + 3) = std::pow(_epsilons(target_index), -1);
-//                    this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+            } else if (_operations(i) == TargetOperation::VectorPointEvaluation) {
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int e=0; e<num_evaluation_sites; ++e) {
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
+                        for (int m=0; m<_sampling_multiplier; ++m) {
+                            int output_components = _basis_multiplier;
+                            for (int c=0; c<output_components; ++c) {
+                                int offset = getTargetOffsetIndexDevice(i, m /*in*/, c /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
+                                // for the case where _sampling_multiplier is > 1,
+                                // this approach relies on c*target_NP being equivalent to P_target_row(offset + j) where offset is 
+                                // getTargetOffsetIndexDevice(i, m /*in*/, c /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
+                                for (int j=0; j<target_NP; ++j) {
+                                    P_target_row(offset + c*target_NP + j) = t1(j);
+                                }
+                            }
+                        }
+                    }
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::DivergenceOfVectorPointEvaluation) {
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int e=0; e<num_evaluation_sites; ++e) {
+                        for (int m=0; m<_sampling_multiplier; ++m) {
+                            this->calcGradientPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, m /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
+                            int offset = getTargetOffsetIndexDevice(i, m /*in*/, 0 /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
+                            for (int j=0; j<target_NP; ++j) {
+                                P_target_row(offset + m*target_NP + j) = t1(j);
+                            }
+                        }
+                    }
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::CurlOfVectorPointEvaluation) {
+                if (_dimensions==3) { 
+                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                        // output component 0
+                        // u_{2,y} - u_{1,z}
+                        {
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 0 on component 0 of curl
+                            // (no contribution)
+
+                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 1 on component 0 of curl
+                            // -u_{1,z}
+                            P_target_row(offset + target_NP + 3) = -std::pow(_epsilons(target_index), -1);
+
+                            offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 2 on component 0 of curl
+                            // u_{2,y}
+                            P_target_row(offset + 2*target_NP + 2) = std::pow(_epsilons(target_index), -1);
+                        }
+
+                        // output component 1
+                        // -u_{2,x} + u_{0,z}
+                        {
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 0 on component 1 of curl
+                            // u_{0,z}
+                            P_target_row(offset + 3) = std::pow(_epsilons(target_index), -1);
+
+                            // offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 1 on component 1 of curl
+                            // (no contribution)
+
+                            offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 2 on component 1 of curl
+                            // -u_{2,x}
+                            P_target_row(offset + 2*target_NP + 1) = -std::pow(_epsilons(target_index), -1);
+                        }
+
+                        // output component 2
+                        // u_{1,x} - u_{0,y}
+                        {
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 2 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 0 on component 1 of curl
+                            // -u_{0,y}
+                            P_target_row(offset + 2) = -std::pow(_epsilons(target_index), -1);
+
+                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 2 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 1 on component 1 of curl
+                            // u_{1,x}
+                            P_target_row(offset + target_NP + 1) = std::pow(_epsilons(target_index), -1);
+
+                            // offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 2 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 2 on component 1 of curl
+                            // (no contribution)
+                        }
+                    });
+                } else if (_dimensions==2) {
+                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                        // output component 0
+                        // u_{1,y}
+                        {
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 0 on component 0 of curl
+                            // (no contribution)
+
+                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 1 on component 0 of curl
+                            // -u_{1,z}
+                            P_target_row(offset + target_NP + 2) = std::pow(_epsilons(target_index), -1);
+                        }
+
+                        // output component 1
+                        // -u_{0,x}
+                        {
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 0 on component 1 of curl
+                            // u_{0,z}
+                            P_target_row(offset + 1) = -std::pow(_epsilons(target_index), -1);
+
+                            //offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // role of input 1 on component 1 of curl
+                            // (no contribution)
+                        }
+                    });
+                }
+            } else {
+                compadre_kernel_assert_release((false) && "Functionality not yet available.");
             }
-        } else if (_operations(i) == TargetOperation::DivergenceOfVectorPointEvaluation) {
-            // vector basis
-            if (_reconstruction_space_rank == 1) {
+
+            /*
+             * End of VectorTaylorPolynomial basis
+             */
+
+        } else if (_reconstruction_space == ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial) {
+
+            /*
+             * Beginning of VectorOfScalarClonesTaylorPolynomial basis
+             */
+
+            if (_operations(i) == TargetOperation::ScalarPointEvaluation || (_operations(i) == TargetOperation::VectorPointEvaluation && _dimensions == 1) /* vector is a scalar in 1D */) {
+                // copied from ScalarTaylorPolynomial
                 Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                    int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                    //for (int j=0; j<_dimensions*target_NP; ++j) {
-                    //    P_target_row(offset + j) = 0;
-                    //}
-                    P_target_row(offset + 1) = std::pow(_epsilons(target_index), -1);
-
-                    if (_dimensions>1) {
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        //for (int j=0; j<_dimensions*target_NP; ++j) {
-                        //    P_target_row(offset + j) = 0;
-                        //}
-                        P_target_row(offset + target_NP + 2) = std::pow(_epsilons(target_index), -1);
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                        for (int k=0; k<target_NP; ++k) {
+                            P_target_row(offset + k) = t1(k);
+                        }
                     }
-
-                    if (_dimensions>2) {
-                        offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                        //for (int j=0; j<_dimensions*target_NP; ++j) {
-                        //    P_target_row(offset + j) = 0;
-                        //}
-                        P_target_row(offset + 2*target_NP + 3) = std::pow(_epsilons(target_index), -1);
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::VectorPointEvaluation) {
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int e=0; e<num_evaluation_sites; ++e) {
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
+                        for (int m=0; m<_sampling_multiplier; ++m) {
+                            auto output_components = std::pow(_local_dimensions, SamplingOutputTensorRank[_data_sampling_functional]);
+                            for (int c=0; c<output_components; ++c) {
+                                int offset = getTargetOffsetIndexDevice(i, c /*in*/, c /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
+                                for (int j=0; j<target_NP; ++j) {
+                                    P_target_row(offset + j) = t1(j);
+                                }
+                            }
+                        }
+                    }
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::LaplacianOfScalarPointEvaluation) {
+                // copied from ScalarTaylorPolynomial
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0)*_basis_multiplier*target_NP;
+                    switch (_dimensions) {
+                    case 3:
+                        P_target_row(offset + 4) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset + 6) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset + 9) = std::pow(_epsilons(target_index), -2);
+                        break;
+                    case 2:
+                        P_target_row(offset + 3) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset + 5) = std::pow(_epsilons(target_index), -2);
+                        break;
+                    default:
+                        P_target_row(offset + 2) = std::pow(_epsilons(target_index), -2);
                     }
                 });
-            // scalar basis
-            } else if (_reconstruction_space_rank == 0) {
+            } else if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
+                // copied from ScalarTaylorPolynomial
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        for (int d=0; d<_dimensions; ++d) {
+                            int offset = getTargetOffsetIndexDevice(i, 0, d, j)*_basis_multiplier*target_NP;
+                            this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        }
+                    }
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::PartialXOfScalarPointEvaluation) {
+                // copied from ScalarTaylorPolynomial
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int j=0; j<num_evaluation_sites; ++j) { 
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                        this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                    }
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                });
+            } else if (_operations(i) == TargetOperation::PartialYOfScalarPointEvaluation) {
+                // copied from ScalarTaylorPolynomial
+                if (_dimensions>1) {
+                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                        for (int j=0; j<num_evaluation_sites; ++j) { 
+                            int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                            this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        }
+                        additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                    });
+                }
+            } else if (_operations(i) == TargetOperation::PartialZOfScalarPointEvaluation) {
+                // copied from ScalarTaylorPolynomial
+                if (_dimensions>2) {
+                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                        for (int j=0; j<num_evaluation_sites; ++j) { 
+                            int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                            this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        }
+                        additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
+                    });
+                }
+            } else if (_operations(i) == TargetOperation::DivergenceOfVectorPointEvaluation) {
                 Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
                     int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
                     for (int j=0; j<target_NP; ++j) {
@@ -363,139 +391,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         P_target_row(offset + 3) = std::pow(_epsilons(target_index), -1);
                     }
                 });
-            }
-        } else if (_operations(i) == TargetOperation::CurlOfVectorPointEvaluation) {
-            // vector basis
-            if (_reconstruction_space_rank == 1) {
-                // comments based on taking curl of vector [u_{0},u_{1},u_{2}]^T
-                // with as e.g., u_{1,z} being the partial derivative with respect to z of
-                // u_{1}
-                if (_dimensions==3) {
-                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                        // output component 0
-                        // u_{2,y} - u_{1,z}
-                        {
-                            int offset = (_lro_total_offsets[i]+0)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 0 on component 0 of curl
-                            // (no contribution)
-
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 1 on component 0 of curl
-                            // -u_{1,z}
-                            P_target_row(offset + target_NP + 3) = -std::pow(_epsilons(target_index), -1);
-
-                            offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 2 on component 0 of curl
-                            // u_{2,y}
-                            P_target_row(offset + 2*target_NP + 2) = std::pow(_epsilons(target_index), -1);
-                        }
-
-                        // output component 1
-                        // -u_{2,x} + u_{0,z}
-                        {
-                            int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 0 on component 1 of curl
-                            // u_{0,z}
-                            P_target_row(offset + 3) = std::pow(_epsilons(target_index), -1);
-
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 1 on component 1 of curl
-                            // (no contribution)
-
-                            offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 2 on component 1 of curl
-                            // -u_{2,x}
-                            P_target_row(offset + 2*target_NP + 1) = -std::pow(_epsilons(target_index), -1);
-                        }
-
-                        // output component 2
-                        // u_{1,x} - u_{0,y}
-                        {
-                            int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 0 on component 1 of curl
-                            // -u_{0,y}
-                            P_target_row(offset + 2) = -std::pow(_epsilons(target_index), -1);
-
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 1 on component 1 of curl
-                            // u_{1,x}
-                            P_target_row(offset + target_NP + 1) = std::pow(_epsilons(target_index), -1);
-
-                            offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 2 on component 1 of curl
-                            // (no contribution)
-                        }
-                    });
-                } else if (_dimensions==2) {
-                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                        // output component 0
-                        // u_{1,y}
-                        {
-                            int offset = (_lro_total_offsets[i]+0)*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 0 on component 0 of curl
-                            // (no contribution)
-
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 1 on component 0 of curl
-                            // -u_{1,z}
-                            P_target_row(offset + 2) = std::pow(_epsilons(target_index), -1);
-                        }
-
-                        // output component 1
-                        // -u_{0,x}
-                        {
-                            int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 0 on component 1 of curl
-                            // u_{0,z}
-                            P_target_row(offset + 1) = -std::pow(_epsilons(target_index), -1);
-
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
-                            for (int j=0; j<_dimensions*target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
-                            }
-                            // role of input 1 on component 1 of curl
-                            // (no contribution)
-                        }
-                    });
-                }
-            // scalar basis repeated number of components in vector
-            } else if (_reconstruction_space_rank == 0) {
+            } else if (_operations(i) == TargetOperation::CurlOfVectorPointEvaluation) {
                 // comments based on taking curl of vector [u_{0},u_{1},u_{2}]^T
                 // with as e.g., u_{1,z} being the partial derivative with respect to z of
                 // u_{1}
@@ -623,9 +519,9 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         }
                     });
                 }
+            } else {
+                compadre_kernel_assert_release((false) && "Functionality not yet available.");
             }
-        } else {
-            compadre_kernel_assert_release((false) && "Functionality not yet available.");
         }
 
         compadre_kernel_assert_release(((additional_evaluation_sites_need_handled && additional_evaluation_sites_handled) || (!additional_evaluation_sites_need_handled)) && "Auxiliary evaluation coordinates are specified by user, but are calling a target operation that can not handle evaluating additional sites.");

--- a/src/Compadre_Operators.hpp
+++ b/src/Compadre_Operators.hpp
@@ -66,13 +66,6 @@ namespace Compadre {
         VectorOfScalarClonesTaylorPolynomial,
     };
 
-    //! Number of effective components in the ReconstructionSpace (behaves like a reconstruction of this rank)
-    const int EffectiveReconstructionSpaceRank[] = {
-        0, ///< ScalarTaylorPolynomial
-        1, ///< VectorTaylorPolynomial
-        1, ///< VectorOfScalarClonesTaylorPolynomial
-    };
-
     //! Number of actual components in the ReconstructionSpace
     const int ActualReconstructionSpaceRank[] = {
         0, ///< ScalarTaylorPolynomial
@@ -93,6 +86,10 @@ namespace Compadre {
         StaggeredEdgeAnalyticGradientIntegralSample,
         //! Samples consist of the result of integrals of a vector dotted with the tangent along edges between neighbor and target
         StaggeredEdgeIntegralSample,
+        //! Only used for integrating polynomial dotted with normal over an edge, not for constracting on data
+        FaceNormalIntegralSample,
+        //! Samples consist of scalar representing a vector field dotted with an edge's normal direction and integrated
+        FaceNormalIntegralSampleData,
     };
 
     //! Rank of sampling functional input for each SamplingFunctional
@@ -102,6 +99,8 @@ namespace Compadre {
         1, ///< ManifoldVectorPointSample
         0, ///< StaggeredEdgeAnalyticGradientIntegralSample,
         1, ///< StaggeredEdgeIntegralSample
+        1, ///< FaceNormalIntegralSample
+        0, ///< FaceNormalIntegralSampleData
     };
 
     //! Rank of sampling functional output for each SamplingFunctional
@@ -111,6 +110,8 @@ namespace Compadre {
         1, ///< ManifoldVectorPointSample
         0, ///< StaggeredEdgeAnalyticGradientIntegralSample,
         0, ///< StaggeredEdgeIntegralSample
+        0, ///< FaceNormalIntegralSample
+        0, ///< FaceNormalIntegralSampleData
     };
 
     //! Describes the SamplingFunction relationship to targets, neighbors
@@ -128,6 +129,8 @@ namespace Compadre {
         (int)DifferentEachTarget,   ///< ManifoldVectorPointSample
         (int)SameForAll,            ///< StaggeredEdgeAnalyticGradientIntegralSample,
         (int)DifferentEachNeighbor, ///< StaggeredEdgeIntegralSample
+        (int)DifferentEachNeighbor, ///< FaceNormalIntegralSample
+        (int)Identity,              ///< FaceNormalIntegralSampleData
     };
 
     //! Whether or not the SamplingTensor acts on the target site as well as the neighbors.
@@ -138,6 +141,8 @@ namespace Compadre {
         0, ///< ManifoldVectorPointSample
         1, ///< StaggeredEdgeAnalyticGradientIntegralSample,
         1, ///< StaggeredEdgeIntegralSample
+        0, ///< FaceNormalIntegralSample
+        0, ///< FaceNormalIntegralSampleData
     };
 
     //! Whether the SamplingFunctional + ReconstructionSpace results in a nontrivial nullspace requiring SVD
@@ -149,6 +154,8 @@ namespace Compadre {
         0, ///< ManifoldVectorPointSample
         1, ///< StaggeredEdgeAnalyticGradientIntegralSample,
         1, ///< StaggeredEdgeIntegralSample
+        0, ///< FaceNormalIntegralSample
+        0, ///< FaceNormalIntegralSampleData
     };
 
     //! Dense solver type, that optionally can also handle manifolds


### PR DESCRIPTION
Refactored the GMLS_Targets (not on manifolds) to be organized by
reconstruction space rather than by operation.

Added a setExtraData function allowing a rank 2 matrix to be
available to sampling functionals acting on a basis and on target
operations.

Added SamplingFunctional::FaceNormalIntegralSample and
SamplingFunctional::FaceNormalIntegralSampleData.

Removed the enum EffectiveReconstructionSpaceRank as it was never used.