### PR TITLE
KokkosParser class added

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -118,7 +118,7 @@ if (Compadre_EXAMPLES)
     # WORKING_DIRECTORY ${EXECUTABLE_OUTPUT_PATH} )
     if (Compadre_USE_PYTHON)
       CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/Python_3D_Convergence.py.in" "${CMAKE_CURRENT_BINARY_DIR}/Python_3D_Convergence.py" @ONLY)
-      ADD_TEST(NAME GMLS_Python_Convergence_Test_3d_Point_Reconstruction COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/Python_3D_Convergence.py")
+      ADD_TEST(NAME GMLS_Python_Convergence_Test_3d_Point_Reconstruction COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/Python_3D_Convergence.py" "--kokkos-threads=4")
       SET_TESTS_PROPERTIES(GMLS_Python_Convergence_Test_3d_Point_Reconstruction PROPERTIES LABELS "UnitTest;unit;python;kokkos" TIMEOUT 10)
 
       if (Compadre_USE_MATLAB)

--- a/examples/GMLS_Device.cpp
+++ b/examples/GMLS_Device.cpp
@@ -10,6 +10,7 @@
 #include <Compadre_GMLS.hpp>
 #include <Compadre_Evaluator.hpp>
 #include <Compadre_PointCloudSearch.hpp>
+#include <Compadre_KokkosParser.hpp>
 
 #include "GMLS_Tutorial.hpp"
 
@@ -33,13 +34,13 @@ MPI_Init(&argc, &args);
 #endif
 
 // initializes Kokkos with command line arguments given
-Kokkos::initialize(argc, args);
+auto kp = KokkosParser(argc, args, true);
 
 // becomes false if the computed solution not within the failure_threshold of the actual solution
 bool all_passed = true;
 
 // code block to reduce scope for all Kokkos View allocations
-// otherwise, Views may be deallocating when we call Kokkos::finalize() later
+// otherwise, Views may be deallocating when we call Kokkos finalize() later
 {
     
     // check if 5 arguments are given from the command line, the first being the program name
@@ -477,10 +478,10 @@ bool all_passed = true;
 
 
 } // end of code block to reduce scope, causing Kokkos View de-allocations
-// otherwise, Views may be deallocating when we call Kokkos::finalize() later
+// otherwise, Views may be deallocating when we call Kokkos finalize() later
 
 // finalize Kokkos and MPI (if available)
-Kokkos::finalize();
+kp.finalize();
 #ifdef COMPADRE_USE_MPI
 MPI_Finalize();
 #endif

--- a/examples/Python_3D_Convergence.py.in
+++ b/examples/Python_3D_Convergence.py.in
@@ -14,10 +14,10 @@ import scipy.spatial.kdtree as kdtree
 
 import argparse
 parser = argparse.ArgumentParser()
-parser.add_argument("--kokkos-threads", help="number of threads to use", default=1)
-parser.add_argument("--kokkos-numa", help="numa region to use", default=0)
-parser.add_argument("--kokkos-device", help="number of device to use", default=0)
-parser.add_argument("--kokkos-ngpus", help="number of total devices available", default=0)
+parser.add_argument("--kokkos-threads", help="number of threads to use", default=-1)
+parser.add_argument("--kokkos-numa", help="numa region to use", default=-1)
+parser.add_argument("--kokkos-device", help="number of device to use", default=-1)
+parser.add_argument("--kokkos-ngpus", help="number of total devices available", default=-1)
 args = parser.parse_args()
 
 # just for formatting

--- a/examples/Python_3D_Convergence.py.in
+++ b/examples/Python_3D_Convergence.py.in
@@ -14,7 +14,7 @@ import scipy.spatial.kdtree as kdtree
 
 import argparse
 parser = argparse.ArgumentParser()
-parser.add_argument("--kokkos-threads", help="number of threads to use", default=0)
+parser.add_argument("--kokkos-threads", help="number of threads to use", default=1)
 parser.add_argument("--kokkos-numa", help="numa region to use", default=0)
 parser.add_argument("--kokkos-device", help="number of device to use", default=0)
 parser.add_argument("--kokkos-ngpus", help="number of total devices available", default=0)
@@ -129,8 +129,9 @@ def test1(ND):
     
     return (l2_error, h1_seminorm_error)
 
-kokkos_obj=GMLS_Module.Kokkos_Python(int(args.kokkos_threads), int(args.kokkos_numa), int(args.kokkos_device), int(args.kokkos_ngpus), 
-                                        True) # print state after initializing 
+kokkos_obj=GMLS_Module.Kokkos_Python(int(args.kokkos_threads), int(args.kokkos_numa),
+                                     int(args.kokkos_device), int(args.kokkos_ngpus),
+                                     True) # print state after initializing
 
 # of points in each dimension to run the test over
 ND = [5, 10, 20, 40]

--- a/examples/Python_3D_Convergence.py.in
+++ b/examples/Python_3D_Convergence.py.in
@@ -12,6 +12,14 @@ import math
 import random
 import scipy.spatial.kdtree as kdtree
 
+import argparse
+parser = argparse.ArgumentParser()
+parser.add_argument("--kokkos-threads", help="number of threads to use", default=0)
+parser.add_argument("--kokkos-numa", help="numa region to use", default=0)
+parser.add_argument("--kokkos-device", help="number of device to use", default=0)
+parser.add_argument("--kokkos-ngpus", help="number of total devices available", default=0)
+args = parser.parse_args()
+
 # just for formatting
 class colors:
     HEADER = '\033[95m'
@@ -121,7 +129,8 @@ def test1(ND):
     
     return (l2_error, h1_seminorm_error)
 
-kokkos_obj=GMLS_Module.Kokkos_Python(2,0,0,0,False)
+kokkos_obj=GMLS_Module.Kokkos_Python(int(args.kokkos_threads), int(args.kokkos_numa), int(args.kokkos_device), int(args.kokkos_ngpus), 
+                                        True) # print state after initializing 
 
 # of points in each dimension to run the test over
 ND = [5, 10, 20, 40]

--- a/examples/Python_3D_Convergence.py.in
+++ b/examples/Python_3D_Convergence.py.in
@@ -121,7 +121,7 @@ def test1(ND):
     
     return (l2_error, h1_seminorm_error)
 
-GMLS_Module.initializeKokkos()
+kokkos_obj=GMLS_Module.Kokkos_Python(2,0,0,0,False)
 
 # of points in each dimension to run the test over
 ND = [5, 10, 20, 40]
@@ -147,4 +147,3 @@ print("\n" + colors.HEADER + "(h1-seminorm) Rates:" + colors.ENDC)
 for i in range(len(ND)-1):
     print(str(math.log(errors[i+1][1]/errors[i][1])/math.log(0.5)))
 print("\n")
-GMLS_Module.finalizeKokkos()

--- a/python/GMLS_Module.py.in
+++ b/python/GMLS_Module.py.in
@@ -95,6 +95,24 @@ except __builtin__.Exception:
         pass
     _newclass = 0
 
+class Kokkos_Python(_object):
+    __swig_setmethods__ = {}
+    __setattr__ = lambda self, name, value: _swig_setattr(self, Kokkos_Python, name, value)
+    __swig_getmethods__ = {}
+    __getattr__ = lambda self, name: _swig_getattr(self, Kokkos_Python, name)
+    __repr__ = _swig_repr
+
+    def __init__(self, num_threads=1, numa=1, device=0, ngpu=1, print_status=False):
+        this = _GMLS_Module.new_Kokkos_Python(num_threads, numa, device, ngpu, print_status)
+        try:
+            self.this.append(this)
+        except __builtin__.Exception:
+            self.this = this
+    __swig_destroy__ = _GMLS_Module.delete_Kokkos_Python
+    __del__ = lambda self: None
+Kokkos_Python_swigregister = _GMLS_Module.Kokkos_Python_swigregister
+Kokkos_Python_swigregister(Kokkos_Python)
+
 
 def initializeKokkos():
     return _GMLS_Module.initializeKokkos()

--- a/python/GMLS_Module_wrap.cxx
+++ b/python/GMLS_Module_wrap.cxx
@@ -3007,9 +3007,10 @@ SWIG_Python_NonDynamicSetAttr(PyObject *obj, PyObject *name, PyObject *value) {
 /* -------- TYPES TABLE (BEGIN) -------- */
 
 #define SWIGTYPE_p_GMLS_Python swig_types[0]
-#define SWIGTYPE_p_char swig_types[1]
-static swig_type_info *swig_types[3];
-static swig_module_info swig_module = {swig_types, 2, 0, 0, 0, 0};
+#define SWIGTYPE_p_Kokkos_Python swig_types[1]
+#define SWIGTYPE_p_char swig_types[2]
+static swig_type_info *swig_types[4];
+static swig_module_info swig_module = {swig_types, 3, 0, 0, 0, 0};
 #define SWIG_TypeQuery(name) SWIG_TypeQueryModule(&swig_module, &swig_module, name)
 #define SWIG_MangledTypeQuery(name) SWIG_MangledTypeQueryModule(&swig_module, &swig_module, name)
 
@@ -3278,6 +3279,20 @@ SWIG_AsVal_int (PyObject * obj, int *val)
 }
 
 
+SWIGINTERN int
+SWIG_AsVal_bool (PyObject *obj, bool *val)
+{
+  int r;
+  if (!PyBool_Check(obj))
+    return SWIG_ERROR;
+  r = PyObject_IsTrue(obj);
+  if (r == -1)
+    return SWIG_ERROR;
+  if (val) *val = r ? true : false;
+  return SWIG_OK;
+}
+
+
 SWIGINTERN swig_type_info*
 SWIG_pchar_descriptor(void)
 {
@@ -3435,20 +3450,6 @@ SWIG_AsPtr_std_string (PyObject * obj, std::string **val)
 }
 
 
-SWIGINTERN int
-SWIG_AsVal_bool (PyObject *obj, bool *val)
-{
-  int r;
-  if (!PyBool_Check(obj))
-    return SWIG_ERROR;
-  r = PyObject_IsTrue(obj);
-  if (r == -1)
-    return SWIG_ERROR;
-  if (val) *val = r ? true : false;
-  return SWIG_OK;
-}
-
-
 SWIGINTERNINLINE PyObject*
   SWIG_From_int  (int value)
 {
@@ -3458,6 +3459,442 @@ SWIGINTERNINLINE PyObject*
 #ifdef __cplusplus
 extern "C" {
 #endif
+SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_0(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  int arg2 ;
+  int arg3 ;
+  int arg4 ;
+  bool arg5 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  bool val5 ;
+  int ecode5 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  PyObject * obj4 = 0 ;
+  Kokkos_Python *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOOO:new_Kokkos_Python",&obj0,&obj1,&obj2,&obj3,&obj4)) SWIG_fail;
+  ecode1 = SWIG_AsVal_int(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "new_Kokkos_Python" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_Kokkos_Python" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  ecode3 = SWIG_AsVal_int(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_Kokkos_Python" "', argument " "3"" of type '" "int""'");
+  } 
+  arg3 = static_cast< int >(val3);
+  ecode4 = SWIG_AsVal_int(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_Kokkos_Python" "', argument " "4"" of type '" "int""'");
+  } 
+  arg4 = static_cast< int >(val4);
+  ecode5 = SWIG_AsVal_bool(obj4, &val5);
+  if (!SWIG_IsOK(ecode5)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode5), "in method '" "new_Kokkos_Python" "', argument " "5"" of type '" "bool""'");
+  } 
+  arg5 = static_cast< bool >(val5);
+  {
+    try {
+      result = (Kokkos_Python *)new Kokkos_Python(arg1,arg2,arg3,arg4,arg5);
+    } catch(std::exception &_e) {
+      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+    } catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_1(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  int arg2 ;
+  int arg3 ;
+  int arg4 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  int val4 ;
+  int ecode4 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  PyObject * obj3 = 0 ;
+  Kokkos_Python *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOOO:new_Kokkos_Python",&obj0,&obj1,&obj2,&obj3)) SWIG_fail;
+  ecode1 = SWIG_AsVal_int(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "new_Kokkos_Python" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_Kokkos_Python" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  ecode3 = SWIG_AsVal_int(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_Kokkos_Python" "', argument " "3"" of type '" "int""'");
+  } 
+  arg3 = static_cast< int >(val3);
+  ecode4 = SWIG_AsVal_int(obj3, &val4);
+  if (!SWIG_IsOK(ecode4)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode4), "in method '" "new_Kokkos_Python" "', argument " "4"" of type '" "int""'");
+  } 
+  arg4 = static_cast< int >(val4);
+  {
+    try {
+      result = (Kokkos_Python *)new Kokkos_Python(arg1,arg2,arg3,arg4);
+    } catch(std::exception &_e) {
+      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+    } catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_2(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  int arg2 ;
+  int arg3 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  int val3 ;
+  int ecode3 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  PyObject * obj2 = 0 ;
+  Kokkos_Python *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OOO:new_Kokkos_Python",&obj0,&obj1,&obj2)) SWIG_fail;
+  ecode1 = SWIG_AsVal_int(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "new_Kokkos_Python" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_Kokkos_Python" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  ecode3 = SWIG_AsVal_int(obj2, &val3);
+  if (!SWIG_IsOK(ecode3)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode3), "in method '" "new_Kokkos_Python" "', argument " "3"" of type '" "int""'");
+  } 
+  arg3 = static_cast< int >(val3);
+  {
+    try {
+      result = (Kokkos_Python *)new Kokkos_Python(arg1,arg2,arg3);
+    } catch(std::exception &_e) {
+      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+    } catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_3(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  int arg2 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  int val2 ;
+  int ecode2 = 0 ;
+  PyObject * obj0 = 0 ;
+  PyObject * obj1 = 0 ;
+  Kokkos_Python *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"OO:new_Kokkos_Python",&obj0,&obj1)) SWIG_fail;
+  ecode1 = SWIG_AsVal_int(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "new_Kokkos_Python" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  ecode2 = SWIG_AsVal_int(obj1, &val2);
+  if (!SWIG_IsOK(ecode2)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode2), "in method '" "new_Kokkos_Python" "', argument " "2"" of type '" "int""'");
+  } 
+  arg2 = static_cast< int >(val2);
+  {
+    try {
+      result = (Kokkos_Python *)new Kokkos_Python(arg1,arg2);
+    } catch(std::exception &_e) {
+      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+    } catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_4(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  int arg1 ;
+  int val1 ;
+  int ecode1 = 0 ;
+  PyObject * obj0 = 0 ;
+  Kokkos_Python *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:new_Kokkos_Python",&obj0)) SWIG_fail;
+  ecode1 = SWIG_AsVal_int(obj0, &val1);
+  if (!SWIG_IsOK(ecode1)) {
+    SWIG_exception_fail(SWIG_ArgError(ecode1), "in method '" "new_Kokkos_Python" "', argument " "1"" of type '" "int""'");
+  } 
+  arg1 = static_cast< int >(val1);
+  {
+    try {
+      result = (Kokkos_Python *)new Kokkos_Python(arg1);
+    } catch(std::exception &_e) {
+      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+    } catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_5(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  Kokkos_Python *result = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)":new_Kokkos_Python")) SWIG_fail;
+  {
+    try {
+      result = (Kokkos_Python *)new Kokkos_Python();
+    } catch(std::exception &_e) {
+      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+    } catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }
+  }
+  resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *_wrap_new_Kokkos_Python(PyObject *self, PyObject *args) {
+  Py_ssize_t argc;
+  PyObject *argv[6] = {
+    0
+  };
+  Py_ssize_t ii;
+  
+  if (!PyTuple_Check(args)) SWIG_fail;
+  argc = args ? PyObject_Length(args) : 0;
+  for (ii = 0; (ii < 5) && (ii < argc); ii++) {
+    argv[ii] = PyTuple_GET_ITEM(args,ii);
+  }
+  if (argc == 0) {
+    return _wrap_new_Kokkos_Python__SWIG_5(self, args);
+  }
+  if (argc == 1) {
+    int _v;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      return _wrap_new_Kokkos_Python__SWIG_4(self, args);
+    }
+  }
+  if (argc == 2) {
+    int _v;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        return _wrap_new_Kokkos_Python__SWIG_3(self, args);
+      }
+    }
+  }
+  if (argc == 3) {
+    int _v;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          return _wrap_new_Kokkos_Python__SWIG_2(self, args);
+        }
+      }
+    }
+  }
+  if (argc == 4) {
+    int _v;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_int(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            return _wrap_new_Kokkos_Python__SWIG_1(self, args);
+          }
+        }
+      }
+    }
+  }
+  if (argc == 5) {
+    int _v;
+    {
+      int res = SWIG_AsVal_int(argv[0], NULL);
+      _v = SWIG_CheckState(res);
+    }
+    if (_v) {
+      {
+        int res = SWIG_AsVal_int(argv[1], NULL);
+        _v = SWIG_CheckState(res);
+      }
+      if (_v) {
+        {
+          int res = SWIG_AsVal_int(argv[2], NULL);
+          _v = SWIG_CheckState(res);
+        }
+        if (_v) {
+          {
+            int res = SWIG_AsVal_int(argv[3], NULL);
+            _v = SWIG_CheckState(res);
+          }
+          if (_v) {
+            {
+              int res = SWIG_AsVal_bool(argv[4], NULL);
+              _v = SWIG_CheckState(res);
+            }
+            if (_v) {
+              return _wrap_new_Kokkos_Python__SWIG_0(self, args);
+            }
+          }
+        }
+      }
+    }
+  }
+  
+fail:
+  SWIG_SetErrorMsg(PyExc_NotImplementedError,"Wrong number or type of arguments for overloaded function 'new_Kokkos_Python'.\n"
+    "  Possible C/C++ prototypes are:\n"
+    "    Kokkos_Python::Kokkos_Python(int,int,int,int,bool)\n"
+    "    Kokkos_Python::Kokkos_Python(int,int,int,int)\n"
+    "    Kokkos_Python::Kokkos_Python(int,int,int)\n"
+    "    Kokkos_Python::Kokkos_Python(int,int)\n"
+    "    Kokkos_Python::Kokkos_Python(int)\n"
+    "    Kokkos_Python::Kokkos_Python()\n");
+  return 0;
+}
+
+
+SWIGINTERN PyObject *_wrap_delete_Kokkos_Python(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *resultobj = 0;
+  Kokkos_Python *arg1 = (Kokkos_Python *) 0 ;
+  void *argp1 = 0 ;
+  int res1 = 0 ;
+  PyObject * obj0 = 0 ;
+  
+  if (!PyArg_ParseTuple(args,(char *)"O:delete_Kokkos_Python",&obj0)) SWIG_fail;
+  res1 = SWIG_ConvertPtr(obj0, &argp1,SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_DISOWN |  0 );
+  if (!SWIG_IsOK(res1)) {
+    SWIG_exception_fail(SWIG_ArgError(res1), "in method '" "delete_Kokkos_Python" "', argument " "1"" of type '" "Kokkos_Python *""'"); 
+  }
+  arg1 = reinterpret_cast< Kokkos_Python * >(argp1);
+  {
+    try {
+      delete arg1;
+    } catch(std::exception &_e) {
+      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+    } catch (...) {
+      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+    }
+  }
+  resultobj = SWIG_Py_Void();
+  return resultobj;
+fail:
+  return NULL;
+}
+
+
+SWIGINTERN PyObject *Kokkos_Python_swigregister(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
+  PyObject *obj;
+  if (!PyArg_ParseTuple(args,(char *)"O:swigregister", &obj)) return NULL;
+  SWIG_TypeNewClientData(SWIGTYPE_p_Kokkos_Python, SWIG_NewClientData(obj));
+  return SWIG_Py_Void();
+}
+
 SWIGINTERN PyObject *_wrap_initializeKokkos(PyObject *SWIGUNUSEDPARM(self), PyObject *args) {
   PyObject *resultobj = 0;
   
@@ -4797,6 +5234,9 @@ fail:
 
 static PyMethodDef SwigMethods[] = {
 	 { (char *)"SWIG_PyInstanceMethod_New", (PyCFunction)SWIG_PyInstanceMethod_New, METH_O, NULL},
+	 { (char *)"new_Kokkos_Python", _wrap_new_Kokkos_Python, METH_VARARGS, NULL},
+	 { (char *)"delete_Kokkos_Python", _wrap_delete_Kokkos_Python, METH_VARARGS, NULL},
+	 { (char *)"Kokkos_Python_swigregister", Kokkos_Python_swigregister, METH_VARARGS, NULL},
 	 { (char *)"initializeKokkos", _wrap_initializeKokkos, METH_VARARGS, NULL},
 	 { (char *)"finalizeKokkos", _wrap_finalizeKokkos, METH_VARARGS, NULL},
 	 { (char *)"new_GMLS_Python", _wrap_new_GMLS_Python, METH_VARARGS, NULL},
@@ -4826,18 +5266,22 @@ static PyMethodDef SwigMethods[] = {
 /* -------- TYPE CONVERSION AND EQUIVALENCE RULES (BEGIN) -------- */
 
 static swig_type_info _swigt__p_GMLS_Python = {"_p_GMLS_Python", "GMLS_Python *", 0, 0, (void*)0, 0};
+static swig_type_info _swigt__p_Kokkos_Python = {"_p_Kokkos_Python", "Kokkos_Python *", 0, 0, (void*)0, 0};
 static swig_type_info _swigt__p_char = {"_p_char", "char *", 0, 0, (void*)0, 0};
 
 static swig_type_info *swig_type_initial[] = {
   &_swigt__p_GMLS_Python,
+  &_swigt__p_Kokkos_Python,
   &_swigt__p_char,
 };
 
 static swig_cast_info _swigc__p_GMLS_Python[] = {  {&_swigt__p_GMLS_Python, 0, 0, 0},{0, 0, 0, 0}};
+static swig_cast_info _swigc__p_Kokkos_Python[] = {  {&_swigt__p_Kokkos_Python, 0, 0, 0},{0, 0, 0, 0}};
 static swig_cast_info _swigc__p_char[] = {  {&_swigt__p_char, 0, 0, 0},{0, 0, 0, 0}};
 
 static swig_cast_info *swig_cast_initial[] = {
   _swigc__p_GMLS_Python,
+  _swigc__p_Kokkos_Python,
   _swigc__p_char,
 };
 

--- a/python/GMLS_Python.hpp
+++ b/python/GMLS_Python.hpp
@@ -4,6 +4,7 @@
 #include <Compadre_GMLS.hpp>
 #include <Compadre_Evaluator.hpp>
 #include <Compadre_PointCloudSearch.hpp>
+#include <Compadre_KokkosParser.hpp>
 #include <Kokkos_Core.hpp>
 #include <Kokkos_Random.hpp>
 #include <Python.h>
@@ -13,6 +14,29 @@
 #ifdef COMPADRE_USE_MPI
     #include <mpi.h>
 #endif
+
+class Kokkos_Python {
+
+private:
+
+    Compadre::KokkosParser* kokkos_parser;
+
+public:
+
+    Kokkos_Python(int num_threads = 1, int numa = 1, int device = 0, int ngpu = 1, bool print_status = false) {
+
+        kokkos_parser = new Compadre::KokkosParser(num_threads, numa, device, ngpu, print_status);
+
+    }
+
+    ~Kokkos_Python() { 
+
+        kokkos_parser->finalize();
+        delete kokkos_parser;
+
+    }
+
+};
 
 void initializeKokkos() {
     Kokkos::initialize();

--- a/python/GMLS_Python.hpp
+++ b/python/GMLS_Python.hpp
@@ -24,16 +24,12 @@ private:
 public:
 
     Kokkos_Python(int num_threads = 1, int numa = 1, int device = 0, int ngpu = 1, bool print_status = false) {
-
         kokkos_parser = new Compadre::KokkosParser(num_threads, numa, device, ngpu, print_status);
-
     }
 
     ~Kokkos_Python() { 
-
-        kokkos_parser->finalize();
+        kokkos_parser->finalize(false);
         delete kokkos_parser;
-
     }
 
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(COMPADRE_HEADERS
   Compadre_GMLS_Basis.hpp
   Compadre_GMLS_Quadrature.hpp
   Compadre_GMLS_Targets.hpp
+  Compadre_KokkosParser.hpp
   Compadre_LinearAlgebra_Declarations.hpp
   Compadre_LinearAlgebra_Definitions.hpp
   Compadre_Misc.hpp
@@ -21,6 +22,7 @@ set(COMPADRE_HEADERS
 
 set(COMPADRE_SOURCES
   Compadre_GMLS.cpp
+  Compadre_KokkosParser.cpp
   Compadre_LinearAlgebra.cpp
   )
 

--- a/src/Compadre_KokkosParser.cpp
+++ b/src/Compadre_KokkosParser.cpp
@@ -1,0 +1,132 @@
+#include "Compadre_KokkosParser.hpp"
+
+using namespace Compadre;
+
+// for command line arguments, pass them directly in to Kokkos
+KokkosParser::KokkosParser(int narg, char **arg, bool print_status) :
+        _num_threads(-1), _numa(-1), _device(-1), _ngpu(-1) {
+
+    // determine if Kokkos is already initialized
+    // if it has been, get the parameters needed from it
+    bool preinitialized = Kokkos::is_initialized();
+
+    if (print_status && preinitialized) {
+        printf("Kokkos already initialized.");
+        // could be improved by retrieving the parameters Kokkos was initialized with
+        // get parameters
+        // set parameters
+        // call status
+    }
+
+    if (!preinitialized) {
+        Kokkos::initialize(narg, arg);
+        _called_initialize = true;
+        // get parameters
+        // set parameters
+        if (print_status) {
+            // call status
+            this->status();
+        }
+    }
+  
+    // MPI 
+    //char *str;
+    //if ((str = getenv("SLURM_LOCALID"))) {
+    //  int local_rank = atoi(str);
+    //  device = local_rank % ngpu;
+    //  if (device >= skip_gpu) device++;
+    //}
+    //if ((str = getenv("MV2_COMM_WORLD_LOCAL_RANK"))) {
+    //  int local_rank = atoi(str);
+    //  device = local_rank % ngpu;
+    //  if (device >= skip_gpu) device++;
+    //}
+    //if ((str = getenv("OMPI_COMM_WORLD_LOCAL_RANK"))) {
+    //  int local_rank = atoi(str);
+    //  device = local_rank % ngpu;
+    //  if (device >= skip_gpu) device++;
+    //}
+}
+
+KokkosParser::KokkosParser(int num_threads, int numa, int device, int ngpu, bool print_status) :
+        _num_threads(num_threads), _numa(numa), _device(device), _ngpu(ngpu) {
+
+#ifdef KOKKOS_HAVE_CUDA
+  // only written for handling one gpu
+  compadre_assert_release((ngpu == 1) && "Only one GPU supported at this time.");
+#else
+  ngpu = 0;
+#endif
+//#ifdef KOKKOS_HAVE_CUDA
+//  compadre_assert_release((ngpu > 0) && "Kokkos has been compiled for CUDA but no GPUs are requested"); 
+//#endif
+
+    // returns 1 if we initialized
+    int _called_initialize = this->initialize();
+  
+    if (print_status && _called_initialize==1) {
+        this->status();
+    } else if (print_status && _called_initialize==0) {
+        printf("Kokkos already initialized.");
+        // could be improved by retrieving the parameters Kokkos was initialized with
+        // get parameters
+        // set parameters
+        // call status
+    } else if (print_status) {
+        printf("Kokkos failed to initialize.");
+    }
+
+}
+
+Kokkos::InitArguments KokkosParser::createInitArguments() const {
+  Kokkos::InitArguments args;
+  args.num_threads = _num_threads;
+  args.num_numa = _numa;
+  args.device_id = _device;
+  return args;
+}
+
+int KokkosParser::initialize() {
+    // return codes:
+    // 1  - success
+    // 0  - already initialized
+    // -1 - failed for some other reason
+
+    // determine if Kokkos is already initialized
+    // if it has been, get the parameters needed from it
+    bool preinitialized = Kokkos::is_initialized();
+    
+    // if already initialized, return
+    if (preinitialized) {
+        return 0;
+    } else {
+        try {
+            auto our_args = this->createInitArguments();
+            Kokkos::initialize(our_args);
+            return 1;
+        } catch (...) {
+            return -1;
+        }
+    }
+}
+
+int KokkosParser::finalize(bool hard_finalize) {
+    if (hard_finalize || _called_initialize) {
+        try {
+            Kokkos::finalize();
+            return 1;
+        } catch (...) {
+            return 0;
+        }
+    } else {
+        return 1;
+    }
+}
+
+void KokkosParser::status() const {
+#ifdef KOKKOS_HAVE_CUDA
+  printf("KOKKOS mode is enabled on GPU with nthreads: %d,  numa: %d, device_id: %d\n", getNumberOfThreads(), getNuma(), getDeviceID());
+#else
+  printf("KOKKOS mode is enabled on CPU with nthreads: %d,  numa: %d\n", getNumberOfThreads(), getNuma());
+#endif
+}

--- a/src/Compadre_KokkosParser.cpp
+++ b/src/Compadre_KokkosParser.cpp
@@ -92,10 +92,11 @@ Kokkos::InitArguments KokkosParser::createInitArguments() const {
 void KokkosParser::retrievePreviouslyInstantiatedKokkosInitArguments() {
 // NUMA parts are not tested, and only work for 1 numa region
 #ifdef KOKKOS_HAVE_CUDA
-    _device = Kokkos::Cuda::cuda_device();
+    //auto cuda_space = Kokkos::DefaultExecutionSpace;
+    _device = 0;//cuda_space.cuda_device();
     _ngpu = 1;
     _numa = 0;
-    _num_threads = 1;
+    _num_threads = 0;
 #else
     _device = 0;
     _ngpu = 0;

--- a/src/Compadre_KokkosParser.cpp
+++ b/src/Compadre_KokkosParser.cpp
@@ -50,12 +50,12 @@ KokkosParser::KokkosParser(int narg, char **arg, bool print_status) :
 KokkosParser::KokkosParser(int num_threads, int numa, int device, int ngpu, bool print_status) :
         _num_threads(num_threads), _numa(numa), _device(device), _ngpu(ngpu) {
 
-#ifdef KOKKOS_HAVE_CUDA
-  // only written for handling one gpu
-  compadre_assert_release((ngpu == 1) && "Only one GPU supported at this time.");
-#else
-  ngpu = 0;
-#endif
+//#ifdef KOKKOS_HAVE_CUDA
+//  // only written for handling one gpu
+//  compadre_assert_release((ngpu == 1) && "Only one GPU supported at this time.");
+//#else
+//  ngpu = 0;
+//#endif
 //#ifdef KOKKOS_HAVE_CUDA
 //  compadre_assert_release((ngpu > 0) && "Kokkos has been compiled for CUDA but no GPUs are requested"); 
 //#endif

--- a/src/Compadre_KokkosParser.cpp
+++ b/src/Compadre_KokkosParser.cpp
@@ -64,6 +64,10 @@ KokkosParser::KokkosParser(int num_threads, int numa, int device, int ngpu, bool
     _called_initialize = this->initialize();
   
     if (print_status && _called_initialize==1) {
+        printf("KOKKOS attempted initialization using settings:\n");
+        this->status();
+        retrievePreviouslyInstantiatedKokkosInitArguments();
+        printf("KOKKOS recalculated and initiatized using settings:\n");
         this->status();
     } else if (_called_initialize==0) {
         // could be improved by retrieving the parameters Kokkos was initialized with

--- a/src/Compadre_KokkosParser.cpp
+++ b/src/Compadre_KokkosParser.cpp
@@ -61,7 +61,7 @@ KokkosParser::KokkosParser(int num_threads, int numa, int device, int ngpu, bool
 //#endif
 
     // returns 1 if we initialized
-    int _called_initialize = this->initialize();
+    _called_initialize = this->initialize();
   
     if (print_status && _called_initialize==1) {
         this->status();
@@ -138,7 +138,7 @@ int KokkosParser::initialize() {
 }
 
 int KokkosParser::finalize(bool hard_finalize) {
-    if (hard_finalize || _called_initialize) {
+    if (hard_finalize || _called_initialize==1) {
         try {
             Kokkos::finalize();
             _called_initialize = 0; // reset since we finalized

--- a/src/Compadre_KokkosParser.cpp
+++ b/src/Compadre_KokkosParser.cpp
@@ -131,6 +131,9 @@ int KokkosParser::initialize() {
             auto our_args = this->createInitArguments();
             Kokkos::initialize(our_args);
             return 1;
+        } catch (const std::exception& e) {
+            std::cout << e.what() << std::endl;
+            throw e;
         } catch (...) {
             return -1;
         }

--- a/src/Compadre_KokkosParser.hpp
+++ b/src/Compadre_KokkosParser.hpp
@@ -58,8 +58,9 @@ public:
   // prints status
   void status() const;
 
-//private:
-//  KokkosParser(const KokkosParser &) {};     // prohibit using the copy constructor
+  // prohibit using the assignment constructor
+  KokkosParser& operator=( const KokkosParser& ) = delete;
+  //KokkosParser( const KokkosParser& ) = delete;
 
 };
 

--- a/src/Compadre_KokkosParser.hpp
+++ b/src/Compadre_KokkosParser.hpp
@@ -1,0 +1,60 @@
+#ifndef _COMPADRE_KOKKOSPARSER_HPP_
+#define _COMPADRE_KOKKOSPARSER_HPP_
+
+#include <Compadre_Typedefs.hpp>
+
+namespace Compadre {
+
+/*! \class KokkosParser
+    \brief Class handling Kokkos command line arguments and returning parameters.
+*/
+class KokkosParser {
+
+private:
+
+  int _num_threads;
+  int _numa;
+  int _device;
+  int _ngpu;
+
+  bool _called_initialize;
+
+public:
+
+  // call with command line arguments
+  KokkosParser(int argc, char* args[], bool print_status = false);
+
+  // call with integer arguments
+  KokkosParser(int num_threads = 1, int numa = 1, int device = 0, int ngpu = 1, bool print_status = false);
+
+  // destructor
+  ~KokkosParser() {};
+
+  // initialize Kokkos if not already initialized using
+  // arguments provided at object construction
+  int initialize();
+  
+  // finalize Kokkos if this object initialized it
+  // or if hard_finalize is true
+  int finalize(bool hard_finalize = false);
+
+  // use this object's state to create a Kokkos object used
+  // later for initialization
+  Kokkos::InitArguments createInitArguments() const;
+
+  int getNumberOfThreads() const { return _num_threads; }
+  int getNuma() const { return _numa; }
+  int getDeviceID() const { return _device; }
+  int getNumberOfGPUs() const { return _ngpu; }
+
+  // prints status
+  void status() const;
+
+//private:
+//  KokkosParser(const KokkosParser &) {};     // prohibit using the copy constructor
+
+};
+
+} // Compadre
+
+#endif

--- a/src/Compadre_KokkosParser.hpp
+++ b/src/Compadre_KokkosParser.hpp
@@ -28,7 +28,12 @@ public:
   KokkosParser(int num_threads = 1, int numa = 1, int device = 0, int ngpu = 1, bool print_status = false);
 
   // destructor
-  ~KokkosParser() {};
+  ~KokkosParser() {
+      // clean-up Kokkos
+      if (_called_initialize) {
+          this->finalize();
+      } 
+  };
 
   // initialize Kokkos if not already initialized using
   // arguments provided at object construction
@@ -37,6 +42,9 @@ public:
   // finalize Kokkos if this object initialized it
   // or if hard_finalize is true
   int finalize(bool hard_finalize = false);
+
+  // retrieve arguments from a previous initialized Kokkos state
+  void retrievePreviouslyInstantiatedKokkosInitArguments();
 
   // use this object's state to create a Kokkos object used
   // later for initialization

--- a/src/Compadre_KokkosParser.hpp
+++ b/src/Compadre_KokkosParser.hpp
@@ -25,7 +25,7 @@ public:
   KokkosParser(int argc, char* args[], bool print_status = false);
 
   // call with integer arguments
-  KokkosParser(int num_threads = 1, int numa = 1, int device = 0, int ngpu = 1, bool print_status = false);
+  KokkosParser(int num_threads = -1, int numa = -1, int device = -1, int ngpu = -1, bool print_status = false);
 
   // destructor
   ~KokkosParser() {


### PR DESCRIPTION
Added a KokkosParser class that acts as a scope-guard for Kokkos initialization.
This takes the place of calling Kokkos::initialize() and Kokkos::finalize(), with the instantiation of KokkosParser objects calling initializing, and calling finalizing automatically upon object destruction.

Added access to this object with a Kokkos_Python object for the Python interface.
It is now possible to initialize Kokkos through the Python interface, calling for a particular GPU device.