### PR TITLE
Changed sampling functionals to constexpr structs

### DIFF
--- a/examples/GMLS_Device.cpp
+++ b/examples/GMLS_Device.cpp
@@ -350,7 +350,7 @@ bool all_passed = true;
     
     // retrieves polynomial coefficients instead of remapped field
     auto scalar_coefficients = gmls_evaluator.applyFullPolynomialCoefficientsBasisToDataAllComponents<double**, Kokkos::HostSpace>
-            (sampling_data_device, VectorPointSample);
+            (sampling_data_device);
     
     //! [Apply GMLS Alphas To Data]
     

--- a/examples/GMLS_Manifold.cpp
+++ b/examples/GMLS_Manifold.cpp
@@ -332,7 +332,7 @@ Kokkos::initialize(argc, args);
     // evaluation of that vector as the sampling functional
     // VectorTaylorPolynomial indicates that the basis will be a polynomial with as many components as the
     // dimension of the manifold. This differs from another possibility, which follows this class.
-    GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial,SamplingFunctional::ManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial, ManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
     my_GMLS_vector.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     std::vector<TargetOperation> lro_vector(2);
     lro_vector[0] = VectorPointEvaluation;
@@ -368,7 +368,7 @@ Kokkos::initialize(argc, args);
     //  In the print-out for this program, we include the timings and errors on this and VectorTaylorPolynomial
     //  in order to demonstrate that they produce exactly the same answer, but that one is much more efficient.
     //
-    GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial,SamplingFunctional::ManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial,ManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
     my_GMLS_vector_of_scalar_clones.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     std::vector<TargetOperation> lro_vector_of_scalar_clones(2);
     lro_vector_of_scalar_clones[0] = VectorPointEvaluation;

--- a/examples/GMLS_Manifold_Multiple_Evaluation_Sites.cpp
+++ b/examples/GMLS_Manifold_Multiple_Evaluation_Sites.cpp
@@ -364,7 +364,7 @@ Kokkos::initialize(argc, args);
     // evaluation of that vector as the sampling functional
     // VectorTaylorPolynomial indicates that the basis will be a polynomial with as many components as the
     // dimension of the manifold. This differs from another possibility, which follows this class.
-    GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial,SamplingFunctional::VaryingManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial,VaryingManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
     my_GMLS_vector.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     my_GMLS_vector.setAdditionalEvaluationSitesData(neighbor_lists_device, source_coords_device);
     std::vector<TargetOperation> lro_vector(2);
@@ -401,7 +401,7 @@ Kokkos::initialize(argc, args);
     //  In the print-out for this program, we include the timings and errors on this and VectorTaylorPolynomial
     //  in order to demonstrate that they produce exactly the same answer, but that one is much more efficient.
     //
-    GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial,SamplingFunctional::VaryingManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial,VaryingManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
     my_GMLS_vector_of_scalar_clones.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     my_GMLS_vector_of_scalar_clones.setAdditionalEvaluationSitesData(neighbor_lists_device, source_coords_device);
     std::vector<TargetOperation> lro_vector_of_scalar_clones(2);
@@ -441,23 +441,23 @@ Kokkos::initialize(argc, args);
     Evaluator vector_gmls_evaluator_of_scalar_clones(&my_GMLS_vector_of_scalar_clones);
     
     auto output_value = scalar_gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double*, Kokkos::HostSpace>
-            (sampling_data_device, ScalarPointEvaluation, SamplingFunctional::PointSample, 
+            (sampling_data_device, ScalarPointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 1 /*evaluation site index*/);
 
     auto output_gaussian_curvature = scalar_gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double*, Kokkos::HostSpace>
-            (ones_data_device, GaussianCurvaturePointEvaluation, SamplingFunctional::PointSample, 
+            (ones_data_device, GaussianCurvaturePointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 1 /*evaluation site index*/);
 
     auto output_curl = scalar_gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double**, Kokkos::HostSpace>
-            (sampling_data_device, CurlOfVectorPointEvaluation, SamplingFunctional::PointSample, 
+            (sampling_data_device, CurlOfVectorPointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 1 /*evaluation site index*/);
     
     //auto output_laplacian = scalar_gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double*, Kokkos::HostSpace>
-    //        (sampling_data_device, LaplacianOfScalarPointEvaluation, SamplingFunctional::PointSample, 
+    //        (sampling_data_device, LaplacianOfScalarPointEvaluation, PointSample, 
     //         true /*scalar_as_vector_if_needed*/, 1 /*evaluation site index*/);
 
     //auto output_gradient = scalar_gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double**, Kokkos::HostSpace>
-    //        (sampling_data_device, GradientOfScalarPointEvaluation, SamplingFunctional::PointSample, 
+    //        (sampling_data_device, GradientOfScalarPointEvaluation, PointSample, 
     //         true /*scalar_as_vector_if_needed*/, 1 /*evaluation site index*/);
 
     auto output_vector = vector_gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double**, Kokkos::HostSpace>

--- a/examples/GMLS_Multiple_Evaluation_Sites.cpp
+++ b/examples/GMLS_Multiple_Evaluation_Sites.cpp
@@ -366,27 +366,27 @@ bool all_passed = true;
     Evaluator gmls_evaluator(&my_GMLS);
     
     auto output_value1 = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double*, Kokkos::HostSpace>
-            (sampling_data_device, ScalarPointEvaluation, SamplingFunctional::PointSample, 
+            (sampling_data_device, ScalarPointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 1 /*evaluation site index*/);
     
     auto output_gradient1 = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double**, Kokkos::HostSpace>
-            (sampling_data_device, GradientOfScalarPointEvaluation, SamplingFunctional::PointSample, 
+            (sampling_data_device, GradientOfScalarPointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 1 /*evaluation site index*/);
 
     auto output_value2 = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double*, Kokkos::HostSpace>
-            (sampling_data_device, ScalarPointEvaluation, SamplingFunctional::PointSample, 
+            (sampling_data_device, ScalarPointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 2 /*evaluation site index*/);
     
     auto output_gradient2 = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double**, Kokkos::HostSpace>
-            (sampling_data_device, GradientOfScalarPointEvaluation, SamplingFunctional::PointSample, 
+            (sampling_data_device, GradientOfScalarPointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 2 /*evaluation site index*/);
 
     auto output_value3 = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double*, Kokkos::HostSpace>
-            (sampling_data_device, ScalarPointEvaluation, SamplingFunctional::PointSample, 
+            (sampling_data_device, ScalarPointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 3 /*evaluation site index*/);
     
     auto output_gradient3 = gmls_evaluator.applyAlphasToDataAllComponentsAllTargetSites<double**, Kokkos::HostSpace>
-            (sampling_data_device, GradientOfScalarPointEvaluation, SamplingFunctional::PointSample, 
+            (sampling_data_device, GradientOfScalarPointEvaluation, PointSample, 
              true /*scalar_as_vector_if_needed*/, 3 /*evaluation site index*/);
     
     //! [Apply GMLS Alphas To Data]

--- a/examples/GMLS_SmallBatchReuse_Device.cpp
+++ b/examples/GMLS_SmallBatchReuse_Device.cpp
@@ -372,7 +372,7 @@ bool all_passed = true;
         
         // retrieves polynomial coefficients instead of remapped field
         auto scalar_coefficients = gmls_evaluator.applyFullPolynomialCoefficientsBasisToDataAllComponents<double**, Kokkos::HostSpace>
-                (sampling_data_device, VectorPointSample);
+                (sampling_data_device);
         
         //! [Apply GMLS Alphas To Data]
         

--- a/examples/GMLS_Staggered_Manifold.cpp
+++ b/examples/GMLS_Staggered_Manifold.cpp
@@ -253,7 +253,7 @@ Kokkos::initialize(argc, args);
     
     // initialize an instance of the GMLS class
     GMLS my_GMLS_vector_1(ReconstructionSpace::VectorTaylorPolynomial, 
-            SamplingFunctional::StaggeredEdgeIntegralSample, 
+            StaggeredEdgeIntegralSample, 
             order, solver_name.c_str(), order /*manifold order*/, dimension);
     
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
@@ -296,8 +296,8 @@ Kokkos::initialize(argc, args);
     
     // initialize another instance of the GMLS class
     GMLS my_GMLS_vector_2(ReconstructionSpace::VectorTaylorPolynomial, 
-            SamplingFunctional::StaggeredEdgeIntegralSample, 
-            SamplingFunctional::StaggeredEdgeAnalyticGradientIntegralSample, 
+            StaggeredEdgeIntegralSample, 
+            StaggeredEdgeAnalyticGradientIntegralSample, 
             order, solver_name.c_str(), order /*manifold order*/, dimension);
     my_GMLS_vector_2.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     std::vector<TargetOperation> lro_vector_2(2);
@@ -313,7 +313,7 @@ Kokkos::initialize(argc, args);
 
     // initialize another instance of the GMLS class
     GMLS my_GMLS_scalar(ReconstructionSpace::ScalarTaylorPolynomial, 
-            SamplingFunctional::StaggeredEdgeAnalyticGradientIntegralSample, 
+            StaggeredEdgeAnalyticGradientIntegralSample, 
             order, solver_name.c_str(), order /*manifold order*/, dimension);
     my_GMLS_scalar.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
 

--- a/examples/GMLS_Vector.cpp
+++ b/examples/GMLS_Vector.cpp
@@ -106,14 +106,27 @@ bool all_passed = true;
     // number of source coordinate sites that will fill a box of [-1,1]x[-1,1]x[-1,1] with a spacing approximately h
     const int number_source_coords = std::pow(n_neg1_to_1, dimension);
     
+    // Coordinates for source and target sites are allocated through memory managed views just
+    // to allocate space for the data and from which to provide a pointer to raw data on the device.
+    // An unmanaged view is then created and pointed at this raw pointer in order to test the GMLS class
+    // setSourceSites and setTargetSites interface.
+
     // coordinates of source sites
-    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> source_coords_device("source coordinates", 
+    // data allocated on device memory space
+    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> source_coords_data("source coordinates", 
             number_source_coords, 3);
-    Kokkos::View<double**>::HostMirror source_coords = Kokkos::create_mirror_view(source_coords_device);
+    // later accessed through unmanaged memory view
+    scratch_matrix_left_type source_coords_device(source_coords_data.data(), 
+            number_source_coords, 3);
+    scratch_matrix_left_type::HostMirror source_coords = Kokkos::create_mirror_view(source_coords_device);
     
     // coordinates of target sites
-    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> target_coords_device ("target coordinates", number_target_coords, 3);
-    Kokkos::View<double**>::HostMirror target_coords = Kokkos::create_mirror_view(target_coords_device);
+    // data allocated on device memory space
+    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> target_coords_data("target coordinates", 
+            number_target_coords, 3);
+    // later accessed through unmanaged memory view
+    scratch_matrix_right_type target_coords_device (target_coords_data.data(), number_target_coords, 3);
+    scratch_matrix_right_type::HostMirror target_coords = Kokkos::create_mirror_view(target_coords_device);
     
     
     // fill source coordinates with a uniform grid

--- a/examples/GMLS_Vector.cpp
+++ b/examples/GMLS_Vector.cpp
@@ -346,7 +346,7 @@ bool all_passed = true;
     
     // retrieves polynomial coefficients instead of remapped field
     auto scalar_coefficients = gmls_evaluator.applyFullPolynomialCoefficientsBasisToDataAllComponents<double**, Kokkos::HostSpace>
-            (sampling_data_device, VectorPointSample);
+            (sampling_data_device);
     
     //! [Apply GMLS Alphas To Data]
     

--- a/src/Compadre_GMLS_Basis.hpp
+++ b/src/Compadre_GMLS_Basis.hpp
@@ -52,10 +52,10 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
     }
 
     // basis ActualReconstructionSpaceRank is 0 (evaluated like a scalar) and sampling functional is traditional
-    if ((polynomial_sampling_functional == SamplingFunctional::PointSample ||
-            polynomial_sampling_functional == SamplingFunctional::VectorPointSample ||
-            polynomial_sampling_functional == SamplingFunctional::ManifoldVectorPointSample ||
-            polynomial_sampling_functional == SamplingFunctional::VaryingManifoldVectorPointSample)&&
+    if ((polynomial_sampling_functional == PointSample ||
+            polynomial_sampling_functional == VectorPointSample ||
+            polynomial_sampling_functional == ManifoldVectorPointSample ||
+            polynomial_sampling_functional == VaryingManifoldVectorPointSample)&&
             (reconstruction_space == ScalarTaylorPolynomial || reconstruction_space == VectorOfScalarClonesTaylorPolynomial)) {
 
         double cutoff_p = _epsilons(target_index);
@@ -94,9 +94,9 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
         }
 
     // basis ActualReconstructionSpaceRank is 1 (is a true vector basis) and sampling functional is traditional
-    } else if ((polynomial_sampling_functional == SamplingFunctional::VectorPointSample ||
-                polynomial_sampling_functional == SamplingFunctional::ManifoldVectorPointSample ||
-                polynomial_sampling_functional == SamplingFunctional::VaryingManifoldVectorPointSample) &&
+    } else if ((polynomial_sampling_functional == VectorPointSample ||
+                polynomial_sampling_functional == ManifoldVectorPointSample ||
+                polynomial_sampling_functional == VaryingManifoldVectorPointSample) &&
                     (reconstruction_space == VectorTaylorPolynomial)) {
 
         const int dimension_offset = this->getNP(_poly_order, dimension);
@@ -146,7 +146,7 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
 
 
     // basis is actually scalar with staggered sampling functional
-    } else if ((polynomial_sampling_functional == SamplingFunctional::StaggeredEdgeAnalyticGradientIntegralSample) &&
+    } else if ((polynomial_sampling_functional == StaggeredEdgeAnalyticGradientIntegralSample) &&
             (reconstruction_space == ScalarTaylorPolynomial)) {
 
         {
@@ -226,7 +226,7 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
                 }
             }
         }
-    } else if (polynomial_sampling_functional == SamplingFunctional::StaggeredEdgeIntegralSample) {
+    } else if (polynomial_sampling_functional == StaggeredEdgeIntegralSample) {
 
         double cutoff_p = _epsilons(target_index);
 
@@ -273,10 +273,10 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
                 }
             }
         }
-    } else if (polynomial_sampling_functional == SamplingFunctional::FaceNormalIntegralSample ||
-                polynomial_sampling_functional == SamplingFunctional::FaceTangentIntegralSample ||
-                polynomial_sampling_functional == SamplingFunctional::FaceNormalPointSample ||
-                polynomial_sampling_functional == SamplingFunctional::FaceTangentPointSample) {
+    } else if (polynomial_sampling_functional == FaceNormalIntegralSample ||
+                polynomial_sampling_functional == FaceTangentIntegralSample ||
+                polynomial_sampling_functional == FaceNormalPointSample ||
+                polynomial_sampling_functional == FaceTangentPointSample) {
 
         double cutoff_p = _epsilons(target_index);
 
@@ -294,8 +294,8 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
          */
 
         // if not integrating, set to 1
-        int quadrature_point_loop = (polynomial_sampling_functional == SamplingFunctional::FaceNormalIntegralSample 
-                || polynomial_sampling_functional == SamplingFunctional::FaceTangentIntegralSample) ?
+        int quadrature_point_loop = (polynomial_sampling_functional == FaceNormalIntegralSample 
+                || polynomial_sampling_functional == FaceTangentIntegralSample) ?
                                     _number_of_quadrature_points : 1;
 
         // only used for integrated quantities
@@ -318,8 +318,8 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
             XYZ quadrature_coord_2d;
             for (int j=0; j<dimension; ++j) {
                 
-                if (polynomial_sampling_functional == SamplingFunctional::FaceNormalIntegralSample 
-                        || polynomial_sampling_functional == SamplingFunctional::FaceTangentIntegralSample) {
+                if (polynomial_sampling_functional == FaceNormalIntegralSample 
+                        || polynomial_sampling_functional == FaceTangentIntegralSample) {
                     // quadrature coord site
                     quadrature_coord_2d[j] = _parameterized_quadrature_sites[quadrature]*_extra_data(neighbor_index_in_source, j);
                     quadrature_coord_2d[j] += (1-_parameterized_quadrature_sites[quadrature])*_extra_data(neighbor_index_in_source, j+2);
@@ -330,8 +330,8 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
                 }
 
                 // normal direction or tangent direction
-                if (polynomial_sampling_functional == SamplingFunctional::FaceNormalIntegralSample 
-                        || polynomial_sampling_functional == SamplingFunctional::FaceNormalPointSample) {
+                if (polynomial_sampling_functional == FaceNormalIntegralSample 
+                        || polynomial_sampling_functional == FaceNormalPointSample) {
                     // normal direction
                     direction_2d[j] = _extra_data(neighbor_index_in_source, 4 + j);
                 } else {
@@ -359,8 +359,8 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
 
                         // multiply by quadrature weight
                         if (quadrature==0) {
-                            if (polynomial_sampling_functional == SamplingFunctional::FaceNormalIntegralSample 
-                                    || polynomial_sampling_functional == SamplingFunctional::FaceTangentIntegralSample) {
+                            if (polynomial_sampling_functional == FaceNormalIntegralSample 
+                                    || polynomial_sampling_functional == FaceTangentIntegralSample) {
                                 // integral
                                 *(delta+i) = dot_product * _quadrature_weights[quadrature] * magnitude;
                             } else {
@@ -413,10 +413,10 @@ void GMLS::calcGradientPij(double* delta, const int target_index, const int neig
 
     double cutoff_p = _epsilons(target_index);
 
-    if ((polynomial_sampling_functional == SamplingFunctional::PointSample ||
-            polynomial_sampling_functional == SamplingFunctional::VectorPointSample ||
-            polynomial_sampling_functional == SamplingFunctional::ManifoldVectorPointSample ||
-            polynomial_sampling_functional == SamplingFunctional::VaryingManifoldVectorPointSample) &&
+    if ((polynomial_sampling_functional == PointSample ||
+            polynomial_sampling_functional == VectorPointSample ||
+            polynomial_sampling_functional == ManifoldVectorPointSample ||
+            polynomial_sampling_functional == VaryingManifoldVectorPointSample) &&
             (reconstruction_space == ScalarTaylorPolynomial || reconstruction_space == VectorOfScalarClonesTaylorPolynomial)) {
 
         int alphax, alphay, alphaz;
@@ -514,8 +514,8 @@ void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type 
 
             // coefficient muliplied by relative distance (allows for mid-edge weighting if applicable)
             double alpha_weight = 1;
-            if (_polynomial_sampling_functional==SamplingFunctional::StaggeredEdgeIntegralSample
-                    || _polynomial_sampling_functional==SamplingFunctional::StaggeredEdgeAnalyticGradientIntegralSample) {
+            if (_polynomial_sampling_functional==StaggeredEdgeIntegralSample
+                    || _polynomial_sampling_functional==StaggeredEdgeAnalyticGradientIntegralSample) {
                 alpha_weight = 0.5;
             }
 

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -15,7 +15,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
             (_reconstruction_space!=ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial
                 || _data_sampling_multiplier!=0
                 || (_reconstruction_space==ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial 
-                        && _polynomial_sampling_functional==SamplingFunctional::PointSample))
+                        && _polynomial_sampling_functional==PointSample))
             && "_reconstruction_space(VectorOfScalar clones incompatible with scalar output sampling functional which is not a PointSample");
     } 
 
@@ -59,7 +59,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
             if (_operations(i) == TargetOperation::ScalarPointEvaluation || (_operations(i) == TargetOperation::VectorPointEvaluation && _dimensions == 1) /* vector is a scalar in 1D */) {
                 Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                         int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         for (int k=0; k<target_NP; ++k) {
                             P_target_row(offset, k) = t1(k);
@@ -90,7 +90,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         for (int d=0; d<_dimensions; ++d) {
                             int offset = getTargetOffsetIndexDevice(i, 0, d, j);
                             auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
-                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                         }
                     }
                 });
@@ -100,7 +100,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
-                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                     }
                 });
                 additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
@@ -110,7 +110,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
-                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                     }
                 });
                 additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
@@ -120,7 +120,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
-                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                     }
                 });
                 additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
@@ -142,7 +142,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                 // copied from ScalarTaylorPolynomial
                 Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                         int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         for (int k=0; k<target_NP; ++k) {
                             P_target_row(offset, k) = t1(k);
@@ -153,7 +153,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
             } else if (_operations(i) == TargetOperation::VectorPointEvaluation) {
                 Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int e=0; e<num_evaluation_sites; ++e) {
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, e);
                         for (int m=0; m<_sampling_multiplier; ++m) {
                             int output_components = _basis_multiplier;
                             for (int c=0; c<output_components; ++c) {
@@ -173,7 +173,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                 Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int e=0; e<num_evaluation_sites; ++e) {
                         for (int m=0; m<_sampling_multiplier; ++m) {
-                            this->calcGradientPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, m /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
+                            this->calcGradientPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, m /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, e);
                             int offset = getTargetOffsetIndexDevice(i, m /*in*/, 0 /*out*/, e/*additional*/);
                             for (int j=0; j<target_NP; ++j) {
                                 P_target_row(offset, m*target_NP + j) = t1(j);
@@ -286,7 +286,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                 // copied from ScalarTaylorPolynomial
                 Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                         int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         for (int k=0; k<target_NP; ++k) {
                             P_target_row(offset, k) = t1(k);
@@ -297,7 +297,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
             } else if (_operations(i) == TargetOperation::VectorPointEvaluation) {
                 Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int e=0; e<num_evaluation_sites; ++e) {
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, e);
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions, _poly_order, false /*bool on only specific order*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, e);
                         for (int m=0; m<_sampling_multiplier; ++m) {
                             auto output_components = std::pow(_local_dimensions, _data_sampling_multiplier);
                             for (int c=0; c<output_components; ++c) {
@@ -335,7 +335,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         for (int d=0; d<_dimensions; ++d) {
                             int offset = getTargetOffsetIndexDevice(i, 0, d, j);
                             auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
-                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, d /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                         }
                     }
                 });
@@ -346,7 +346,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                     for (int j=0; j<num_evaluation_sites; ++j) { 
                         int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
-                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 0 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                     }
                 });
                 additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
@@ -357,7 +357,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         for (int j=0; j<num_evaluation_sites; ++j) { 
                             int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                             auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
-                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 1 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                         }
                     });
                     additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
@@ -369,7 +369,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                         for (int j=0; j<num_evaluation_sites; ++j) { 
                             int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                             auto row = Kokkos::subview(P_target_row, offset, Kokkos::ALL());
-                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                            this->calcGradientPij(row.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, 2 /*partial_direction*/, _dimensions, _poly_order, false /*specific order only*/, NULL /*&V*/, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                         }
                     });
                     additional_evaluation_sites_handled = true; // additional non-target site evaluations handled
@@ -556,7 +556,7 @@ void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_ve
         if (_curvature_support_operations(i) == TargetOperation::ScalarPointEvaluation) {
             Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
                 int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
-                this->calcPij(t1.data(), target_index, local_neighbor_index, 0 /*alpha*/, _dimensions-1, _curvature_poly_order, false /*bool on only specific order*/, V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
+                this->calcPij(t1.data(), target_index, local_neighbor_index, 0 /*alpha*/, _dimensions-1, _curvature_poly_order, false /*bool on only specific order*/, V, ReconstructionSpace::ScalarTaylorPolynomial, PointSample);
                 for (int j=0; j<manifold_NP; ++j) {
                     P_target_row(offset, j) = t1(j);
                 }
@@ -565,14 +565,14 @@ void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_ve
             Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
                 //int offset = i*manifold_NP;
                 int offset = getTargetOffsetIndexDevice(i, 0, 0, 0);
-                this->calcGradientPij(t1.data(), target_index, local_neighbor_index, 0 /*alpha*/, 0 /*partial_direction*/, _dimensions-1, _curvature_poly_order, false /*specific order only*/, V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
+                this->calcGradientPij(t1.data(), target_index, local_neighbor_index, 0 /*alpha*/, 0 /*partial_direction*/, _dimensions-1, _curvature_poly_order, false /*specific order only*/, V, ReconstructionSpace::ScalarTaylorPolynomial, PointSample);
                 for (int j=0; j<manifold_NP; ++j) {
                     P_target_row(offset, j) = t1(j);
                 }
                 if (_dimensions>2) { // _dimensions-1 > 1
                     //offset = (i+1)*manifold_NP;
                     offset = getTargetOffsetIndexDevice(i, 0, 1, 0);
-                    this->calcGradientPij(t1.data(), target_index, local_neighbor_index, 0 /*alpha*/, 1 /*partial_direction*/, _dimensions-1, _curvature_poly_order, false /*specific order only*/, V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample);
+                    this->calcGradientPij(t1.data(), target_index, local_neighbor_index, 0 /*alpha*/, 1 /*partial_direction*/, _dimensions-1, _curvature_poly_order, false /*specific order only*/, V, ReconstructionSpace::ScalarTaylorPolynomial, PointSample);
                     for (int j=0; j<manifold_NP; ++j) {
                         P_target_row(offset, j) = t1(j);
                     }
@@ -622,7 +622,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
             if (_operations(i) == TargetOperation::ScalarPointEvaluation) {
                 Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                     for (int j=0; j<num_evaluation_sites; ++j) { 
-                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, j);
+                        this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, j);
                         int offset = getTargetOffsetIndexDevice(i, 0, 0, j);
                         for (int k=0; k<target_NP; ++k) {
                             P_target_row(offset, k) = t1(k);
@@ -636,7 +636,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                     Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
                         for (int k=0; k<num_evaluation_sites; ++k) { 
                             // output component 0
-                            this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, k);
+                            this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, k);
                             int offset = getTargetOffsetIndexDevice(i, 0, 0, k);
                             for (int j=0; j<target_NP; ++j) {
                                 P_target_row(offset, j) = t1(j);
@@ -667,7 +667,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                     Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
                         for (int k=0; k<num_evaluation_sites; ++k) { 
                             // output component 0
-                            this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, SamplingFunctional::PointSample, k);
+                            this->calcPij(t1.data(), target_index, -1 /* target is neighbor */, 1 /*alpha*/, _dimensions-1, _poly_order, false /*bool on only specific order*/, &V, ReconstructionSpace::ScalarTaylorPolynomial, PointSample, k);
                             int offset = getTargetOffsetIndexDevice(i, 0, 0, k);
                             for (int j=0; j<target_NP; ++j) {
                                 P_target_row(offset, j) = t1(j);
@@ -917,8 +917,8 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                 }
             } else if (_operations(i) == TargetOperation::GradientOfScalarPointEvaluation) {
                 if (_reconstruction_space_rank == 0
-                    && (_polynomial_sampling_functional == SamplingFunctional::PointSample
-                    || _polynomial_sampling_functional == SamplingFunctional::ManifoldVectorPointSample)) {
+                    && (_polynomial_sampling_functional == PointSample
+                    || _polynomial_sampling_functional == ManifoldVectorPointSample)) {
                     Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
 
                         double h = _epsilons(target_index);
@@ -959,14 +959,14 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                 // with a vector basis
                 } else if (_reconstruction_space_rank == 1
                         && _polynomial_sampling_functional 
-                            == SamplingFunctional::StaggeredEdgeIntegralSample) {
+                            == StaggeredEdgeIntegralSample) {
                     compadre_kernel_assert_release((false) && "Functionality not yet available.");
 
                 // staggered gradient w/ edge integrals known analytically, using a basis
                 // of potentials
                 } else if (_reconstruction_space_rank == 0
                         && _polynomial_sampling_functional 
-                            == SamplingFunctional::StaggeredEdgeAnalyticGradientIntegralSample) {
+                            == StaggeredEdgeAnalyticGradientIntegralSample) {
                     compadre_kernel_assert_release((false) && "Functionality not yet available.");
 
                 } else {
@@ -975,7 +975,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
             } else if (_operations(i) == TargetOperation::DivergenceOfVectorPointEvaluation) {
                 // vector basis
                 if (_reconstruction_space_rank == 1
-                        && _polynomial_sampling_functional == SamplingFunctional::ManifoldVectorPointSample) {
+                        && _polynomial_sampling_functional == ManifoldVectorPointSample) {
                     Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
 
                         double h = _epsilons(target_index);
@@ -1023,7 +1023,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                     });
                 // scalar basis times number of components in the vector
                 } else if (_reconstruction_space_rank == 0
-                        && _polynomial_sampling_functional == SamplingFunctional::ManifoldVectorPointSample) {
+                        && _polynomial_sampling_functional == ManifoldVectorPointSample) {
                     Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
 
                         double h = _epsilons(target_index);
@@ -1070,7 +1070,7 @@ void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scr
                 // staggered divergence acting on vector polynomial space
                 } else if (_reconstruction_space_rank == 1
                         && _polynomial_sampling_functional 
-                            == SamplingFunctional::StaggeredEdgeIntegralSample) {
+                            == StaggeredEdgeIntegralSample) {
 
                     Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
 

--- a/src/Compadre_Operators.hpp
+++ b/src/Compadre_Operators.hpp
@@ -88,8 +88,6 @@ namespace Compadre {
         DifferentEachNeighbor, ///< Each target applies a different transform for each neighbor
     };
 
-    enum SamplingName { nPointSample, nVectorPointSample, nManifoldVectorPointSample, nStaggeredEdgeAnalyticGradientIntegralSample, nStaggeredEdgeIntegralSample, nVaryingManifoldVectorPointSample, nFaceNormalIntegralSample, nFaceNormalPointSample, nFaceTangentIntegralSample, nFaceTangentPointSample};
-
     struct SamplingFunctional {
         //! for uniqueness
         size_t id;

--- a/src/Compadre_Operators.hpp
+++ b/src/Compadre_Operators.hpp
@@ -1,6 +1,8 @@
 #ifndef _COMPADRE_OPERATORS_HPP_
 #define _COMPADRE_OPERATORS_HPP_
 
+#include "Compadre_Typedefs.hpp"
+
 namespace Compadre {
 
     //! Available target functionals
@@ -76,60 +78,6 @@ namespace Compadre {
         0, ///< VectorOfScalarClonesTaylorPolynomial
     };
 
-    //! Available sampling functionals
-    enum SamplingFunctional {
-        //! Point evaluations of the scalar source function
-        PointSample,
-        //! Point evaluations of the entire vector source function
-        VectorPointSample,
-        //! Point evaluations of the entire vector source function 
-        //! (but on a manifold, so it includes a transform into local coordinates)
-        ManifoldVectorPointSample,
-        //! Analytical integral of a gradient source vector is just a difference of the scalar source at neighbor and target
-        StaggeredEdgeAnalyticGradientIntegralSample,
-        //! Samples consist of the result of integrals of a vector dotted with the tangent along edges between neighbor and target
-        StaggeredEdgeIntegralSample,
-        //! For integrating polynomial dotted with normal over an edge
-        FaceNormalIntegralSample,
-        //! For polynomial dotted with normal on edge
-        FaceNormalPointSample,
-        //! For integrating polynomial dotted with tangent over an edge
-        FaceTangentIntegralSample,
-        //! For polynomial dotted with tangent
-        FaceTangentPointSample,
-        //! Point evaluations of the entire vector source function 
-        //! (but on a manifold, so it includes a transform into local coordinates)
-        VaryingManifoldVectorPointSample,
-    };
-
-    //! Rank of sampling functional input for each SamplingFunctional
-    const int SamplingInputTensorRank[] = {
-        0, ///< PointSample
-        1, ///< VectorPointSample
-        1, ///< ManifoldVectorPointSample
-        0, ///< StaggeredEdgeAnalyticGradientIntegralSample,
-        1, ///< StaggeredEdgeIntegralSample
-        1, ///< FaceNormalIntegralSample,
-        1, ///< FaceNormalPointSample,
-        1, ///< FaceTangentIntegralSample,
-        1, ///< FaceTangentPointSample,
-        1, ///< VaryingManifoldVectorPointSample
-    };
-
-    //! Rank of sampling functional output for each SamplingFunctional
-    const int SamplingOutputTensorRank[] {
-        0, ///< PointSample
-        1, ///< VectorPointSample
-        1, ///< ManifoldVectorPointSample
-        0, ///< StaggeredEdgeAnalyticGradientIntegralSample,
-        0, ///< StaggeredEdgeIntegralSample
-        0, ///< FaceNormalIntegralSample,
-        0, ///< FaceNormalPointSample,
-        0, ///< FaceTangentIntegralSample,
-        0, ///< FaceTangentPointSample,
-        1, ///< VaryingManifoldVectorPointSample
-    };
-
     //! Describes the SamplingFunction relationship to targets, neighbors
     enum SamplingTransformType {
         Identity,           ///< No action performed on data before GMLS target operation
@@ -138,50 +86,74 @@ namespace Compadre {
         DifferentEachNeighbor, ///< Each target applies a different transform for each neighbor
     };
 
-    //! Rank of sampling functional output for each SamplingFunctional
-    const int SamplingTensorStyle[] {
-        (int)Identity,              ///< PointSample
-        (int)Identity,              ///< VectorPointSample
-        (int)DifferentEachTarget,   ///< ManifoldVectorPointSample
-        (int)SameForAll,            ///< StaggeredEdgeAnalyticGradientIntegralSample,
-        (int)DifferentEachNeighbor, ///< StaggeredEdgeIntegralSample
-        (int)Identity,              ///< FaceNormalIntegralSample,
-        (int)Identity,              ///< FaceNormalPointSample,
-        (int)Identity,              ///< FaceTangentIntegralSample,
-        (int)Identity,              ///< FaceTangentPointSample,
-        (int)DifferentEachNeighbor, ///< VaryingManifoldVectorPointSample
+    struct SamplingFunctional {
+        //! hash of name, for uniqueness
+        size_t id;
+        //! Rank of sampling functional input for each SamplingFunctional
+        const int input_rank;
+        //! Rank of sampling functional output for each SamplingFunctional
+        const int output_rank;
+        //! Whether or not the SamplingTensor acts on the target site as well as the neighbors.
+        //! This makes sense only in staggered schemes, when each target site is also a source site
+        const bool use_target_site_weights;
+        //! Whether the SamplingFunctional + ReconstructionSpace results in a nontrivial nullspace requiring SVD
+        const bool nontrivial_nullspace;
+        //! Describes the SamplingFunction relationship to targets, neighbors
+        const int transform_type;
+
+        SamplingFunctional(std::string name, const int input_rank_, const int output_rank_,
+                const bool use_target_site_weights_, const bool nontrivial_nullspace_,
+                const int transform_type_) : input_rank(input_rank_), output_rank(output_rank_),
+                use_target_site_weights(use_target_site_weights_), nontrivial_nullspace(nontrivial_nullspace_),
+                transform_type(transform_type_) {
+
+            std::hash<std::string> str_hash;
+            id = str_hash(name);
+        }
+
+        inline bool operator == (const SamplingFunctional &sf) const {
+            return id == sf.id;
+        }
+
+        inline bool operator != (const SamplingFunctional &sf) const {
+            return id != sf.id;
+        }
     };
 
-    //! Whether or not the SamplingTensor acts on the target site as well as the neighbors.
-    //! This makes sense only in staggered schemes, when each target site is also a source site
-    const int SamplingTensorForTargetSite[] {
-        0, ///< PointSample
-        0, ///< VectorPointSample
-        0, ///< ManifoldVectorPointSample
-        1, ///< StaggeredEdgeAnalyticGradientIntegralSample,
-        1, ///< StaggeredEdgeIntegralSample
-        0, ///< FaceNormalIntegralSample,
-        0, ///< FaceNormalPointSample,
-        0, ///< FaceTangentIntegralSample,
-        0, ///< FaceTangentPointSample,
-        0, ///< VaryingManifoldVectorPointSample
-    };
+    ////! Available sampling functionals
+    extern const SamplingFunctional 
 
-    //! Whether the SamplingFunctional + ReconstructionSpace results in a nontrivial nullspace requiring SVD
-    const int SamplingNontrivialNullspace[] {
-        // does the sample over polynomials result in an operator
-        // with a nontrivial nullspace requiring SVD
-        0, ///< PointSample
-        0, ///< VectorPointSample
-        0, ///< ManifoldVectorPointSample
-        1, ///< StaggeredEdgeAnalyticGradientIntegralSample,
-        1, ///< StaggeredEdgeIntegralSample
-        0, ///< FaceNormalIntegralSample,
-        0, ///< FaceNormalPointSample,
-        0, ///< FaceTangentIntegralSample,
-        0, ///< FaceTangentPointSample,
-        0, ///< VaryingManifoldVectorPointSample
-    };
+        //! Point evaluations of the scalar source function
+        PointSample = SamplingFunctional("PointSample",0,0,false,false,(int)Identity),
+
+        //! Point evaluations of the entire vector source function
+        VectorPointSample = SamplingFunctional("VectorPointSample",1,1,false,false,(int)Identity),
+
+        //! Point evaluations of the entire vector source function 
+        //! (but on a manifold, so it includes a transform into local coordinates)
+        ManifoldVectorPointSample = SamplingFunctional("ManifoldVectorPointSample",1,1,false,false,(int)DifferentEachTarget),
+
+        //! Analytical integral of a gradient source vector is just a difference of the scalar source at neighbor and target
+        StaggeredEdgeAnalyticGradientIntegralSample = SamplingFunctional("StaggeredEdgeAnalyticGradientIntegralSample",0,0,true,true,(int)SameForAll),
+
+        //! Samples consist of the result of integrals of a vector dotted with the tangent along edges between neighbor and target
+        StaggeredEdgeIntegralSample = SamplingFunctional("StaggeredEdgeIntegralSample",1,0,true,true,(int)DifferentEachNeighbor),
+
+        //! For integrating polynomial dotted with normal over an edge
+        VaryingManifoldVectorPointSample = SamplingFunctional("VaryingManifoldVectorPointSample",1,1,false,false,(int)DifferentEachNeighbor),
+
+        //! For integrating polynomial dotted with normal over an edge
+        FaceNormalIntegralSample = SamplingFunctional("FaceNormalIntegralSample",1,0,false,false,(int)Identity),
+
+        //! For polynomial dotted with normal on edge
+        FaceNormalPointSample = SamplingFunctional("FaceNormalPointSample",1,0,false,false,(int)Identity),
+
+        //! For integrating polynomial dotted with tangent over an edge
+        FaceTangentIntegralSample = SamplingFunctional("FaceTangentIntegralSample",1,0,false,false,(int)Identity),
+
+        //! For polynomial dotted with tangent
+        FaceTangentPointSample = SamplingFunctional("FaceTangentPointSample",1,0,false,false,(int)Identity);
+
 
     //! Dense solver type, that optionally can also handle manifolds
     enum DenseSolverType {
@@ -213,14 +185,9 @@ namespace Compadre {
         return axis_1_size*output_component_axis_1 + output_component_axis_2; // 0 for scalar, 0 for vector;
     }
 
-    //static int getSamplingInputIndex(const int operation_num, const int input_component_axis_1, const int input_component_axis_2) {
-    //    const int axis_1_size = (SamplingInputTensorRank[operation_num] > 1) ? SamplingInputTensorRank[operation_num] : 1;
-    //    return axis_1_size*input_component_axis_1 + input_component_axis_2; // 0 for scalar, 0 for vector;
-    //}
-
     //! Helper function for finding alpha coefficients
-    static int getSamplingOutputIndex(const int operation_num, const int output_component_axis_1, const int output_component_axis_2) {
-        const int axis_1_size = (SamplingOutputTensorRank[operation_num] > 1) ? SamplingOutputTensorRank[operation_num] : 1;
+    static int getSamplingOutputIndex(const SamplingFunctional sf, const int output_component_axis_1, const int output_component_axis_2) {
+        const int axis_1_size = (sf.output_rank > 1) ? sf.output_rank : 1;
         return axis_1_size*output_component_axis_1 + output_component_axis_2; // 0 for scalar, 0 for vector;
     }
 

--- a/src/Compadre_Operators.hpp
+++ b/src/Compadre_Operators.hpp
@@ -90,16 +90,16 @@ namespace Compadre {
         //! hash of name, for uniqueness
         size_t id;
         //! Rank of sampling functional input for each SamplingFunctional
-        const int input_rank;
+        int input_rank;
         //! Rank of sampling functional output for each SamplingFunctional
-        const int output_rank;
+        int output_rank;
         //! Whether or not the SamplingTensor acts on the target site as well as the neighbors.
         //! This makes sense only in staggered schemes, when each target site is also a source site
-        const bool use_target_site_weights;
+        bool use_target_site_weights;
         //! Whether the SamplingFunctional + ReconstructionSpace results in a nontrivial nullspace requiring SVD
-        const bool nontrivial_nullspace;
+        bool nontrivial_nullspace;
         //! Describes the SamplingFunction relationship to targets, neighbors
-        const int transform_type;
+        int transform_type;
 
         SamplingFunctional(std::string name, const int input_rank_, const int output_rank_,
                 const bool use_target_site_weights_, const bool nontrivial_nullspace_,
@@ -118,10 +118,12 @@ namespace Compadre {
         inline bool operator != (const SamplingFunctional &sf) const {
             return id != sf.id;
         }
+
     };
 
-    ////! Available sampling functionals
-    extern const SamplingFunctional 
+
+    //! Available sampling functionals
+    static const SamplingFunctional 
 
         //! Point evaluations of the scalar source function
         PointSample = SamplingFunctional("PointSample",0,0,false,false,(int)Identity),

--- a/src/Compadre_PointCloudSearch.hpp
+++ b/src/Compadre_PointCloudSearch.hpp
@@ -169,13 +169,15 @@ class PointCloudSearch {
         }
 
         //! Generates neighbor lists
-        template <typename neighbor_lists_view_type, typename epsilons_view_type>
-        void generateNeighborListsFromKNNSearch(view_type trg_pts_view, neighbor_lists_view_type neighbor_lists,
+        template <typename trg_view_type, typename neighbor_lists_view_type, typename epsilons_view_type>
+        void generateNeighborListsFromKNNSearch(trg_view_type trg_pts_view, neighbor_lists_view_type neighbor_lists,
                 epsilons_view_type epsilons, const int neighbors_needed, 
                 const int dimension = 3, const double epsilon_multiplier = 1.6, std::shared_ptr<tree_type> kd_tree = NULL, bool max_search_radius = 0.0) {
 
+            compadre_assert_release((std::is_same<typename trg_view_type::memory_space, Kokkos::HostSpace>::value) &&
+                    "Target coordinates view passed to generateNeighborListsFromKNNSearch should reside on the host.");
             compadre_assert_release(trg_pts_view.dimension_1()==3 &&
-                    "Views passed to PointCloudSearch at construction must have second dimension of 3.");
+                    "Target coordinates view passed to generateNeighborListsFromKNNSearch must have second dimension of 3.");
             compadre_assert_release((std::is_same<typename neighbor_lists_view_type::memory_space, Kokkos::HostSpace>::value) &&
                     "Views passed to generateNeighborListsFromKNNSearch should reside on the host.");
             compadre_assert_release((std::is_same<typename epsilons_view_type::memory_space, Kokkos::HostSpace>::value) &&
@@ -313,12 +315,6 @@ class PointCloudSearch {
         }
 
 }; // PointCloudSearch
-
-//! CreatePointCloudSearch allows for the construction of an object of type PointCloudSearch with template deduction
-template <typename view_type>
-PointCloudSearch<view_type> CreatePointCloudSearch(view_type src_view, view_type trg_view) { 
-    return PointCloudSearch<view_type>(src_view, trg_view);
-}
 
 //! CreatePointCloudSearch allows for the construction of an object of type PointCloudSearch with template deduction
 template <typename view_type>

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -9,6 +9,8 @@
 #include <vector>
 #include <sstream>
 #include <cstddef>
+#include <functional>
+#include <string>
 
 /*!
  


### PR DESCRIPTION
Previously, SamplingFunctionals were an enum having arrays the same size as the enum with characteristics corresponding to each enum member. This more naturally fits the use of a struct, but it was necessary to have this struct be of type constexpr in order to have access to the SamplingFunctional struct instances on both host and device. SamplingFunctionals are now constexpr struct instances, which will make the addition of a new SamplingFunctional by users simpler and less prone to hard-to-find errors.