### PR TITLE
KOKKOS_ENABLE_DEBUG CMake flag now propagated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,8 @@ else()
       set(KokkosCore_PREFIX "${PROJECT_BINARY_DIR}/KokkosCore-install")
       find_package(Kokkos PATHS "${KokkosCore_PREFIX}/lib/CMake/Kokkos" NO_DEFAULT_PATH QUIET)
 
+      bob_input(KOKKOS_ENABLE_DEBUG "${Compadre_DEBUG}" PATH "Debugging mode on or off for KokkosCore install")
+
       # fPIC flag is needed to link against Kokkos library when our library we are creating is shared
       set(KokkosCore_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
       set(KokkosCore_ARGS
@@ -219,6 +221,7 @@ else()
         "-DKOKKOS_CUDA_DIR=${CUDA_PREFIX}"
         "-DKOKKOS_ENABLE_DEPRECATED_CODE=${KOKKOS_ENABLE_DEPRECATED_CODE}"
         "-DKokkos_ENABLE_Cuda_Lambda=ON"
+        "-DKOKKOS_ENABLE_DEBUG=${KOKKOS_ENABLE_DEBUG}"
         "-DCMAKE_OSX_DEPLOYMENT_TARGET=${CMAKE_OSX_DEPLOYMENT_TARGET}"
       )
       

--- a/examples/GMLS_Staggered.cpp
+++ b/examples/GMLS_Staggered.cpp
@@ -252,14 +252,14 @@ bool all_passed = true;
     GMLS scalar_basis_gmls(ScalarTaylorPolynomial,
                  StaggeredEdgeAnalyticGradientIntegralSample,
                  order, solver_name.c_str(),
-                 NULL /*manifold order*/ , dimension);
+                 0 /*manifold order*/ , dimension);
 
     // Another class performing Gaussian quadrature integration on vector polynomial basis
     GMLS vector_basis_gmls(VectorTaylorPolynomial,
                            StaggeredEdgeIntegralSample,
                            StaggeredEdgeAnalyticGradientIntegralSample,
                            order, solver_name.c_str(),
-                           NULL /*manifold order*/ , dimension);
+                           0 /*manifold order*/ , dimension);
 
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
     //

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -1632,6 +1632,13 @@ public:
 
         _total_alpha_values = total_offset;
 
+        if (_dense_solver_type == DenseSolverType::MANIFOLD) {
+            // if on a manifold, the total alphas values must be large enough to hold the gradient
+            // of the geometry reconstruction
+            _total_alpha_values = (_total_alpha_values > std::pow(_local_dimensions, 1)) ? 
+                _total_alpha_values : std::pow(_local_dimensions, 1);
+        }
+
         Kokkos::deep_copy(_lro_total_offsets, _host_lro_total_offsets);
         Kokkos::deep_copy(_lro_output_tile_size, _host_lro_output_tile_size);
         Kokkos::deep_copy(_lro_input_tile_size, _host_lro_input_tile_size);


### PR DESCRIPTION
Now propagate KOKKOS_ENABLE_DEBUG into Kokkos builds, using a default value of whatever Compadre_DEBUG is set to, which by default is ON. This allows Kokkos to be built in a mode independent of Compadre.
    
Fixed a size variable that didn't take into account that when a gradient is needed for curvature and only a scalar target is selected, the size would have been incorrect.
    
Replaced two NULL statements in a test that require an integer.
