### PR TITLE
Cleanup and simplify GMLS class

### DIFF
--- a/src/Compadre_Evaluator.hpp
+++ b/src/Compadre_Evaluator.hpp
@@ -148,7 +148,7 @@ public:
 
         double value = 0;
 
-        const int alpha_column_base_multiplier = _gmls->getAlphaColumnOffset(lro, output_component_axis_1, 
+        const int alpha_input_output_component_index = _gmls->getAlphaColumnOffset(lro, output_component_axis_1, 
                 output_component_axis_2, input_component_axis_1, input_component_axis_2, evaluation_site_local_index);
 
         auto sampling_subview_maker = CreateNDSliceOnDeviceView(sampling_input_data, scalar_as_vector_if_needed);
@@ -167,7 +167,7 @@ public:
                 KOKKOS_LAMBDA(const int i, double& t_value) {
 
             t_value += sampling_data_device(neighbor_lists(target_index, i+1))
-                *alphas(ORDER_INDICES(target_index, alpha_column_base_multiplier*neighbor_lists(target_index, 0) + i));
+                *alphas(target_index, alpha_input_output_component_index, i);
 
         }, value );
         Kokkos::fence();
@@ -204,9 +204,9 @@ public:
     template <typename view_type_data_out, typename view_type_data_in>
     void applyAlphasToDataSingleComponentAllTargetSitesWithPreAndPostTransform(view_type_data_out output_data_single_column, view_type_data_in sampling_data_single_column, TargetOperation lro, SamplingFunctional sro, const int evaluation_site_local_index, const int output_component_axis_1, const int output_component_axis_2, const int input_component_axis_1, const int input_component_axis_2, const int pre_transform_local_index = -1, const int pre_transform_global_index = -1, const int post_transform_local_index = -1, const int post_transform_global_index = -1, bool transform_output_ambient = false, bool vary_on_target = false, bool vary_on_neighbor = false) const {
 
-        const int alpha_column_base_multiplier = _gmls->getAlphaColumnOffset(lro, output_component_axis_1, 
+        const int alpha_input_output_component_index = _gmls->getAlphaColumnOffset(lro, output_component_axis_1, 
                 output_component_axis_2, input_component_axis_1, input_component_axis_2, evaluation_site_local_index);
-        const int alpha_column_base_multiplier2 = alpha_column_base_multiplier;
+        const int alpha_input_output_component_index2 = alpha_input_output_component_index;
 
         auto global_dimensions = _gmls->getGlobalDimensions();
 
@@ -250,7 +250,7 @@ public:
                     : 1.0;
 
                 t_value += neighbor_varying_pre_T * sampling_data_single_column(neighbor_lists(target_index, i+1))
-                    *alphas(ORDER_INDICES(target_index, alpha_column_base_multiplier*neighbor_lists(target_index,0) +i));
+                    *alphas(target_index, alpha_input_output_component_index, i);
 
             }, gmls_value );
 
@@ -276,7 +276,7 @@ public:
                         : 1.0;
 
                     t_value += neighbor_varying_pre_T_staggered * sampling_data_single_column(neighbor_lists(target_index, 1))
-                        *alphas(ORDER_INDICES(target_index, alpha_column_base_multiplier2*neighbor_lists(target_index,0) +i));
+                        *alphas(target_index, alpha_input_output_component_index2, i);
 
                 }, staggered_value_from_targets );
 

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -15,7 +15,7 @@ void GMLS::generatePolynomialCoefficients() {
      */
 
     // copy over operations
-    _operations = Kokkos::View<TargetOperation*> ("operations", _lro.size());
+    _operations = decltype(_operations)("operations", _lro.size());
     _host_operations = Kokkos::create_mirror_view(_operations);
     
     compadre_assert_release((_max_num_neighbors >= 0) && "Neighbor lists not set in GMLS class before calling generateAlphas");
@@ -34,12 +34,12 @@ void GMLS::generatePolynomialCoefficients() {
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
     // would have to store for the max case (potentially number
-    _alphas = Kokkos::View<double***, layout_right>("coefficients", _neighbor_lists.extent(0), _total_alpha_values*max_evaluation_sites, _max_num_neighbors);
+    _alphas = decltype(_alphas)("coefficients", _neighbor_lists.extent(0), _total_alpha_values*max_evaluation_sites, _max_num_neighbors);
 
     // initialize the prestencil weights that are applied to sampling data to put it into a form 
     // that the GMLS operator will be able to operate on
     auto sro = _data_sampling_functional;
-    _prestencil_weights = Kokkos::View<double*****, layout_type>("Prestencil weights",
+    _prestencil_weights = decltype(_prestencil_weights)("Prestencil weights",
             std::pow(2,SamplingTensorForTargetSite[(int)sro]), 
             (SamplingTensorStyle[(int)sro]==DifferentEachTarget 
                     || SamplingTensorStyle[(int)sro]==DifferentEachNeighbor) ?
@@ -117,8 +117,8 @@ void GMLS::generatePolynomialCoefficients() {
          *    Calculate Scratch Space Allocations
          */
 
-        _team_scratch_size_b += scratch_matrix_type::shmem_size(_dimensions-1, _dimensions-1); // G
-        _team_scratch_size_b += scratch_matrix_type::shmem_size(_dimensions, _dimensions); // PTP matrix
+        _team_scratch_size_b += scratch_matrix_right_type::shmem_size(_dimensions-1, _dimensions-1); // G
+        _team_scratch_size_b += scratch_matrix_right_type::shmem_size(_dimensions, _dimensions); // PTP matrix
         _team_scratch_size_b += scratch_vector_type::shmem_size( (_dimensions-1)*_max_num_neighbors ); // manifold_gradient
 
         _team_scratch_size_b += scratch_vector_type::shmem_size(_max_num_neighbors*std::max(_sampling_multiplier,_basis_multiplier)); // t1 work vector for qr
@@ -169,9 +169,8 @@ void GMLS::generatePolynomialCoefficients() {
 
 
 #ifdef COMPADRE_USE_CUDA
-    int nt = 32;
-    _threads_per_team = nt;
-    if (_basis_multiplier*_NP > 96) _threads_per_team += nt;
+    _threads_per_team = 32;
+    if (_basis_multiplier*_NP > 96) _threads_per_team += 32;
 #else
     _threads_per_team = 1;
 #endif
@@ -304,8 +303,13 @@ void GMLS::generateAlphas() {
          */
 
         // evaluates targets, applies target evaluation to polynomial coefficients to store in _alphas
+#ifdef COMPADRE_USE_CUDA
         int nv=8;
-        this->CallFunctorWithTeamThreadsAndVectors<ApplyStandardTargets>(_threads_per_team/nv, nv, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+#else
+        int nv=1;
+#endif
+        int nt=_threads_per_team/nv;
+        this->CallFunctorWithTeamThreadsAndVectors<ApplyStandardTargets>(nt, nv, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
 
     }
     Kokkos::fence();
@@ -346,11 +350,11 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
     // the threads in a team work on these local copies that only the team sees
     // thread_scratch has a copy per thread
 
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    scratch_matrix_right_type PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RHS(_RHS.data() 
+    scratch_matrix_right_type RHS(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > w(_w.data() 
+    scratch_vector_type w(_w.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows), max_num_rows);
 
     // delta, used for each thread
@@ -393,12 +397,12 @@ void GMLS::operator()(const ApplyStandardTargets&, const member_type& teamMember
      *    Data
      */
 
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    scratch_matrix_right_type PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
     // Coefficients for polynomial basis have overwritten _RHS
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Coeffs(_RHS.data() 
+    scratch_matrix_right_type Coeffs(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > w(_w.data() 
+    scratch_vector_type w(_w.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows), max_num_rows);
 
     scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_a), max_num_rows);
@@ -437,14 +441,14 @@ void GMLS::operator()(const ComputeCoarseTangentPlane&, const member_type& teamM
      *    Data
      */
 
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    scratch_matrix_right_type PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > w(_w.data() 
+    scratch_vector_type w(_w.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows), max_num_rows);
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() 
+    scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
-    scratch_matrix_type PTP(teamMember.team_scratch(_scratch_team_level_b), _dimensions, _dimensions);
+    scratch_matrix_right_type PTP(teamMember.team_scratch(_scratch_team_level_b), _dimensions, _dimensions);
 
     // delta, used for each thread
     scratch_vector_type delta(teamMember.thread_scratch(_scratch_thread_level_b), max_manifold_NP*_basis_multiplier);
@@ -487,13 +491,13 @@ void GMLS::operator()(const AssembleCurvaturePsqrtW&, const member_type& teamMem
      *    Data
      */
 
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > CurvaturePsqrtW(_P.data() 
+    scratch_matrix_right_type CurvaturePsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RHS(_RHS.data() 
+    scratch_matrix_right_type RHS(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > w(_w.data() 
+    scratch_vector_type w(_w.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows), max_num_rows);
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() 
+    scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
     // delta, used for each thread
@@ -542,9 +546,9 @@ void GMLS::operator()(const GetAccurateTangentDirections&, const member_type& te
      *    Data
      */
 
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Q(_RHS.data() 
+    scratch_matrix_right_type Q(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() 
+    scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
     scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
@@ -674,8 +678,8 @@ void GMLS::operator()(const FixTangentDirectionOrdering&, const member_type& tea
      *    Data
      */
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() + target_index*_dimensions*_dimensions, _dimensions, _dimensions);
-    Kokkos::View<double*, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > N(_ref_N.data() + target_index*_dimensions, _dimensions);
+    scratch_matrix_right_type T(_T.data() + target_index*_dimensions*_dimensions, _dimensions, _dimensions);
+    scratch_vector_type N(_ref_N.data() + target_index*_dimensions, _dimensions);
 
     // take the dot product of the calculated normal in the tangent bundle with a given reference outward normal 
     // direction provided by the user. if the dot product is negative, flip the tangent vector ordering 
@@ -727,17 +731,17 @@ void GMLS::operator()(const ApplyCurvatureTargets&, const member_type& teamMembe
      *    Data
      */
 
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Q(_RHS.data() 
+    scratch_matrix_right_type Q(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() 
+    scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > G_inv(_manifold_metric_tensor_inverse.data() 
+    scratch_matrix_right_type G_inv(_manifold_metric_tensor_inverse.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL((_dimensions-1))*TO_GLOBAL((_dimensions-1)), _dimensions-1, _dimensions-1);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > manifold_coeffs(_manifold_curvature_coefficients.data() + target_index*manifold_NP, manifold_NP);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > manifold_gradient_coeffs(_manifold_curvature_gradient.data() + target_index*(_dimensions-1), (_dimensions-1));
+    scratch_vector_type manifold_coeffs(_manifold_curvature_coefficients.data() + target_index*manifold_NP, manifold_NP);
+    scratch_vector_type manifold_gradient_coeffs(_manifold_curvature_gradient.data() + target_index*(_dimensions-1), (_dimensions-1));
 
-    scratch_matrix_type G(teamMember.team_scratch(_scratch_team_level_b), _dimensions-1, _dimensions-1);
+    scratch_matrix_right_type G(teamMember.team_scratch(_scratch_team_level_b), _dimensions-1, _dimensions-1);
     scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
     scratch_vector_type t2(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
     scratch_vector_type manifold_gradient(teamMember.team_scratch(_scratch_team_level_b), (_dimensions-1)*_max_num_neighbors);
@@ -856,13 +860,13 @@ void GMLS::operator()(const AssembleManifoldPsqrtW&, const member_type& teamMemb
      *    Data
      */
 
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    scratch_matrix_right_type PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Q(_RHS.data() 
+    scratch_matrix_right_type Q(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > w(_w.data() 
+    scratch_vector_type w(_w.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows), max_num_rows);
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() 
+    scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
     // delta, used for each thread
@@ -908,19 +912,19 @@ void GMLS::operator()(const ApplyManifoldTargets&, const member_type& teamMember
      *    Data
      */
 
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    scratch_matrix_right_type PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
-    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Coeffs(_RHS.data() 
+    scratch_matrix_right_type Coeffs(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > w(_w.data() 
+    scratch_vector_type w(_w.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows), max_num_rows);
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() 
+    scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > G_inv(_manifold_metric_tensor_inverse.data() 
+    scratch_matrix_right_type G_inv(_manifold_metric_tensor_inverse.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL((_dimensions-1))*TO_GLOBAL((_dimensions-1)), _dimensions-1, _dimensions-1);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > manifold_coeffs(_manifold_curvature_coefficients.data() + target_index*manifold_NP, manifold_NP);
-    Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > manifold_gradient_coeffs(_manifold_curvature_gradient.data() + target_index*(_dimensions-1), (_dimensions-1));
+    scratch_vector_type manifold_coeffs(_manifold_curvature_coefficients.data() + target_index*manifold_NP, manifold_NP);
+    scratch_vector_type manifold_gradient_coeffs(_manifold_curvature_gradient.data() + target_index*(_dimensions-1), (_dimensions-1));
 
     scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
     scratch_vector_type t2(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
@@ -953,7 +957,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
      *    Data
      */
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() 
+    scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
     /*

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -346,9 +346,9 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
     // the threads in a team work on these local copies that only the team sees
     // thread_scratch has a copy per thread
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RHS(_RHS.data() 
+    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RHS(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
     Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > w(_w.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows), max_num_rows);
@@ -393,7 +393,7 @@ void GMLS::operator()(const ApplyStandardTargets&, const member_type& teamMember
      *    Data
      */
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
     // Coefficients for polynomial basis have overwritten _RHS
     Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Coeffs(_RHS.data() 
@@ -437,7 +437,7 @@ void GMLS::operator()(const ComputeCoarseTangentPlane&, const member_type& teamM
      *    Data
      */
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
     Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > w(_w.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows), max_num_rows);
@@ -487,7 +487,7 @@ void GMLS::operator()(const AssembleCurvaturePsqrtW&, const member_type& teamMem
      *    Data
      */
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > CurvaturePsqrtW(_P.data() 
+    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > CurvaturePsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
     Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > RHS(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
@@ -856,7 +856,7 @@ void GMLS::operator()(const AssembleManifoldPsqrtW&, const member_type& teamMemb
      *    Data
      */
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
     Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Q(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
@@ -908,7 +908,7 @@ void GMLS::operator()(const ApplyManifoldTargets&, const member_type& teamMember
      *    Data
      */
 
-    Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
+    Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > PsqrtW(_P.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_columns), max_num_rows, this_num_columns);
     Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > Coeffs(_RHS.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -1047,9 +1047,9 @@ public:
         //
 
         const int alpha_column_offset = this->getAlphaColumnOffset( lro, output_component_axis_1, 
-                output_component_axis_2, input_component_axis_1, input_component_axis_2);
+                output_component_axis_2, input_component_axis_1, input_component_axis_2, 0 /* additional evaluation site */);
 
-        return _host_alphas(target_index, (int)lro, alpha_column_offset, 0 /* additional evaluation site */, neighbor_index);
+        return _host_alphas(target_index, alpha_column_offset, neighbor_index);
     }
 
     //! Returns a stencil to transform data from its existing state into the input expected 

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -61,23 +61,23 @@ protected:
     Kokkos::View<double*> _manifold_curvature_gradient;
 
     //! Extra data available to basis functions and target operations (optional)
-    Kokkos::View<double**> _extra_data;
+    Kokkos::View<double**, layout_right> _extra_data;
 
     
     //! contains local IDs of neighbors to get coordinates from _source_coordinates (device)
-    Kokkos::View<int**, layout_type> _neighbor_lists; 
+    Kokkos::View<int**, layout_right> _neighbor_lists; 
 
     //! contains local IDs of neighbors to get coordinates from _source_coordinates (host)
-    Kokkos::View<int**, layout_type>::HostMirror _host_neighbor_lists;
+    Kokkos::View<int**, layout_right>::HostMirror _host_neighbor_lists;
 
     //! contains the # of neighbors for each target (host)
     Kokkos::View<int*, Kokkos::HostSpace> _number_of_neighbors_list; 
 
     //! all coordinates for the source for which _neighbor_lists refers (device)
-    Kokkos::View<double**, layout_type> _source_coordinates; 
+    Kokkos::View<double**, layout_right> _source_coordinates; 
 
     //! coordinates for target sites for reconstruction same number of rows as _neighbor_lists (device)
-    Kokkos::View<double**, layout_type> _target_coordinates; 
+    Kokkos::View<double**, layout_right> _target_coordinates; 
 
     //! h supports determined through neighbor search, same number of rows as _neighbor_lists (device)
     Kokkos::View<double*> _epsilons; 
@@ -93,20 +93,20 @@ protected:
     
     //! generated weights for nontraditional samples required to transform data into expected sampling 
     //! functional form (device). 
-    Kokkos::View<double*****, layout_type> _prestencil_weights; 
+    Kokkos::View<double*****, layout_right> _prestencil_weights; 
 
     //! generated weights for nontraditional samples required to transform data into expected sampling 
     //! functional form (host)
-    Kokkos::View<const double*****, layout_type>::HostMirror _host_prestencil_weights;
+    Kokkos::View<const double*****, layout_right>::HostMirror _host_prestencil_weights;
 
     //! (OPTIONAL) user provided additional coordinates for target operation evaluation (device)
-    Kokkos::View<double**, layout_type> _additional_evaluation_coordinates; 
+    Kokkos::View<double**, layout_right> _additional_evaluation_coordinates; 
 
     //! (OPTIONAL) contains indices of entries in the _additional_evaluation_coordinates view (device)
-    Kokkos::View<int**, layout_type> _additional_evaluation_indices; 
+    Kokkos::View<int**, layout_right> _additional_evaluation_indices; 
 
     //! (OPTIONAL) contains indices of entries in the _additional_evaluation_coordinates view (host)
-    Kokkos::View<int**, layout_type>::HostMirror _host_additional_evaluation_indices;
+    Kokkos::View<int**, layout_right>::HostMirror _host_additional_evaluation_indices;
 
     //! (OPTIONAL) contains the # of additional coordinate indices for each target (host)
     Kokkos::View<int*, Kokkos::HostSpace> _number_of_additional_evaluation_indices; 
@@ -158,10 +158,10 @@ protected:
 
 
     //! 1D quadrature weights for staggered approaches
-    Kokkos::View<double*, layout_type> _quadrature_weights;
+    Kokkos::View<double*, layout_right> _quadrature_weights;
 
     //! 1D quadrature sites (reference [0,1]) for staggered approaches
-    Kokkos::View<double*, layout_type> _parameterized_quadrature_sites;
+    Kokkos::View<double*, layout_right> _parameterized_quadrature_sites;
 
 
 
@@ -222,34 +222,34 @@ protected:
     std::vector<int> _lro_lookup; 
 
     //! index for where this operation begins the for _alpha coefficients (device)
-    Kokkos::View<int*, layout_type> _lro_total_offsets; 
+    Kokkos::View<int*> _lro_total_offsets; 
 
     //! index for where this operation begins the for _alpha coefficients (host)
-    Kokkos::View<int*, layout_type>::HostMirror _host_lro_total_offsets; 
+    Kokkos::View<int*>::HostMirror _host_lro_total_offsets; 
 
     //! dimensions ^ rank of tensor of output for each target functional (device)
-    Kokkos::View<int*, layout_type> _lro_output_tile_size; 
+    Kokkos::View<int*> _lro_output_tile_size; 
 
     //! dimensions ^ rank of tensor of output for each target functional (host)
-    Kokkos::View<int*, layout_type>::HostMirror _host_lro_output_tile_size; 
+    Kokkos::View<int*>::HostMirror _host_lro_output_tile_size; 
 
     //! dimensions ^ rank of tensor of output for each sampling functional (device)
-    Kokkos::View<int*, layout_type> _lro_input_tile_size; 
+    Kokkos::View<int*> _lro_input_tile_size; 
 
     //! dimensions ^ rank of tensor of output for each sampling functional (host)
-    Kokkos::View<int*, layout_type>::HostMirror _host_lro_input_tile_size; 
+    Kokkos::View<int*>::HostMirror _host_lro_input_tile_size; 
 
     //! tensor rank of target functional (device)
-    Kokkos::View<int*, layout_type> _lro_output_tensor_rank;
+    Kokkos::View<int*> _lro_output_tensor_rank;
 
     //! tensor rank of target functional (host)
-    Kokkos::View<int*, layout_type>::HostMirror _host_lro_output_tensor_rank;
+    Kokkos::View<int*>::HostMirror _host_lro_output_tensor_rank;
 
     //! tensor rank of sampling functional (device)
-    Kokkos::View<int*, layout_type> _lro_input_tensor_rank;
+    Kokkos::View<int*> _lro_input_tensor_rank;
 
     //! tensor rank of sampling functional (host)
-    Kokkos::View<int*, layout_type>::HostMirror _host_lro_input_tensor_rank;
+    Kokkos::View<int*>::HostMirror _host_lro_input_tensor_rank;
 
     //! used for sizing P_target_row and the _alphas view
     int _total_alpha_values;
@@ -344,7 +344,7 @@ protected:
         \param additional_evaluation_local_index [in] - local index for evaluation sites 
     */
     KOKKOS_INLINE_FUNCTION
-    void calcPij(double* delta, const int target_index, int neighbor_index, const double alpha, const int dimension, const int poly_order, bool specific_order_only = false, scratch_matrix_type* V = NULL, const ReconstructionSpace reconstruction_space = ReconstructionSpace::ScalarTaylorPolynomial, const SamplingFunctional sampling_strategy = SamplingFunctional::PointSample, const int additional_evaluation_local_index = 0) const;
+    void calcPij(double* delta, const int target_index, int neighbor_index, const double alpha, const int dimension, const int poly_order, bool specific_order_only = false, scratch_matrix_right_type* V = NULL, const ReconstructionSpace reconstruction_space = ReconstructionSpace::ScalarTaylorPolynomial, const SamplingFunctional sampling_strategy = SamplingFunctional::PointSample, const int additional_evaluation_local_index = 0) const;
 
     /*! \brief Evaluates the gradient of a polynomial basis under the Dirac Delta (pointwise) sampling function.
         \param delta            [in/out] - scratch space that is allocated so that each thread has its own copy. Must be at least as large is the _basis_multipler*the dimension of the polynomial basis.
@@ -361,7 +361,7 @@ protected:
         \param additional_evaluation_local_index [in] - local index for evaluation sites 
     */
     KOKKOS_INLINE_FUNCTION
-    void calcGradientPij(double* delta, const int target_index, const int neighbor_index, const double alpha, const int partial_direction, const int dimension, const int poly_order, bool specific_order_only, scratch_matrix_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional sampling_strategy, const int additional_evaluation_local_index = 0) const;
+    void calcGradientPij(double* delta, const int target_index, const int neighbor_index, const double alpha, const int partial_direction, const int dimension, const int poly_order, bool specific_order_only, scratch_matrix_right_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional sampling_strategy, const int additional_evaluation_local_index = 0) const;
 
     /*! \brief Evaluates the weighting kernel
         \param r                [in] - Euclidean distance of relative vector. Euclidean distance of (target - neighbor) in some basis.
@@ -385,7 +385,7 @@ protected:
         \param sampling_strategy    [in] - sampling functional specification
     */
     KOKKOS_INLINE_FUNCTION
-    void createWeightsAndP(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, int polynomial_order, bool weight_p = false, scratch_matrix_type* V = NULL, const ReconstructionSpace reconstruction_space = ReconstructionSpace::ScalarTaylorPolynomial, const SamplingFunctional sampling_strategy = SamplingFunctional::PointSample) const;
+    void createWeightsAndP(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, int polynomial_order, bool weight_p = false, scratch_matrix_right_type* V = NULL, const ReconstructionSpace reconstruction_space = ReconstructionSpace::ScalarTaylorPolynomial, const SamplingFunctional sampling_strategy = SamplingFunctional::PointSample) const;
 
     /*! \brief Fills the _P matrix with P*sqrt(w) for use in solving for curvature
 
@@ -400,7 +400,7 @@ protected:
         \param V                    [in] - orthonormal basis matrix size _dimensions * _dimensions whose first _dimensions-1 columns are an approximation of the tangent plane
     */
     KOKKOS_INLINE_FUNCTION
-    void createWeightsAndPForCurvature(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, bool only_specific_order, scratch_matrix_type* V = NULL) const;
+    void createWeightsAndPForCurvature(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, bool only_specific_order, scratch_matrix_right_type* V = NULL) const;
 
     /*! \brief Evaluates a polynomial basis with a target functional applied to each member of the basis
         \param teamMember                   [in] - Kokkos::TeamPolicy member type (created by parallel_for)
@@ -422,7 +422,7 @@ protected:
         \param V                            [in] - orthonormal basis matrix size _dimensions * _dimensions whose first _dimensions-1 columns are an approximation of the tangent plane
     */
     KOKKOS_INLINE_FUNCTION
-    void computeCurvatureFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_type* V) const;
+    void computeCurvatureFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_right_type* V) const;
 
     /*! \brief Evaluates a polynomial basis with a target functional applied, using information from the manifold curvature
 
@@ -438,7 +438,7 @@ protected:
         \param curvature_gradients          [in] - approximation of gradient of curvature, Kokkos View of size (_dimensions-1)
     */
     KOKKOS_INLINE_FUNCTION
-    void computeTargetFunctionalsOnManifold(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_type V, scratch_matrix_type G_inv, scratch_vector_type curvature_coefficients, scratch_vector_type curvature_gradients) const;
+    void computeTargetFunctionalsOnManifold(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_right_type V, scratch_matrix_right_type G_inv, scratch_vector_type curvature_coefficients, scratch_vector_type curvature_gradients) const;
 
     //! Helper function for applying the evaluations from a target functional to the polynomial coefficients
     KOKKOS_INLINE_FUNCTION
@@ -514,7 +514,7 @@ protected:
     //! Returns one component of the target coordinate for a particular target. Whether global or local coordinates 
     //! depends upon V being specified
     KOKKOS_INLINE_FUNCTION
-    double getTargetCoordinate(const int target_index, const int dim, const scratch_matrix_type* V = NULL) const {
+    double getTargetCoordinate(const int target_index, const int dim, const scratch_matrix_right_type* V = NULL) const {
         compadre_kernel_assert_debug((_target_coordinates.extent(0) >= target_index) && "Target index is out of range for _target_coordinates.");
         if (V==NULL) {
             return _target_coordinates(target_index, dim);
@@ -530,7 +530,7 @@ protected:
     //! Returns one component of the additional evaluation coordinates. Whether global or local coordinates 
     //! depends upon V being specified
     KOKKOS_INLINE_FUNCTION
-    double getTargetAuxiliaryCoordinate(const int target_index, const int additional_list_num, const int dim, const scratch_matrix_type* V = NULL) const {
+    double getTargetAuxiliaryCoordinate(const int target_index, const int additional_list_num, const int dim, const scratch_matrix_right_type* V = NULL) const {
         auto additional_evaluation_index = getAdditionalEvaluationIndex(target_index, additional_list_num);
         compadre_kernel_assert_debug((_additional_evaluation_coordinates.extent(0) >= additional_evaluation_index) && "Additional evaluation index is out of range for _additional_evaluation_coordinates.");
         if (V==NULL) {
@@ -546,7 +546,7 @@ protected:
     //! Returns one component of the neighbor coordinate for a particular target. Whether global or local coordinates 
     //! depends upon V being specified
     KOKKOS_INLINE_FUNCTION
-    double getNeighborCoordinate(const int target_index, const int neighbor_list_num, const int dim, const scratch_matrix_type* V = NULL) const {
+    double getNeighborCoordinate(const int target_index, const int neighbor_list_num, const int dim, const scratch_matrix_right_type* V = NULL) const {
         compadre_kernel_assert_debug((_source_coordinates.extent(0) >= this->getNeighborIndex(target_index, neighbor_list_num)) && "Source index is out of range for _source_coordinates.");
         if (V==NULL) {
             return _source_coordinates(this->getNeighborIndex(target_index, neighbor_list_num), dim);
@@ -559,7 +559,7 @@ protected:
     //! Returns the relative coordinate as a vector between the target site and the neighbor site. 
     //! Whether global or local coordinates depends upon V being specified
     KOKKOS_INLINE_FUNCTION
-    XYZ getRelativeCoord(const int target_index, const int neighbor_list_num, const int dimension, const scratch_matrix_type* V = NULL) const {
+    XYZ getRelativeCoord(const int target_index, const int neighbor_list_num, const int dimension, const scratch_matrix_right_type* V = NULL) const {
         XYZ coordinate_delta;
 
         coordinate_delta.x = this->getNeighborCoordinate(target_index, neighbor_list_num, 0, V) - this->getTargetCoordinate(target_index, 0, V);
@@ -571,7 +571,7 @@ protected:
 
     //! Returns a component of the local coordinate after transformation from global to local under the orthonormal basis V.
     KOKKOS_INLINE_FUNCTION
-    double convertGlobalToLocalCoordinate(const XYZ global_coord, const int dim, const scratch_matrix_type* V) const {
+    double convertGlobalToLocalCoordinate(const XYZ global_coord, const int dim, const scratch_matrix_right_type* V) const {
         // only written for 2d manifold in 3d space
         double val = 0;
         val += global_coord.x * (*V)(dim, 0);
@@ -582,7 +582,7 @@ protected:
 
     //! Returns a component of the global coordinate after transformation from local to global under the orthonormal basis V^T.
     KOKKOS_INLINE_FUNCTION
-    double convertLocalToGlobalCoordinate(const XYZ local_coord, const int dim, const scratch_matrix_type* V) const {
+    double convertLocalToGlobalCoordinate(const XYZ local_coord, const int dim, const scratch_matrix_right_type* V) const {
         // only written for 2d manifold in 3d space
         double val;
         if (dim == 0 && _dimensions==2) { // 2D problem with 1D manifold
@@ -903,7 +903,7 @@ public:
     double getTangentBundle(const int target_index, const int direction, const int component) const {
         // Component index 0.._dimensions-2 will return tangent direction
         // Component index _dimensions-1 will return the normal direction
-        Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >::HostMirror 
+        scratch_matrix_right_type::HostMirror 
                 T(_host_T.data() + target_index*_dimensions*_dimensions, _dimensions, _dimensions);
         return T(direction, component);
     }
@@ -912,7 +912,7 @@ public:
     double getReferenceNormalDirection(const int target_index, const int component) const {
         compadre_assert_debug(_reference_outward_normal_direction_provided && 
                 "getRefenceNormalDirection called, but reference outwrad normal directions were never provided.");
-        Kokkos::View<double*, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> >::HostMirror 
+        scratch_vector_type::HostMirror 
                 ref_N(_host_ref_N.data() + target_index*_dimensions, _dimensions);
         return ref_N(component);
     }
@@ -1151,14 +1151,13 @@ public:
     //! first entry in ever row should be the number of neighbors for the corresponding target.
     template <typename view_type>
     void setNeighborLists(view_type neighbor_lists) {
-        // Catches Kokkos::View<int**, Kokkos::DefaultHostExecutionSpace
         // allocate memory on device
-        _neighbor_lists = Kokkos::View<int**, layout_type>("device neighbor lists",
+        _neighbor_lists = decltype(_neighbor_lists)("device neighbor lists",
             neighbor_lists.dimension_0(), neighbor_lists.dimension_1());
         _host_neighbor_lists = Kokkos::create_mirror_view(_neighbor_lists);
 
         typedef typename view_type::memory_space input_array_memory_space;
-        if (std::is_same<input_array_memory_space, Kokkos::DefaultExecutionSpace::memory_space>::value) {
+        if (std::is_same<input_array_memory_space, device_execution_space::memory_space>::value) {
             // check if on the device, then copy directly
             // if it is, then it doesn't match the internal layout we use
             // then copy to the host mirror
@@ -1188,7 +1187,7 @@ public:
     //! Sets neighbor list information. 2D array should be # targets x maximum number of neighbors for any target + 1.
     //! first entry in ever row should be the number of neighbors for the corresponding target.
     template <typename view_type>
-    void setNeighborLists(Kokkos::View<int**, layout_right, Kokkos::DefaultExecutionSpace> neighbor_lists) {
+    void setNeighborLists(decltype(_neighbor_lists) neighbor_lists) {
         _neighbor_lists = neighbor_lists;
 
         _host_neighbor_lists = Kokkos::create_mirror_view(_neighbor_lists);
@@ -1210,11 +1209,11 @@ public:
     void setSourceSites(view_type source_coordinates) {
 
         // allocate memory on device
-        _source_coordinates = Kokkos::View<double**, layout_type>("device neighbor coordinates",
+        _source_coordinates = decltype(_source_coordinates)("device neighbor coordinates",
                 source_coordinates.dimension_0(), source_coordinates.dimension_1());
 
         typedef typename view_type::memory_space input_array_memory_space;
-        if (std::is_same<input_array_memory_space, Kokkos::DefaultExecutionSpace::memory_space>::value) {
+        if (std::is_same<input_array_memory_space, device_execution_space::memory_space>::value) {
             // check if on the device, then copy directly
             // if it is, then it doesn't match the internal layout we use
             // then copy to the host mirror
@@ -1235,7 +1234,7 @@ public:
     //! Sets source coordinate information. Rows of this 2D-array should correspond to neighbor IDs contained in the entries
     //! of the neighbor lists 2D array.
     template<typename view_type>
-    void setSourceSites(Kokkos::View<double**, layout_right, Kokkos::DefaultExecutionSpace> source_coordinates) {
+    void setSourceSites(decltype(_source_coordinates) source_coordinates) {
         // allocate memory on device
         _source_coordinates = source_coordinates;
         this->resetCoefficientData();
@@ -1245,11 +1244,11 @@ public:
     template<typename view_type>
     void setTargetSites(view_type target_coordinates) {
         // allocate memory on device
-        _target_coordinates = Kokkos::View<double**, layout_type>("device target coordinates",
+        _target_coordinates = decltype(_target_coordinates)("device target coordinates",
                 target_coordinates.dimension_0(), target_coordinates.dimension_1());
 
         typedef typename view_type::memory_space input_array_memory_space;
-        if (std::is_same<input_array_memory_space, Kokkos::DefaultExecutionSpace::memory_space>::value) {
+        if (std::is_same<input_array_memory_space, device_execution_space::memory_space>::value) {
             // check if on the device, then copy directly
             // if it is, then it doesn't match the internal layout we use
             // then copy to the host mirror
@@ -1269,7 +1268,7 @@ public:
 
     //! Sets target coordinate information. Rows of this 2D-array should correspond to rows of the neighbor lists.
     template<typename view_type>
-    void setTargetSites(Kokkos::View<double**, layout_right, Kokkos::DefaultExecutionSpace> target_coordinates) {
+    void setTargetSites(decltype(_target_coordinates) target_coordinates) {
         // allocate memory on device
         _target_coordinates = target_coordinates;
         this->resetCoefficientData();
@@ -1280,7 +1279,7 @@ public:
     void setWindowSizes(view_type epsilons) {
 
         // allocate memory on device
-        _epsilons = Kokkos::View<double*>("device epsilons",
+        _epsilons = decltype(_epsilons)("device epsilons",
                         epsilons.dimension_0(), epsilons.dimension_1());
 
         _host_epsilons = Kokkos::create_mirror_view(_epsilons);
@@ -1292,7 +1291,7 @@ public:
 
     //! Sets window sizes, also called the support of the kernel (device)
     template<typename view_type>
-    void setWindowSizes(Kokkos::View<double*, Kokkos::DefaultExecutionSpace> epsilons) {
+    void setWindowSizes(decltype(_epsilons) epsilons) {
         // allocate memory on device
         _epsilons = epsilons;
         this->resetCoefficientData();
@@ -1313,11 +1312,11 @@ public:
         // (_dense_solver_type == DenseSolverType::MANIFOLD) {
 
         // allocate memory on device
-        _T = Kokkos::View<double*>("device tangent directions", _target_coordinates.dimension_0()*_dimensions*_dimensions);
+        _T = decltype(_T)("device tangent directions", _target_coordinates.dimension_0()*_dimensions*_dimensions);
 
         // rearrange data on device from data given on host
-        Kokkos::parallel_for("copy tangent vectors", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, _target_coordinates.dimension_0()), KOKKOS_LAMBDA(const int i) {
-            Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > T(_T.data() + i*_dimensions*_dimensions, _dimensions, _dimensions);
+        Kokkos::parallel_for("copy tangent vectors", Kokkos::RangePolicy<device_execution_space>(0, _target_coordinates.dimension_0()), KOKKOS_LAMBDA(const int i) {
+            scratch_matrix_right_type T(_T.data() + i*_dimensions*_dimensions, _dimensions, _dimensions);
             for (int j=0; j<_dimensions; ++j) {
                 for (int k=0; k<_dimensions; ++k) {
                     T(j,k) = tangent_directions(i, j, k);
@@ -1340,13 +1339,13 @@ public:
         // accept input from user as a rank 2 tensor
         
         // allocate memory on device
-        _ref_N = Kokkos::View<double*>("device normal directions", _target_coordinates.dimension_0()*_dimensions);
+        _ref_N = decltype(_ref_N)("device normal directions", _target_coordinates.dimension_0()*_dimensions);
         // to assist LAMBDA capture
         auto this_ref_N = this->_ref_N;
         auto this_dimensions = this->_dimensions;
 
         // rearrange data on device from data given on host
-        Kokkos::parallel_for("copy normal vectors", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>(0, _target_coordinates.extent(0)), KOKKOS_LAMBDA(const int i) {
+        Kokkos::parallel_for("copy normal vectors", Kokkos::RangePolicy<device_execution_space>(0, _target_coordinates.extent(0)), KOKKOS_LAMBDA(const int i) {
             for (int j=0; j<this_dimensions; ++j) {
                 this_ref_N(i*this_dimensions + j) = outward_normal_directions(i, j);
             }
@@ -1367,7 +1366,7 @@ public:
     void setExtraData(view_type extra_data) {
 
         // allocate memory on device
-        _extra_data = Kokkos::View<double**>("device extra data", extra_data.extent(0), extra_data.extent(1));
+        _extra_data = decltype(_extra_data)("device extra data", extra_data.extent(0), extra_data.extent(1));
 
         auto host_extra_data = Kokkos::create_mirror_view(_extra_data);
         Kokkos::deep_copy(host_extra_data, extra_data);
@@ -1379,7 +1378,7 @@ public:
     //! (OPTIONAL)
     //! Sets extra data to be used by sampling functionals and target operations in certain instances. (device)
     template<typename view_type>
-    void setExtraData(Kokkos::View<double**, layout_right, Kokkos::DefaultExecutionSpace> extra_data) {
+    void setExtraData(decltype(_extra_data) extra_data) {
         // allocate memory on device
         _extra_data = extra_data;
         this->resetCoefficientData();
@@ -1391,13 +1390,12 @@ public:
     //! operations will be evaluated and applied to polynomial reconstructions.
     template <typename view_type>
     void setAuxiliaryEvaluationCoordinates(view_type evaluation_coordinates) {
-        // Catches Kokkos::View<int**, Kokkos::DefaultHostExecutionSpace
         // allocate memory on device
-        _additional_evaluation_coordinates = Kokkos::View<double**, layout_type>("device additional evaluation coordinates",
+        _additional_evaluation_coordinates = decltype(_additional_evaluation_coordinates)("device additional evaluation coordinates",
             evaluation_coordinates.dimension_0(), evaluation_coordinates.dimension_1());
 
         typedef typename view_type::memory_space input_array_memory_space;
-        if (std::is_same<input_array_memory_space, Kokkos::DefaultExecutionSpace::memory_space>::value) {
+        if (std::is_same<input_array_memory_space, device_execution_space::memory_space>::value) {
             // check if on the device, then copy directly
             // if it is, then it doesn't match the internal layout we use
             // then copy to the host mirror
@@ -1420,7 +1418,7 @@ public:
     //! If this is never called, then the target sites are the only locations where the target
     //! operations will be evaluated and applied to polynomial reconstructions. (device)
     template <typename view_type>
-    void setAuxiliaryEvaluationCoordinates(Kokkos::View<double**, layout_right, Kokkos::DefaultExecutionSpace> evaluation_coordinates) {
+    void setAuxiliaryEvaluationCoordinates(decltype(_additional_evaluation_coordinates) evaluation_coordinates) {
         _additional_evaluation_coordinates = evaluation_coordinates;
         this->resetCoefficientData();
     }
@@ -1430,15 +1428,14 @@ public:
     //! evaluation indices for any target + 1. first entry in every row should be the number of indices for the corresponding target.
     template <typename view_type>
     void setAuxiliaryEvaluationIndicesLists(view_type indices_lists) {
-        // Catches Kokkos::View<int**, Kokkos::DefaultHostExecutionSpace
         // allocate memory on device
-        _additional_evaluation_indices = Kokkos::View<int**, layout_type>("device additional evaluation indices",
+        _additional_evaluation_indices = decltype(_additional_evaluation_indices)("device additional evaluation indices",
             indices_lists.dimension_0(), indices_lists.dimension_1());
 
         _host_additional_evaluation_indices = Kokkos::create_mirror_view(_additional_evaluation_indices);
 
         typedef typename view_type::memory_space input_array_memory_space;
-        if (std::is_same<input_array_memory_space, Kokkos::DefaultExecutionSpace::memory_space>::value) {
+        if (std::is_same<input_array_memory_space, device_execution_space::memory_space>::value) {
             // check if on the device, then copy directly
             // if it is, then it doesn't match the internal layout we use
             // then copy to the host mirror
@@ -1467,7 +1464,7 @@ public:
     //! Sets the additional target evaluation coordinate indices list information. Should be # targets x maximum number of indices
     //! evaluation indices for any target + 1. first entry in every row should be the number of indices for the corresponding target.
     template <typename view_type>
-    void setAuxiliaryEvaluationIndicesLists(Kokkos::View<int**, layout_right, Kokkos::DefaultExecutionSpace> indices_lists) {
+    void setAuxiliaryEvaluationIndicesLists(decltype(_additional_evaluation_indices) indices_lists) {
         // allocate memory on device
         _additional_evaluation_indices = indices_lists;
 
@@ -1607,11 +1604,11 @@ public:
             }
         }
 
-        _lro_total_offsets = Kokkos::View<int*, layout_type>("total offsets for alphas", _lro.size());
-        _lro_output_tile_size = Kokkos::View<int*, layout_type>("output tile size for each operation", _lro.size());
-        _lro_input_tile_size = Kokkos::View<int*, layout_type>("output tile size for each operation", _lro.size());
-        _lro_output_tensor_rank = Kokkos::View<int*, layout_type>("output tensor rank", _lro.size());
-        _lro_input_tensor_rank = Kokkos::View<int*, layout_type>("input tensor rank", _lro.size());
+        _lro_total_offsets = Kokkos::View<int*>("total offsets for alphas", _lro.size());
+        _lro_output_tile_size = Kokkos::View<int*>("output tile size for each operation", _lro.size());
+        _lro_input_tile_size = Kokkos::View<int*>("output tile size for each operation", _lro.size());
+        _lro_output_tensor_rank = Kokkos::View<int*>("output tensor rank", _lro.size());
+        _lro_input_tensor_rank = Kokkos::View<int*>("input tensor rank", _lro.size());
 
         _host_lro_total_offsets = create_mirror(_lro_total_offsets);
         _host_lro_output_tile_size = create_mirror(_lro_output_tile_size);

--- a/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
+++ b/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
@@ -26,9 +26,9 @@ void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vec
                         Kokkos::parallel_reduce(Kokkos::TeamThreadRange(teamMember,
                             _basis_multiplier*target_NP), [=] (const int l, double &talpha_ij) {
                             if (_sampling_multiplier>1 && m<_sampling_multiplier) {
-                                talpha_ij += P_target_row(offset_index_jmke, l)*Q(ORDER_INDICES(i + m*this->getNNeighbors(target_index),l));
+                                talpha_ij += P_target_row(offset_index_jmke, l)*Q(i + m*this->getNNeighbors(target_index),l);
                             } else if (_sampling_multiplier == 1) {
-                                talpha_ij += P_target_row(offset_index_jmke, l)*Q(ORDER_INDICES(i,l));
+                                talpha_ij += P_target_row(offset_index_jmke, l)*Q(i,l);
                             } else {
                                 talpha_ij += 0;
                             }

--- a/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
+++ b/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
@@ -6,42 +6,42 @@
 namespace Compadre {
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_type Q, scratch_matrix_type R, scratch_vector_type w, scratch_vector_type P_target_row, const int target_NP) const {
+void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type Q, scratch_matrix_type R, scratch_vector_type w, scratch_matrix_right_type P_target_row, const int target_NP) const {
 
     const int target_index = teamMember.league_rank();
         
     const int num_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
             ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
-    if (std::is_same<scratch_matrix_type::array_layout, Kokkos::LayoutRight>::value) {
+#ifdef COMPADRE_USE_LAPACK
 
-        // CPU
-        for (int e=0; e<num_evaluation_sites; ++e) {
-            for (int i=0; i<this->getNNeighbors(target_index); ++i) {
-                for (int j=0; j<_operations.size(); ++j) {
-                    for (int k=0; k<_lro_output_tile_size[j]; ++k) {
-                        for (int m=0; m<_lro_input_tile_size[j]; ++m) {
-                            double alpha_ij = 0;
-                            int offset_index_jmke = getTargetOffsetIndexDevice(j,m,k,e);
-                            Kokkos::parallel_reduce(Kokkos::TeamThreadRange(teamMember,
-                                _basis_multiplier*target_NP), [=] (const int l, double &talpha_ij) {
-                                if (_sampling_multiplier>1 && m<_sampling_multiplier) {
-                                    talpha_ij += P_target_row(offset_index_jmke*_basis_multiplier*target_NP + l)*Q(ORDER_INDICES(i + m*this->getNNeighbors(target_index),l));
-                                } else if (_sampling_multiplier == 1) {
-                                    talpha_ij += P_target_row(offset_index_jmke*_basis_multiplier*target_NP + l)*Q(ORDER_INDICES(i,l));
-                                } else {
-                                    talpha_ij += 0;
-                                }
-                            }, alpha_ij);
-                            Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
-                                _alphas(ORDER_INDICES(target_index, offset_index_jmke*_neighbor_lists(target_index,0) + i)) = alpha_ij;
-                            });
-                        }
+    // CPU
+    for (int e=0; e<num_evaluation_sites; ++e) {
+        for (int i=0; i<this->getNNeighbors(target_index); ++i) {
+            for (int j=0; j<_operations.size(); ++j) {
+                for (int k=0; k<_lro_output_tile_size[j]; ++k) {
+                    for (int m=0; m<_lro_input_tile_size[j]; ++m) {
+                        double alpha_ij = 0;
+                        int offset_index_jmke = getTargetOffsetIndexDevice(j,m,k,e);
+                        Kokkos::parallel_reduce(Kokkos::TeamThreadRange(teamMember,
+                            _basis_multiplier*target_NP), [=] (const int l, double &talpha_ij) {
+                            if (_sampling_multiplier>1 && m<_sampling_multiplier) {
+                                talpha_ij += P_target_row(offset_index_jmke, l)*Q(ORDER_INDICES(i + m*this->getNNeighbors(target_index),l));
+                            } else if (_sampling_multiplier == 1) {
+                                talpha_ij += P_target_row(offset_index_jmke, l)*Q(ORDER_INDICES(i,l));
+                            } else {
+                                talpha_ij += 0;
+                            }
+                        }, alpha_ij);
+                        Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
+                            _alphas(target_index, offset_index_jmke, i) = alpha_ij;
+                        });
                     }
                 }
             }
         }
-    } else {
+    }
+#elif defined(COMPADRE_USE_CUDA)
 //        // GPU
 //        for (int j=0; j<_operations.size(); ++j) {
 //            for (int k=0; k<_lro_output_tile_size[j]; ++k) {
@@ -81,33 +81,38 @@ void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vec
 //            }
 //        }
 
-        // GPU
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,
-                this->getNNeighbors(target_index)), [=] (const int i) {
-            for (int e=0; e<num_evaluation_sites; ++e) {
-                for (int j=0; j<_operations.size(); ++j) {
-                    for (int k=0; k<_lro_output_tile_size[j]; ++k) {
-                        for (int m=0; m<_lro_input_tile_size[j]; ++m) {
-                            int offset_index_jmke = getTargetOffsetIndexDevice(j,m,k,e);
+    // GPU
+    for (int e=0; e<num_evaluation_sites; ++e) {
+        for (int j=0; j<_operations.size(); ++j) {
+            for (int k=0; k<_lro_output_tile_size[j]; ++k) {
+                for (int m=0; m<_lro_input_tile_size[j]; ++m) {
+                    int offset_index_jmke = getTargetOffsetIndexDevice(j,m,k,e);
+                    Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,
+                            this->getNNeighbors(target_index)), [&] (const int i) {
+                        double alpha_ij = 0;
+                        if (_sampling_multiplier>1 && m<_sampling_multiplier) {
+                            const int m_neighbor_offset = i+m*this->getNNeighbors(target_index);
+                            Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(teamMember, _basis_multiplier*target_NP),
+                              [=] (int& l, double& t_alpha_ij) {
+                                t_alpha_ij += P_target_row(offset_index_jmke, l)*Q(m_neighbor_offset,l);
+                            }, alpha_ij);
+                        } else if (_sampling_multiplier == 1) {
+                            Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(teamMember, _basis_multiplier*target_NP),
+                              [=] (int& l, double& t_alpha_ij) {
+                                t_alpha_ij += P_target_row(offset_index_jmke, l)*Q(i,l);
+                            }, alpha_ij);
+                        } 
+                        Kokkos::single(Kokkos::PerThread(teamMember), [=] () {
+                            _alphas(target_index, offset_index_jmke, i) = alpha_ij;
+                        });
+                    });
 
-                            double alpha_ij = 0;
-                            if (_sampling_multiplier>1 && m<_sampling_multiplier) {
-                                const int m_neighbor_offset = i+m*this->getNNeighbors(target_index);
-                                for (int l=0; l<_basis_multiplier*target_NP; ++l) {
-                                    alpha_ij += P_target_row(offset_index_jmke*_basis_multiplier*target_NP + l)*Q(ORDER_INDICES(m_neighbor_offset,l));
-                                }
-                            } else if (_sampling_multiplier == 1) {
-                                for (int l=0; l<_basis_multiplier*target_NP; ++l) {
-                                    alpha_ij += P_target_row(offset_index_jmke*_basis_multiplier*target_NP+ l)*Q(ORDER_INDICES(i,l));
-                                }
-                            } 
-                            _alphas(ORDER_INDICES(target_index, offset_index_jmke*_neighbor_lists(target_index,0) + i)) = alpha_ij;
-                        }
-                    }
                 }
             }
-        });
+        }
     }
+#endif
+
     teamMember.team_barrier();
 }
 

--- a/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
+++ b/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
@@ -6,7 +6,7 @@
 namespace Compadre {
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type Q, scratch_matrix_type R, scratch_vector_type w, scratch_matrix_right_type P_target_row, const int target_NP) const {
+void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type Q, scratch_matrix_right_type R, scratch_vector_type w, scratch_matrix_right_type P_target_row, const int target_NP) const {
 
     const int target_index = teamMember.league_rank();
         

--- a/src/Compadre_GMLS_Basis.hpp
+++ b/src/Compadre_GMLS_Basis.hpp
@@ -450,7 +450,7 @@ void GMLS::calcGradientPij(double* delta, const int target_index, const int neig
 
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_type P, scratch_vector_type w, const int dimension, int polynomial_order, bool weight_p, scratch_matrix_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional polynomial_sampling_functional) const {
+void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, int polynomial_order, bool weight_p, scratch_matrix_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional polynomial_sampling_functional) const {
     /*
      * Creates sqrt(W)*P
      */
@@ -524,7 +524,7 @@ void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type 
 }
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::createWeightsAndPForCurvature(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_type P, scratch_vector_type w, const int dimension, bool only_specific_order, scratch_matrix_type* V) const {
+void GMLS::createWeightsAndPForCurvature(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, bool only_specific_order, scratch_matrix_type* V) const {
 /*
  * This function has two purposes
  * 1.) Used to calculate specifically for 1st order polynomials, from which we can reconstruct a tangent plane

--- a/src/Compadre_GMLS_Basis.hpp
+++ b/src/Compadre_GMLS_Basis.hpp
@@ -19,7 +19,7 @@ double GMLS::Wab(const double r, const double h, const WeightingFunctionType& we
 }
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, const double alpha, const int dimension, const int poly_order, bool specific_order_only, scratch_matrix_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional polynomial_sampling_functional, const int additional_evaluation_local_index) const {
+void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, const double alpha, const int dimension, const int poly_order, bool specific_order_only, scratch_matrix_right_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional polynomial_sampling_functional, const int additional_evaluation_local_index) const {
 /*
  * This class is under two levels of hierarchical parallelism, so we
  * do not put in any finer grain parallelism in this function
@@ -348,7 +348,7 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
 
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::calcGradientPij(double* delta, const int target_index, const int neighbor_index, const double alpha, const int partial_direction, const int dimension, const int poly_order, bool specific_order_only, scratch_matrix_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional polynomial_sampling_functional, const int additional_evaluation_index) const {
+void GMLS::calcGradientPij(double* delta, const int target_index, const int neighbor_index, const double alpha, const int partial_direction, const int dimension, const int poly_order, bool specific_order_only, scratch_matrix_right_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional polynomial_sampling_functional, const int additional_evaluation_index) const {
 /*
  * This class is under two levels of hierarchical parallelism, so we
  * do not put in any finer grain parallelism in this function
@@ -450,7 +450,7 @@ void GMLS::calcGradientPij(double* delta, const int target_index, const int neig
 
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, int polynomial_order, bool weight_p, scratch_matrix_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional polynomial_sampling_functional) const {
+void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, int polynomial_order, bool weight_p, scratch_matrix_right_type* V, const ReconstructionSpace reconstruction_space, const SamplingFunctional polynomial_sampling_functional) const {
     /*
      * Creates sqrt(W)*P
      */
@@ -461,7 +461,9 @@ void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type 
 //        printf("storage size: %d\n", storage_size);
 //    }
 //    printf("weight_p: %d\n", weight_p);
-    double * p_data = P.data();
+    // P is stored layout left, because that is what CUDA and LAPACK expect, and storing it
+    // this way prevents copying data later
+    auto alt_P = scratch_matrix_left_type(P.data(), P.extent(0), P.extent(1));
     const int my_num_neighbors = this->getNNeighbors(target_index);
 
     teamMember.team_barrier();
@@ -500,14 +502,14 @@ void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type 
                 for (int j = 0; j < storage_size; ++j) {
                     // stores layout left for CUDA or LAPACK calls later
                     // no need to convert offsets to global indices because the sum will never be large
-                    *(p_data + j*P.dimension_0() + i+my_num_neighbors*d) = delta[j] * std::sqrt(w(i+my_num_neighbors*d));
+                    alt_P(i+my_num_neighbors*d, j) = delta[j] * std::sqrt(w(i+my_num_neighbors*d));
                 }
 
             } else {
                 for (int j = 0; j < storage_size; ++j) {
                     // stores layout left for CUDA or LAPACK calls later
                     // no need to convert offsets to global indices because the sum will never be large
-                    *(p_data + j*P.dimension_0() + i+my_num_neighbors*d) = delta[j];
+                    alt_P(i+my_num_neighbors*d, j) = delta[j];
                 }
             }
         }
@@ -524,7 +526,7 @@ void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type 
 }
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::createWeightsAndPForCurvature(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, bool only_specific_order, scratch_matrix_type* V) const {
+void GMLS::createWeightsAndPForCurvature(const member_type& teamMember, scratch_vector_type delta, scratch_matrix_right_type P, scratch_vector_type w, const int dimension, bool only_specific_order, scratch_matrix_right_type* V) const {
 /*
  * This function has two purposes
  * 1.) Used to calculate specifically for 1st order polynomials, from which we can reconstruct a tangent plane
@@ -532,7 +534,10 @@ void GMLS::createWeightsAndPForCurvature(const member_type& teamMember, scratch_
  */
 
     const int target_index = teamMember.league_rank();
-    double * p_data = P.data();
+
+    // P is stored layout left, because that is what CUDA and LAPACK expect, and storing it
+    // this way prevents copying data later
+    auto alt_P = scratch_matrix_left_type(P.data(), P.extent(0), P.extent(1));
 
     teamMember.team_barrier();
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this->getNNeighbors(target_index)),
@@ -562,8 +567,8 @@ void GMLS::createWeightsAndPForCurvature(const member_type& teamMember, scratch_
         int storage_size = only_specific_order ? this->getNP(1, dimension)-this->getNP(0, dimension) : this->getNP(_curvature_poly_order, dimension);
 
         for (int j = 0; j < storage_size; ++j) {
-                        // stores layout left for CUDA or LAPACK calls later
-            *(p_data + j*P.dimension_0() + i) = delta[j] * std::sqrt(w(i));
+            // stores layout left for CUDA or LAPACK calls later
+            alt_P(i, j) = delta[j] * std::sqrt(w(i));
         }
 
     });

--- a/src/Compadre_GMLS_Quadrature.hpp
+++ b/src/Compadre_GMLS_Quadrature.hpp
@@ -7,11 +7,11 @@ namespace Compadre {
 
 void GMLS::generate1DQuadrature() {
 
-    _quadrature_weights = Kokkos::View<double*, layout_type>("1d quadrature weights", _number_of_quadrature_points);
-    _parameterized_quadrature_sites = Kokkos::View<double*, layout_type>("1d quadrature sites", _number_of_quadrature_points);
+    _quadrature_weights = decltype(_quadrature_weights)("1d quadrature weights", _number_of_quadrature_points);
+    _parameterized_quadrature_sites = decltype(_parameterized_quadrature_sites)("1d quadrature sites", _number_of_quadrature_points);
 
-    Kokkos::View<double*, layout_type>::HostMirror quadrature_weights = create_mirror(_quadrature_weights);
-    Kokkos::View<double*, layout_type>::HostMirror parameterized_quadrature_sites = create_mirror(_parameterized_quadrature_sites);
+    decltype(_quadrature_weights)::HostMirror quadrature_weights = create_mirror(_quadrature_weights);
+    decltype(_parameterized_quadrature_sites)::HostMirror parameterized_quadrature_sites = create_mirror(_parameterized_quadrature_sites);
 
     switch (_number_of_quadrature_points) {
     case 1:

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -6,7 +6,7 @@
 namespace Compadre {
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_vector_type P_target_row) const {
+void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row) const {
 
     // check if VectorOfScalarClonesTaylorPolynomial is used with a scalar sampling functional other than PointSample
     if (_dimensions > 1) {
@@ -24,8 +24,11 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
 
     const int target_index = teamMember.league_rank();
 
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, P_target_row.dimension_0()), [=] (const int i) {
-        P_target_row(i) = 0;
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, P_target_row.extent(0)), [&] (const int j) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(teamMember, P_target_row.extent(1)),
+          [=] (const int& k) {
+            P_target_row(j,k) = 0;
+        });
     });
     teamMember.team_barrier();
 
@@ -53,69 +56,73 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
              */
 
             if (_operations(i) == TargetOperation::ScalarPointEvaluation || (_operations(i) == TargetOperation::VectorPointEvaluation && _dimensions == 1) /* vector is a scalar in 1D */) {
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
-                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         for (int k=0; k<target_NP; ++k) {
-                            P_target_row(offset + k) = t1(k);
+                            P_target_row(offset, k) = t1(k);
                         }
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::LaplacianOfScalarPointEvaluation) {
                 Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0)*_basis_multiplier*target_NP;
+                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                     switch (_dimensions) {
                     case 3:
-                        P_target_row(offset + 4) = std::pow(_epsilons(target_index), -2);
-                        P_target_row(offset + 6) = std::pow(_epsilons(target_index), -2);
-                        P_target_row(offset + 9) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 4) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 6) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 9) = std::pow(_epsilons(target_index), -2);
                         break;
                     case 2:
-                        P_target_row(offset + 3) = std::pow(_epsilons(target_index), -2);
-                        P_target_row(offset + 5) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 3) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 5) = std::pow(_epsilons(target_index), -2);
                         break;
                     default:
-                        P_target_row(offset + 2) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 2) = std::pow(_epsilons(target_index), -2);
                     }
                 });
             } else if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         for (int d=0; d<_dimensions; ++d) {
-                            int offset = getTargetOffsetIndexDevice(i, 0, d, j)*_basis_multiplier*target_NP;
-                            this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                            int offset = getTargetOffsetIndexDevice(i, 0, d, j);
+                            auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
+                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                         }
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::PartialXOfScalarPointEvaluation) {
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
-                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
-                        this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
+                        auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
+                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::PartialYOfScalarPointEvaluation) {
                 compadre_kernel_assert_release(_dimensions>1 && "PartialYOfScalarPointEvaluation requested for dim < 2");
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
-                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
-                        this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
+                        auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
+                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::PartialZOfScalarPointEvaluation) {
                 compadre_kernel_assert_release(_dimensions>2 && "PartialZOfScalarPointEvaluation requested for dim < 3");
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
-                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
-                        this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
+                        auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
+                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else {
                 compadre_kernel_assert_release((false) && "Functionality not yet available.");
             }
@@ -132,101 +139,101 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
 
             if (_operations(i) == TargetOperation::ScalarPointEvaluation || (_operations(i) == TargetOperation::VectorPointEvaluation && _dimensions == 1) /* vector is a scalar in 1D */) {
                 // copied from ScalarTaylorPolynomial
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
-                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         for (int k=0; k<target_NP; ++k) {
-                            P_target_row(offset + k) = t1(k);
+                            P_target_row(offset, k) = t1(k);
                         }
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::VectorPointEvaluation) {
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int e=0; e<num_evaluation_sites; ++e) {
                         this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
                         for (int m=0; m<_sampling_multiplier; ++m) {
                             int output_components = _basis_multiplier;
                             for (int c=0; c<output_components; ++c) {
-                                int offset = getTargetOffsetIndexDevice(i, m /*in*/, c /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
+                                int offset = getTargetOffsetIndexDevice(i, m /*in*/, c /*out*/, e/*additional*/);
                                 // for the case where _sampling_multiplier is > 1,
-                                // this approach relies on c*target_NP being equivalent to P_target_row(offset + j) where offset is 
+                                // this approach relies on c*target_NP being equivalent to P_target_row(offset, j) where offset is 
                                 // getTargetOffsetIndexDevice(i, m /*in*/, c /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
                                 for (int j=0; j<target_NP; ++j) {
-                                    P_target_row(offset + c*target_NP + j) = t1(j);
+                                    P_target_row(offset, c*target_NP + j) = t1(j);
                                 }
                             }
                         }
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::DivergenceOfVectorPointEvaluation) {
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int e=0; e<num_evaluation_sites; ++e) {
                         for (int m=0; m<_sampling_multiplier; ++m) {
                             this->calcGradientPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, m /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
-                            int offset = getTargetOffsetIndexDevice(i, m /*in*/, 0 /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, m /*in*/, 0 /*out*/, e/*additional*/);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + m*target_NP + j) = t1(j);
+                                P_target_row(offset, m*target_NP + j) = t1(j);
                             }
                         }
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::CurlOfVectorPointEvaluation) {
                 if (_dimensions==3) { 
                     Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
                         // output component 0
                         // u_{2,y} - u_{1,z}
                         {
-                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 0 /*out*/, 0/*additional*/);
                             // role of input 0 on component 0 of curl
                             // (no contribution)
 
-                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 0 /*out*/, 0/*additional*/);
                             // role of input 1 on component 0 of curl
                             // -u_{1,z}
-                            P_target_row(offset + target_NP + 3) = -std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, target_NP + 3) = -std::pow(_epsilons(target_index), -1);
 
-                            offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 0 /*out*/, 0/*additional*/);
                             // role of input 2 on component 0 of curl
                             // u_{2,y}
-                            P_target_row(offset + 2*target_NP + 2) = std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 2*target_NP + 2) = std::pow(_epsilons(target_index), -1);
                         }
 
                         // output component 1
                         // -u_{2,x} + u_{0,z}
                         {
-                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 1 /*out*/, 0/*additional*/);
                             // role of input 0 on component 1 of curl
                             // u_{0,z}
-                            P_target_row(offset + 3) = std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 3) = std::pow(_epsilons(target_index), -1);
 
-                            // offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 1 /*out*/, 0/*additional*/);
                             // role of input 1 on component 1 of curl
                             // (no contribution)
 
-                            offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 1 /*out*/, 0/*additional*/);
                             // role of input 2 on component 1 of curl
                             // -u_{2,x}
-                            P_target_row(offset + 2*target_NP + 1) = -std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 2*target_NP + 1) = -std::pow(_epsilons(target_index), -1);
                         }
 
                         // output component 2
                         // u_{1,x} - u_{0,y}
                         {
-                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 2 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 2 /*out*/, 0/*additional*/);
                             // role of input 0 on component 1 of curl
                             // -u_{0,y}
-                            P_target_row(offset + 2) = -std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 2) = -std::pow(_epsilons(target_index), -1);
 
-                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 2 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 2 /*out*/, 0/*additional*/);
                             // role of input 1 on component 1 of curl
                             // u_{1,x}
-                            P_target_row(offset + target_NP + 1) = std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, target_NP + 1) = std::pow(_epsilons(target_index), -1);
 
-                            // offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 2 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            // offset = getTargetOffsetIndexDevice(i, 2 /*in*/, 2 /*out*/, 0/*additional*/);
                             // role of input 2 on component 1 of curl
                             // (no contribution)
                         }
@@ -236,25 +243,25 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         // output component 0
                         // u_{1,y}
                         {
-                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 0 /*out*/, 0/*additional*/);
                             // role of input 0 on component 0 of curl
                             // (no contribution)
 
-                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 0 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 0 /*out*/, 0/*additional*/);
                             // role of input 1 on component 0 of curl
                             // -u_{1,z}
-                            P_target_row(offset + target_NP + 2) = std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, target_NP + 2) = std::pow(_epsilons(target_index), -1);
                         }
 
                         // output component 1
                         // -u_{0,x}
                         {
-                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0 /*in*/, 1 /*out*/, 0/*additional*/);
                             // role of input 0 on component 1 of curl
                             // u_{0,z}
-                            P_target_row(offset + 1) = -std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 1) = -std::pow(_epsilons(target_index), -1);
 
-                            //offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 1 /*out*/, 0/*additional*/)*_basis_multiplier*target_NP;
+                            //offset = getTargetOffsetIndexDevice(i, 1 /*in*/, 1 /*out*/, 0/*additional*/);
                             // role of input 1 on component 1 of curl
                             // (no contribution)
                         }
@@ -276,115 +283,119 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
 
             if (_operations(i) == TargetOperation::ScalarPointEvaluation || (_operations(i) == TargetOperation::VectorPointEvaluation && _dimensions == 1) /* vector is a scalar in 1D */) {
                 // copied from ScalarTaylorPolynomial
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
-                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         for (int k=0; k<target_NP; ++k) {
-                            P_target_row(offset + k) = t1(k);
+                            P_target_row(offset, k) = t1(k);
                         }
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::VectorPointEvaluation) {
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int e=0; e<num_evaluation_sites; ++e) {
                         this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
                         for (int m=0; m<_sampling_multiplier; ++m) {
                             auto output_components = std::pow(_local_dimensions, _data_sampling_multiplier);
                             for (int c=0; c<output_components; ++c) {
-                                int offset = getTargetOffsetIndexDevice(i, c /*in*/, c /*out*/, e/*additional*/)*_basis_multiplier*target_NP;
+                                int offset = getTargetOffsetIndexDevice(i, c /*in*/, c /*out*/, e/*additional*/);
                                 for (int j=0; j<target_NP; ++j) {
-                                    P_target_row(offset + j) = t1(j);
+                                    P_target_row(offset, j) = t1(j);
                                 }
                             }
                         }
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::LaplacianOfScalarPointEvaluation) {
                 // copied from ScalarTaylorPolynomial
                 Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0)*_basis_multiplier*target_NP;
+                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                     switch (_dimensions) {
                     case 3:
-                        P_target_row(offset + 4) = std::pow(_epsilons(target_index), -2);
-                        P_target_row(offset + 6) = std::pow(_epsilons(target_index), -2);
-                        P_target_row(offset + 9) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 4) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 6) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 9) = std::pow(_epsilons(target_index), -2);
                         break;
                     case 2:
-                        P_target_row(offset + 3) = std::pow(_epsilons(target_index), -2);
-                        P_target_row(offset + 5) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 3) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 5) = std::pow(_epsilons(target_index), -2);
                         break;
                     default:
-                        P_target_row(offset + 2) = std::pow(_epsilons(target_index), -2);
+                        P_target_row(offset, 2) = std::pow(_epsilons(target_index), -2);
                     }
                 });
             } else if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
                 // copied from ScalarTaylorPolynomial
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         for (int d=0; d<_dimensions; ++d) {
-                            int offset = getTargetOffsetIndexDevice(i, 0, d, j)*_basis_multiplier*target_NP;
-                            this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                            int offset = getTargetOffsetIndexDevice(i, 0, d, j);
+                            auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
+                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                         }
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::PartialXOfScalarPointEvaluation) {
                 // copied from ScalarTaylorPolynomial
-                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
-                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
-                        this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
+                        auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
+                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                     }
-                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 });
+                additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
             } else if (_operations(i) == TargetOperation::PartialYOfScalarPointEvaluation) {
                 // copied from ScalarTaylorPolynomial
                 if (_dimensions>1) {
-                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                         for (int j=0; j<num_evaluation_sites; ++j) { 
-                            int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
-                            this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                            int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
+                            auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
+                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                         }
-                        additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                     });
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 }
             } else if (_operations(i) == TargetOperation::PartialZOfScalarPointEvaluation) {
                 // copied from ScalarTaylorPolynomial
                 if (_dimensions>2) {
-                    Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                         for (int j=0; j<num_evaluation_sites; ++j) { 
-                            int offset = getTargetOffsetIndexDevice(i, 0, 0, j)*_basis_multiplier*target_NP;
-                            this->calcGradientPij(P_target_row.data()+offset, target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                            int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
+                            auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
+                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
                         }
-                        additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                     });
+                    additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
                 }
             } else if (_operations(i) == TargetOperation::DivergenceOfVectorPointEvaluation) {
                 Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                    int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                     for (int j=0; j<target_NP; ++j) {
-                        P_target_row(offset + j) = 0;
+                        P_target_row(offset, j) = 0;
                     }
 
-                    P_target_row(offset + 1) = std::pow(_epsilons(target_index), -1);
+                    P_target_row(offset, 1) = std::pow(_epsilons(target_index), -1);
 
                     if (_dimensions>1) {
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
-                        P_target_row(offset + 2) = std::pow(_epsilons(target_index), -1);
+                        P_target_row(offset, 2) = std::pow(_epsilons(target_index), -1);
                     }
 
                     if (_dimensions>2) {
-                        offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 2, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
-                        P_target_row(offset + 3) = std::pow(_epsilons(target_index), -1);
+                        P_target_row(offset, 3) = std::pow(_epsilons(target_index), -1);
                     }
                 });
             } else if (_operations(i) == TargetOperation::CurlOfVectorPointEvaluation) {
@@ -396,79 +407,79 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         // output component 0
                         // u_{2,y} - u_{1,z}
                         {
-                            int offset = (_lro_total_offsets[i]+0)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 0 on component 0 of curl
                             // (no contribution)
 
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 1 on component 0 of curl
                             // -u_{1,z}
-                            P_target_row(offset + 3) = -std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 3) = -std::pow(_epsilons(target_index), -1);
 
-                            offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 2, 0, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 2 on component 0 of curl
                             // u_{2,y}
-                            P_target_row(offset + 2) = std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 2) = std::pow(_epsilons(target_index), -1);
                         }
 
                         // output component 1
                         // -u_{2,x} + u_{0,z}
                         {
-                            int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 0 on component 1 of curl
                             // u_{0,z}
-                            P_target_row(offset + 3) = std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 3) = std::pow(_epsilons(target_index), -1);
 
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 1, 1, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 1 on component 1 of curl
                             // (no contribution)
 
-                            offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 2, 1, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 2 on component 1 of curl
                             // -u_{2,x}
-                            P_target_row(offset + 1) = -std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 1) = -std::pow(_epsilons(target_index), -1);
                         }
 
                         // output component 2
                         // u_{1,x} - u_{0,y}
                         {
-                            int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0, 2, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 0 on component 1 of curl
                             // -u_{0,y}
-                            P_target_row(offset + 2) = -std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 2) = -std::pow(_epsilons(target_index), -1);
 
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 1, 2, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 1 on component 1 of curl
                             // u_{1,x}
-                            P_target_row(offset + 1) = std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 1) = std::pow(_epsilons(target_index), -1);
 
-                            offset = (_lro_total_offsets[i]+2*_lro_output_tile_size[i]+2)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 2, 2, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 2 on component 1 of curl
                             // (no contribution)
@@ -479,36 +490,36 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         // output component 0
                         // u_{1,y}
                         {
-                            int offset = (_lro_total_offsets[i]+0)*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 0 on component 0 of curl
                             // (no contribution)
 
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 1 on component 0 of curl
                             // -u_{1,z}
-                            P_target_row(offset + 2) = std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 2) = std::pow(_epsilons(target_index), -1);
                         }
 
                         // output component 1
                         // -u_{0,x}
                         {
-                            int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                            int offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 0 on component 1 of curl
                             // u_{0,z}
-                            P_target_row(offset + 1) = -std::pow(_epsilons(target_index), -1);
+                            P_target_row(offset, 1) = -std::pow(_epsilons(target_index), -1);
 
-                            offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                            offset = getTargetOffsetIndexDevice(i, 1, 1, 0);
                             for (int j=0; j<target_NP; ++j) {
-                                P_target_row(offset + j) = 0;
+                                P_target_row(offset, j) = 0;
                             }
                             // role of input 1 on component 1 of curl
                             // (no contribution)
@@ -527,38 +538,42 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
 }
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_vector_type P_target_row, scratch_matrix_type* V) const {
+void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_type* V) const {
 
     const int target_index = teamMember.league_rank();
 
-    for (int i=0; i<P_target_row.dimension_0(); ++i) {
-        for (int j=0; j<P_target_row.dimension_1(); ++j) {
-            P_target_row(i,j) = 0;
-        }
-    }
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, P_target_row.extent(0)), [&] (const int j) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(teamMember, P_target_row.extent(1)),
+          [=] (const int& k) {
+            P_target_row(j,k) = 0;
+        });
+    });
+    teamMember.team_barrier();
 
     const int manifold_NP = this->getNP(_curvature_poly_order, _dimensions-1);
     for (int i=0; i<_curvature_support_operations.size(); ++i) {
         if (_curvature_support_operations(i) == TargetOperation::ScalarPointEvaluation) {
             Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                int offset = i*manifold_NP;
+                int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                 this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _curvature_poly_order, false /*bool on only specific order*/, V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
                 for (int j=0; j<manifold_NP; ++j) {
-                    P_target_row(offset + j) = t1(j);
+                    P_target_row(offset, j) = t1(j);
                 }
             });
         } else if (_curvature_support_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
             Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                int offset = i*manifold_NP;
+                //int offset = i*manifold_NP;
+                int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                 this->calcGradientPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions-1, _curvature_poly_order, false /*specific order only*/, V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
                 for (int j=0; j<manifold_NP; ++j) {
-                    P_target_row(offset + j) = t1(j);
+                    P_target_row(offset, j) = t1(j);
                 }
                 if (_dimensions>2) { // _dimensions-1 > 1
-                    offset = (i+1)*manifold_NP;
+                    //offset = (i+1)*manifold_NP;
+                    offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
                     this->calcGradientPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions-1, _curvature_poly_order, false /*specific order only*/, V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
                     for (int j=0; j<manifold_NP; ++j) {
-                        P_target_row(offset + j) = t1(j);
+                        P_target_row(offset, j) = t1(j);
                     }
                 }
             });
@@ -569,17 +584,19 @@ void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_ve
 }
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_vector_type P_target_row, scratch_matrix_type V, scratch_matrix_type G_inv, scratch_vector_type curvature_coefficients, scratch_vector_type curvature_gradients) const {
+void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_type V, scratch_matrix_type G_inv, scratch_vector_type curvature_coefficients, scratch_vector_type curvature_gradients) const {
 
     // only designed for 2D manifold embedded in 3D space
     const int target_index = teamMember.league_rank();
     const int target_NP = this->getNP(_poly_order, _dimensions-1);
 
-    for (int i=0; i<P_target_row.dimension_0(); ++i) {
-        for (int j=0; j<P_target_row.dimension_1(); ++j) {
-            P_target_row(i,j) = 0;
-        }
-    }
+    Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, P_target_row.extent(0)), [&] (const int j) {
+        Kokkos::parallel_for(Kokkos::ThreadVectorRange(teamMember, P_target_row.extent(1)),
+          [=] (const int& k) {
+            P_target_row(j,k) = 0;
+        });
+    });
+    teamMember.team_barrier();
 
     for (int i=0; i<_operations.size(); ++i) {
 
@@ -596,9 +613,9 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                 Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
 //                    this->calcPij(P_target_row.data()+_lro_total_offsets[i]*target_NP, target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, SamplingFunctional::PointSample);
                     this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
-                    int offset = _lro_total_offsets[i]*_basis_multiplier*target_NP;
+                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                     for (int j=0; j<target_NP; ++j) {
-                        P_target_row(offset + j) = t1(j);
+                        P_target_row(offset, j) = t1(j);
                     }
                 });
             } else if (_operations(i) == TargetOperation::VectorPointEvaluation) {
@@ -609,27 +626,27 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
 
                         // output component 0
                         this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = t1(j);
+                            P_target_row(offset, target_NP + j) = 0;
                         }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = 0;
                         }
 
                         // output component 1
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = 0;
                         }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = t1(j);
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = t1(j);
                         }
 
                     });
@@ -639,23 +656,23 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
 
                         // output component 0
                         this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
+                            P_target_row(offset, j) = t1(j);
                         }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
 
                         // output component 1
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
+                            P_target_row(offset, j) = t1(j);
                         }
 
                     });
@@ -682,19 +699,19 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                     //std::cout << "Gaussian curvature is: " << K_curvature << std::endl;
 
 
-                    const int offset = _lro_total_offsets[i]*_basis_multiplier*target_NP;
+                    const int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                     for (int j=0; j<target_NP; ++j) {
-                        P_target_row(offset + j) = 0;
+                        P_target_row(offset, j) = 0;
                     }
                     // scaled
                     if (_poly_order > 0 && _curvature_poly_order > 1) {
-                        P_target_row(offset + 1) = (-a1*((h*h+a2*a2)*a3 - 2*a1*a2*a4 + (h*h+a1*a1)*a5))/den/den/(h*h);
-                        P_target_row(offset + 2) = (-a2*((h*h+a2*a2)*a3 - 2*a1*a2*a4 + (h*h+a1*a1)*a5))/den/den/(h*h);
+                        P_target_row(offset, 1) = (-a1*((h*h+a2*a2)*a3 - 2*a1*a2*a4 + (h*h+a1*a1)*a5))/den/den/(h*h);
+                        P_target_row(offset, 2) = (-a2*((h*h+a2*a2)*a3 - 2*a1*a2*a4 + (h*h+a1*a1)*a5))/den/den/(h*h);
                     }
                     if (_poly_order > 1 && _curvature_poly_order > 0) {
-                        P_target_row(offset + 3) = (h*h+a2*a2)/den/(h*h);
-                        P_target_row(offset + 4) = -2*a1*a2/den/(h*h);
-                        P_target_row(offset + 5) = (h*h+a1*a1)/den/(h*h);
+                        P_target_row(offset, 3) = (h*h+a2*a2)/den/(h*h);
+                        P_target_row(offset, 4) = -2*a1*a2/den/(h*h);
+                        P_target_row(offset, 5) = (h*h+a1*a1)/den/(h*h);
                     }
 
                 });
@@ -724,17 +741,17 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         double c2b = (h*h+a1*a1)/den/h;
 
                         // 1st input component
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = 0;
                         }
-                        P_target_row(offset + 0) = c0a;
-                        P_target_row(offset + 1) = c1a;
-                        P_target_row(offset + 2) = c2a;
-                        P_target_row(offset + target_NP + 0) = c0b;
-                        P_target_row(offset + target_NP + 1) = c1b;
-                        P_target_row(offset + target_NP + 2) = c2b;
+                        P_target_row(offset, 0) = c0a;
+                        P_target_row(offset, 1) = c1a;
+                        P_target_row(offset, 2) = c2a;
+                        P_target_row(offset, target_NP + 0) = c0b;
+                        P_target_row(offset, target_NP + 1) = c1b;
+                        P_target_row(offset, target_NP + 2) = c2b;
                     });
                 } else if (_reconstruction_space == ReconstructionSpace::ScalarTaylorPolynomial) {
                     Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
@@ -752,20 +769,20 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         }
                         double den = (h*h + a1*a1 + a2*a2);
 
-                        const int offset = _lro_total_offsets[i]*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
 
                         // verified
                         if (_poly_order > 0 && _curvature_poly_order > 1) {
-                            P_target_row(offset + 1) = (-a1*((h*h+a2*a2)*a3 - 2*a1*a2*a4 + (h*h+a1*a1)*a5))/den/den/(h*h);
-                            P_target_row(offset + 2) = (-a2*((h*h+a2*a2)*a3 - 2*a1*a2*a4 + (h*h+a1*a1)*a5))/den/den/(h*h);
+                            P_target_row(offset, 1) = (-a1*((h*h+a2*a2)*a3 - 2*a1*a2*a4 + (h*h+a1*a1)*a5))/den/den/(h*h);
+                            P_target_row(offset, 2) = (-a2*((h*h+a2*a2)*a3 - 2*a1*a2*a4 + (h*h+a1*a1)*a5))/den/den/(h*h);
                         }
                         if (_poly_order > 1 && _curvature_poly_order > 0) {
-                            P_target_row(offset + 3) = (h*h+a2*a2)/den/(h*h);
-                            P_target_row(offset + 4) = -2*a1*a2/den/(h*h);
-                            P_target_row(offset + 5) = (h*h+a1*a1)/den/(h*h);
+                            P_target_row(offset, 3) = (h*h+a2*a2)/den/(h*h);
+                            P_target_row(offset, 4) = -2*a1*a2/den/(h*h);
+                            P_target_row(offset, 5) = (h*h+a1*a1)/den/(h*h);
                         }
 
                     });
@@ -806,27 +823,27 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         }
 
                         // output component 0
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = t1(j);
+                            P_target_row(offset, target_NP + j) = 0;
                         }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = 0;
                         }
 
                         // output component 1
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = 0;
                         }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = t1(j);
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = t1(j);
                         }
 
                     });
@@ -865,23 +882,23 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         }
 
                         // output component 0
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
+                            P_target_row(offset, j) = t1(j);
                         }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
 
                         // output component 1
-                        offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = t1(j);
+                            P_target_row(offset, j) = t1(j);
                         }
                     });
                 }
@@ -906,22 +923,22 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         double t2b = q2*0 + q3*1;
 
                         // scaled
-                        int offset = (_lro_total_offsets[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
                         if (_poly_order > 0 && _curvature_poly_order > 0) {
-                            P_target_row(offset + 1) = t1a + t2a;
-                            P_target_row(offset + 2) = 0;
+                            P_target_row(offset, 1) = t1a + t2a;
+                            P_target_row(offset, 2) = 0;
                         }
 
-                        offset = (_lro_total_offsets[i]+1)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
                         if (_poly_order > 0 && _curvature_poly_order > 0) {
-                            P_target_row(offset + 1) = 0;
-                            P_target_row(offset + 2) = t1b + t2b;
+                            P_target_row(offset, 1) = 0;
+                            P_target_row(offset, 2) = t1b + t2b;
                         }
 
                     });
@@ -972,24 +989,24 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         double c2b = 1./h;
 
                         // 1st input component
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = 0;
                         }
-                        P_target_row(offset + 0) = c0a;
-                        P_target_row(offset + 1) = c1a;
-                        P_target_row(offset + 2) = c2a;
+                        P_target_row(offset, 0) = c0a;
+                        P_target_row(offset, 1) = c1a;
+                        P_target_row(offset, 2) = c2a;
 
                         // 2nd input component
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = 0;
                         }
-                        P_target_row(offset + target_NP + 0) = c0b;
-                        P_target_row(offset + target_NP + 1) = c1b;
-                        P_target_row(offset + target_NP + 2) = c2b;
+                        P_target_row(offset, target_NP + 0) = c0b;
+                        P_target_row(offset, target_NP + 1) = c1b;
+                        P_target_row(offset, target_NP + 2) = c2b;
                     });
                 // scalar basis times number of components in the vector
                 } else if (_reconstruction_space_rank == 0
@@ -1020,22 +1037,22 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         double c2b = 1./h;
 
                         // 1st input component
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
-                        P_target_row(offset + 0) = c0a;
-                        P_target_row(offset + 1) = c1a;
-                        P_target_row(offset + 2) = c2a;
+                        P_target_row(offset, 0) = c0a;
+                        P_target_row(offset, 1) = c1a;
+                        P_target_row(offset, 2) = c2a;
 
                         // 2nd input component
-                        offset = (_lro_total_offsets[i]+1*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        offset = getTargetOffsetIndexDevice(i, 1, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
+                            P_target_row(offset, j) = 0;
                         }
-                        P_target_row(offset + 0) = c0b;
-                        P_target_row(offset + 1) = c1b;
-                        P_target_row(offset + 2) = c2b;
+                        P_target_row(offset, 0) = c0b;
+                        P_target_row(offset, 1) = c1b;
+                        P_target_row(offset, 2) = c2b;
                     });
                 // staggered divergence acting on vector polynomial space
                 } else if (_reconstruction_space_rank == 1
@@ -1068,17 +1085,17 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                         double c2b = (h*h+a1*a1)/den/h;
 
                         // 1st input component
-                        int offset = (_lro_total_offsets[i]+0*_lro_output_tile_size[i]+0)*_basis_multiplier*target_NP;
+                        int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                         for (int j=0; j<target_NP; ++j) {
-                            P_target_row(offset + j) = 0;
-                            P_target_row(offset + target_NP + j) = 0;
+                            P_target_row(offset, j) = 0;
+                            P_target_row(offset, target_NP + j) = 0;
                         }
-                        P_target_row(offset + 0) = c0a;
-                        P_target_row(offset + 1) = c1a;
-                        P_target_row(offset + 2) = c2a;
-                        P_target_row(offset + target_NP + 0) = c0b;
-                        P_target_row(offset + target_NP + 1) = c1b;
-                        P_target_row(offset + target_NP + 2) = c2b;
+                        P_target_row(offset, 0) = c0a;
+                        P_target_row(offset, 1) = c1a;
+                        P_target_row(offset, 2) = c2a;
+                        P_target_row(offset, target_NP + 0) = c0b;
+                        P_target_row(offset, target_NP + 1) = c1b;
+                        P_target_row(offset, target_NP + 2) = c2b;
 
                     });
                 } else {
@@ -1090,14 +1107,14 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
         } else if (_dimensions==2) { // 1D manifold in 2D problem
             if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
                 Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
-                    int offset = (_lro_total_offsets[i]+0)*target_NP;
+                    int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
                     for (int j=0; j<target_NP; ++j) {
-                        P_target_row(offset + j) = 0;
+                        P_target_row(offset, j) = 0;
                         t1(j) = (j == 1) ? std::pow(_epsilons(target_index), -1) : 0;
                     }
                     for (int j=0; j<target_NP; ++j) {
                         double v1 = t1(j)*G_inv(0,0);
-                        P_target_row(offset + j) = v1;
+                        P_target_row(offset, j) = v1;
                     }
                 });
             } else {

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -538,7 +538,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
 }
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_type* V) const {
+void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_right_type* V) const {
 
     const int target_index = teamMember.league_rank();
 
@@ -584,7 +584,7 @@ void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_ve
 }
 
 KOKKOS_INLINE_FUNCTION
-void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_type V, scratch_matrix_type G_inv, scratch_vector_type curvature_coefficients, scratch_vector_type curvature_gradients) const {
+void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_right_type V, scratch_matrix_right_type G_inv, scratch_vector_type curvature_coefficients, scratch_vector_type curvature_gradients) const {
 
     // only designed for 2D manifold embedded in 3D space
     const int target_index = teamMember.league_rank();

--- a/src/Compadre_LinearAlgebra_Declarations.hpp
+++ b/src/Compadre_LinearAlgebra_Declarations.hpp
@@ -35,7 +35,7 @@ namespace GMLS_LinearAlgebra {
         \param rows          [in] - number of rows in weighted_P
     */
     KOKKOS_INLINE_FUNCTION
-    void createM(const member_type& teamMember, scratch_matrix_type M_data, scratch_matrix_right_type weighted_P, const int columns, const int rows);
+    void createM(const member_type& teamMember, scratch_matrix_right_type M_data, scratch_matrix_right_type weighted_P, const int columns, const int rows);
 
     /*! \brief Calculates two eigenvectors corresponding to two dominant eigenvalues
         \param teamMember    [in] - Kokkos::TeamPolicy member type (created by parallel_for)
@@ -44,7 +44,7 @@ namespace GMLS_LinearAlgebra {
         \param dimensions    [in] - dimension of PtP
     */
     KOKKOS_INLINE_FUNCTION
-    void largestTwoEigenvectorsThreeByThreeSymmetric(const member_type& teamMember, scratch_matrix_type V, scratch_matrix_type PtP, const int dimensions, pool_type& random_number_pool);
+    void largestTwoEigenvectorsThreeByThreeSymmetric(const member_type& teamMember, scratch_matrix_right_type V, scratch_matrix_right_type PtP, const int dimensions, pool_type& random_number_pool);
 
     /*! \brief Calls LAPACK or CUBLAS to solve a batch of QR problems
 

--- a/src/Compadre_LinearAlgebra_Declarations.hpp
+++ b/src/Compadre_LinearAlgebra_Declarations.hpp
@@ -35,7 +35,7 @@ namespace GMLS_LinearAlgebra {
         \param rows          [in] - number of rows in weighted_P
     */
     KOKKOS_INLINE_FUNCTION
-    void createM(const member_type& teamMember, scratch_matrix_type M_data, scratch_matrix_type weighted_P, const int columns, const int rows);
+    void createM(const member_type& teamMember, scratch_matrix_type M_data, scratch_matrix_right_type weighted_P, const int columns, const int rows);
 
     /*! \brief Calculates two eigenvectors corresponding to two dominant eigenvalues
         \param teamMember    [in] - Kokkos::TeamPolicy member type (created by parallel_for)

--- a/src/Compadre_LinearAlgebra_Definitions.hpp
+++ b/src/Compadre_LinearAlgebra_Definitions.hpp
@@ -7,7 +7,7 @@ namespace Compadre {
 namespace GMLS_LinearAlgebra {
 
 KOKKOS_INLINE_FUNCTION
-void createM(const member_type& teamMember, scratch_matrix_type M_data, scratch_matrix_type weighted_P, const int columns, const int rows) {
+void createM(const member_type& teamMember, scratch_matrix_type M_data, scratch_matrix_right_type weighted_P, const int columns, const int rows) {
     /*
      * Creates M = P^T * W * P
      */

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -33,6 +33,7 @@ typedef Kokkos::TeamPolicy<>               team_policy;
 typedef Kokkos::TeamPolicy<>::member_type  member_type;
 
 typedef Kokkos::DefaultExecutionSpace::array_layout layout_type;
+typedef Kokkos::LayoutRight layout_right;
 
 // reorders indices for layout of device
 #ifdef COMPADRE_USE_CUDA
@@ -42,6 +43,7 @@ typedef Kokkos::DefaultExecutionSpace::array_layout layout_type;
 #endif
 
 typedef Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_matrix_type;
+typedef Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_matrix_right_type;
 typedef Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_vector_type;
 typedef Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_local_index_type;
 

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -29,25 +29,33 @@ typedef std::size_t global_index_type;
 
 // KOKKOS TYPEDEFS
 
-typedef Kokkos::TeamPolicy<>               team_policy;
-typedef Kokkos::TeamPolicy<>::member_type  member_type;
-
-typedef Kokkos::DefaultExecutionSpace::array_layout layout_type;
-//typedef Kokkos::LayoutRight layout_type;
-typedef Kokkos::LayoutRight layout_right;
-
-// reorders indices for layout of device
+// execution spaces
+typedef Kokkos::DefaultHostExecutionSpace host_execution_space;
 #ifdef COMPADRE_USE_CUDA
-#define ORDER_INDICES(i,j) j,i
+  typedef Kokkos::DefaultExecutionSpace device_execution_space;
 #else
-#define ORDER_INDICES(i,j) i,j
+  typedef Kokkos::DefaultHostExecutionSpace device_execution_space;
 #endif
 
-typedef Kokkos::View<double**, layout_type, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_matrix_type;
+// team policies
+typedef typename Kokkos::TeamPolicy<device_execution_space> team_policy;
+typedef typename team_policy::member_type  member_type;
+
+typedef typename Kokkos::TeamPolicy<host_execution_space> host_team_policy;
+typedef typename host_team_policy::member_type  host_member_type;
+
+// layout types
+typedef Kokkos::LayoutRight layout_right;
+typedef Kokkos::LayoutLeft layout_left;
+
+// unmanaged data wrappers
 typedef Kokkos::View<double**, layout_right, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_matrix_right_type;
+typedef Kokkos::View<double**, layout_left, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_matrix_left_type;
+
 typedef Kokkos::View<double*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_vector_type;
 typedef Kokkos::View<int*, Kokkos::MemoryTraits<Kokkos::Unmanaged> > scratch_local_index_type;
 
+// random number generator
 typedef Kokkos::Random_XorShift64_Pool<> pool_type;
 typedef typename pool_type::generator_type generator_type;
 

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -33,6 +33,7 @@ typedef Kokkos::TeamPolicy<>               team_policy;
 typedef Kokkos::TeamPolicy<>::member_type  member_type;
 
 typedef Kokkos::DefaultExecutionSpace::array_layout layout_type;
+//typedef Kokkos::LayoutRight layout_type;
 typedef Kokkos::LayoutRight layout_right;
 
 // reorders indices for layout of device


### PR DESCRIPTION
- Create typedefs to execution spaces (host or device)
- Make layout types explicit (layout_left or layout_right, with layout_right being used primarily because it is most efficient for hierarchical parallelism)
- Remove redundant type naming (if it is declared in the header, then use decltype in the cpp file)
- Switch from alphas being rank 2 and P_target_row being rank 1 with a much higher effective rank (by creative indexing) to alphas being rank 3 and P_target_row being rank 2, with the second rank for alphas requiring a function to calculate and the first rank for P_target_row requiring a function to calculate. This exposes maximum parallelism by ensuring the that rank on which dot products are performed are sequential in memory.
- Do a better job with filtering view_type in templates so that device views can be given with either layout right or layout left, and the appropriate action is performed (copy to new layout, or use existing if it matches). Nothing changed for host views being copied to device (already worked perfectly).
