### PR TITLE
Fixing a bug for special case in polynomial order

### DIFF
--- a/examples/GMLS_Host.cpp
+++ b/examples/GMLS_Host.cpp
@@ -163,7 +163,7 @@ bool all_passed = true;
     
     // need Kokkos View storing true solution
     Kokkos::View<double*, Kokkos::HostSpace> sampling_data("samples of true solution", source_coords.dimension_0());
-	Kokkos::View<double**, Kokkos::HostSpace> gradient_sampling_data("samples of true gradient", source_coords.dimension_0(), dimension);
+    Kokkos::View<double**, Kokkos::HostSpace> gradient_sampling_data("samples of true gradient", source_coords.dimension_0(), dimension);
     Kokkos::View<double**, Kokkos::LayoutLeft, Kokkos::HostSpace> divergence_sampling_data("samples of true solution for divergence test", source_coords.dimension_0(), dimension);
     Kokkos::parallel_for("Sampling Manufactured Solutions", Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,source_coords.dimension_0()), KOKKOS_LAMBDA(const int i) {
         double xval = source_coords(i,0);

--- a/python/GMLS_Python.hpp
+++ b/python/GMLS_Python.hpp
@@ -51,9 +51,9 @@ public:
 
     ~GMLS_Python() { 
 
-		delete gmls_object; 
+        delete gmls_object;
 
-	}
+    }
 
     void setWeightingOrder(int regular_weight, int curvature_weight = -1) {
         if (curvature_weight < 0) curvature_weight = regular_weight;

--- a/src/Compadre_Evaluator.hpp
+++ b/src/Compadre_Evaluator.hpp
@@ -305,7 +305,7 @@ public:
     template <typename view_type_data_out, typename view_type_data_in>
     void applyLocalChartToAmbientSpaceTransform(view_type_data_out output_data_single_column, view_type_data_in sampling_data_single_column, const int local_dim_index, const int global_dim_index) const {
 
-		// Does T transpose times a vector
+        // Does T transpose times a vector
         auto global_dimensions = _gmls->getGlobalDimensions();
 
         // gather needed information for evaluation

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -84,6 +84,7 @@ void GMLS::generatePolynomialCoefficients() {
         // if the reconstruction is being made with a gradient of a basis, then we want that basis to be one order higher so that
         // the gradient is consistent with the convergence order expected.
         _poly_order += 1;
+        _NP = this->getNP(_poly_order, _dimensions);
     }
 
     /*

--- a/src/Compadre_Manifold_Functions.hpp
+++ b/src/Compadre_Manifold_Functions.hpp
@@ -2,8 +2,8 @@
 namespace Compadre {
 
     //! Metric factor (det(G)) at any point in the local chart
-	KOKKOS_INLINE_FUNCTION
-	double MetricFactor(const scratch_vector_type a_, const double h, const double u1, const double u2) {
+    KOKKOS_INLINE_FUNCTION
+    double MetricFactor(const scratch_vector_type a_, const double h, const double u1, const double u2) {
         double det_g = 1.0;
         double q1 = 0;
         double q2 = 0;
@@ -46,8 +46,8 @@ namespace Compadre {
     }
 
     //! Gaussian curvature K at any point in the local chart
-	KOKKOS_INLINE_FUNCTION
-	double GaussianCurvature(const scratch_vector_type a_, const double h, const double u1, const double u2) {
+    KOKKOS_INLINE_FUNCTION
+    double GaussianCurvature(const scratch_vector_type a_, const double h, const double u1, const double u2) {
 
         double q1=0, q2=0, q3=0;
         switch (a_.extent(0)) {
@@ -92,8 +92,8 @@ namespace Compadre {
     }
 
     //! Surface curl at any point in the local chart
-	KOKKOS_INLINE_FUNCTION
-	double SurfaceCurlOfScalar(const scratch_vector_type a_, const double h, const double u1, const double u2, int x_pow, int y_pow, const int component) {
+    KOKKOS_INLINE_FUNCTION
+    double SurfaceCurlOfScalar(const scratch_vector_type a_, const double h, const double u1, const double u2, int x_pow, int y_pow, const int component) {
 
         const double factorial[15] = {1, 1, 2, 6, 24, 120, 720, 5040, 40320, 362880, 3628800, 39916800, 479001600, 6227020800, 87178291200};
 


### PR DESCRIPTION
When the reconstruction is made with a gradient of basis, the basis needs to be one higher order for consistency with the expected order of convergence.

The original code update member value `_poly_order` but does not update `_NP`. The latter is used to calculated the dimension of the `P` matrix. This PR fix that bug, along with replacing some runaway tabs in these files.