### PR TITLE
Add curl and curl-curl operator acting on div-free vector fields

### DIFF
--- a/examples/GMLS_DivergenceFree.cpp
+++ b/examples/GMLS_DivergenceFree.cpp
@@ -178,7 +178,7 @@ bool all_passed = true;
             source_coords_device.extent(0), dimension);
     Kokkos::View<double**, Kokkos::DefaultExecutionSpace> curl_vector_sampling_data_device("samples of curl of true vector solution",
             source_coords_device.extent(0), dimension);
-    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> curlcurl_vector_sampling_data_device("samples of curl of true vector solution",
+    Kokkos::View<double**, Kokkos::DefaultExecutionSpace> curlcurl_vector_sampling_data_device("samples of curl curl of true vector solution",
             source_coords_device.extent(0), dimension);
 
     Kokkos::parallel_for("Sampling Manufactured Solutions", Kokkos::RangePolicy<Kokkos::DefaultExecutionSpace>
@@ -412,17 +412,17 @@ bool all_passed = true;
         // check curl of vector evaluation
         if(std::abs(actual_curl_vector[0] - GMLS_Curl_DivFree_VectorX) > failure_tolerance) {
             all_passed = false;
-            std::cout << i << " Failed VectorX by: " << std::abs(actual_curl_vector[0] - GMLS_Curl_DivFree_VectorX) << std::endl;
+            std::cout << i << " Failed curl VectorX by: " << std::abs(actual_curl_vector[0] - GMLS_Curl_DivFree_VectorX) << std::endl;
             if (dimension>1) {
                 if(std::abs(actual_curl_vector[1] - GMLS_Curl_DivFree_VectorY) > failure_tolerance) {
                     all_passed = false;
-                    std::cout << i << " Failed VectorY by: " << std::abs(actual_curl_vector[1] - GMLS_Curl_DivFree_VectorY) << std::endl;
+                    std::cout << i << " Failed curl VectorY by: " << std::abs(actual_curl_vector[1] - GMLS_Curl_DivFree_VectorY) << std::endl;
                 }
             }
             if (dimension>2) {
                 if(std::abs(actual_curl_vector[2] - GMLS_Curl_DivFree_VectorZ) > failure_tolerance) {
                     all_passed = false;
-                    std::cout << i << " Failed VectorZ by: " << std::abs(actual_curl_vector[2] - GMLS_Curl_DivFree_VectorZ) << std::endl;
+                    std::cout << i << " Failed curl VectorZ by: " << std::abs(actual_curl_vector[2] - GMLS_Curl_DivFree_VectorZ) << std::endl;
                 }
             }
         }
@@ -430,11 +430,11 @@ bool all_passed = true;
         // check curlcurl curlcurl of vector evaluation
         if(std::abs(actual_curlcurl_vector[0] - GMLS_CurlCurl_DivFree_VectorX) > failure_tolerance) {
             all_passed = false;
-            std::cout << i << " Failed VectorX by: " << std::abs(actual_curlcurl_vector[0] - GMLS_CurlCurl_DivFree_VectorX) << std::endl;
+            std::cout << i << " Failed curl curl VectorX by: " << std::abs(actual_curlcurl_vector[0] - GMLS_CurlCurl_DivFree_VectorX) << std::endl;
             if (dimension>1) {
                 if(std::abs(actual_curlcurl_vector[1] - GMLS_CurlCurl_DivFree_VectorY) > failure_tolerance) {
                     all_passed = false;
-                    std::cout << i << " Failed VectorY by: " << std::abs(actual_curlcurl_vector[1] - GMLS_CurlCurl_DivFree_VectorY) << std::endl;
+                    std::cout << i << " Failed curl curl VectorY by: " << std::abs(actual_curlcurl_vector[1] - GMLS_CurlCurl_DivFree_VectorY) << std::endl;
                 }
             }
             if (dimension>2) {

--- a/examples/GMLS_DivergenceFree.cpp
+++ b/examples/GMLS_DivergenceFree.cpp
@@ -188,8 +188,8 @@ bool all_passed = true;
 
         // data for targets with vector input
         for (int j=0; j<dimension; ++j) {
-            vector_sampling_data_device(i, j) = curlTestSolution(xval, yval, zval, j, dimension);
-            curl_vector_sampling_data_device(i, j) = curlcurlTestSolution(xval, yval, zval, j, dimension);
+            vector_sampling_data_device(i, j) = divfreeTestSolution(xval, yval, zval, j, dimension);
+            curl_vector_sampling_data_device(i, j) = curldivfreeTestSolution(xval, yval, zval, j, dimension);
         }
     });
 
@@ -347,11 +347,11 @@ bool all_passed = true;
         // evaluation of vector exact solutions
         double actual_vector[3] = {0, 0, 0};
         if (dimension>=1) {
-            actual_vector[0] = curlTestSolution(xval, yval, zval, 0, dimension);
+            actual_vector[0] = divfreeTestSolution(xval, yval, zval, 0, dimension);
             if (dimension>=2) {
-                actual_vector[1] = curlTestSolution(xval, yval, zval, 1, dimension);
+                actual_vector[1] = divfreeTestSolution(xval, yval, zval, 1, dimension);
                 if (dimension==3) {
-                    actual_vector[2] = curlTestSolution(xval, yval, zval, 2, dimension);
+                    actual_vector[2] = divfreeTestSolution(xval, yval, zval, 2, dimension);
                 }
             }
         }
@@ -359,11 +359,11 @@ bool all_passed = true;
         // evaluation of vector exact solutions
         double actual_curl_vector[3] = {0, 0, 0};
         if (dimension>=1) {
-            actual_curl_vector[0] = curlcurlTestSolution(xval, yval, zval, 0, dimension);
+            actual_curl_vector[0] = curldivfreeTestSolution(xval, yval, zval, 0, dimension);
             if (dimension>=2) {
-                actual_curl_vector[1] = curlcurlTestSolution(xval, yval, zval, 1, dimension);
+                actual_curl_vector[1] = curldivfreeTestSolution(xval, yval, zval, 1, dimension);
                 if (dimension==3) {
-                    actual_curl_vector[2] = curlcurlTestSolution(xval, yval, zval, 2, dimension);
+                    actual_curl_vector[2] = curldivfreeTestSolution(xval, yval, zval, 2, dimension);
                 }
             }
         }

--- a/examples/GMLS_DivergenceFree.cpp
+++ b/examples/GMLS_DivergenceFree.cpp
@@ -440,7 +440,7 @@ bool all_passed = true;
             if (dimension>2) {
                 if(std::abs(actual_curlcurl_vector[2] - GMLS_CurlCurl_DivFree_VectorZ) > failure_tolerance) {
                     all_passed = false;
-                    std::cout << i << " Failed VectorZ by: " << std::abs(actual_curlcurl_vector[2] - GMLS_CurlCurl_DivFree_VectorZ) << std::endl;
+                    std::cout << i << " Failed curl curl VectorZ by: " << std::abs(actual_curlcurl_vector[2] - GMLS_CurlCurl_DivFree_VectorZ) << std::endl;
                 }
             }
         }

--- a/examples/GMLS_Tutorial.hpp
+++ b/examples/GMLS_Tutorial.hpp
@@ -198,16 +198,50 @@ double curlTestSolution(double x, double y, double z, int component, int dimensi
 }
 
 KOKKOS_INLINE_FUNCTION
-double curlcurlTestSolution(double x, double y, double z, int component, int dimension) {
+double divfreeTestSolution(double x, double y, double z, int component, int dimension) {
     if (dimension==3) {
         // returns curl of divergenceTestSamples
         switch (component) {
         case 0:
-            return 3.0*y;
+            return 6.0*x*x*y - 9.0*x*y + 7.0*x*z*z + 6.0*y*y*z;
         case 1:
-            return 3.0*x;
+            return 10.0*x*x*z - 7.0*y*z*z - 6.0*x*y*y;
         default:
-            return 0.0;
+            return -2.0*x*x*x + 9.0*x*y*y + 9.0*y*z;
+        }
+    } else {
+        return 0;
+    }
+}
+
+KOKKOS_INLINE_FUNCTION
+double curldivfreeTestSolution(double x, double y, double z, int component, int dimension) {
+    if (dimension==3) {
+        // returns curl of divergenceTestSamples
+        switch (component) {
+        case 0:
+            return -10.0*x*x + 18.0*x*y + 14.0*y*z + 9.0*z;
+        case 1:
+            return 6.0*x*x + 14.0*x*z - 3.0*y*y;
+        default:
+            return -6.0*x*x + 20.0*x*z + 9.0*x - 6.0*y*y + 12.0*y*z;
+        }
+    } else {
+        return 0;
+    }
+}
+
+KOKKOS_INLINE_FUNCTION
+double curlcurldivfreeTestSolution(double x, double y, double z, int component, int dimension) {
+    if (dimension==3) {
+        // returns curl of divergenceTestSamples
+        switch (component) {
+        case 0:
+            return -14.0*x - 12.0*y - 12.0*z;
+        case 1:
+            return 12.0*x + 14.0*y - 20.0*z;
+        default:
+            return -6.0*x;
         }
     } else {
         return 0;

--- a/examples/GMLS_Tutorial.hpp
+++ b/examples/GMLS_Tutorial.hpp
@@ -197,6 +197,22 @@ double curlTestSolution(double x, double y, double z, int component, int dimensi
     }
 }
 
+KOKKOS_INLINE_FUNCTION
+double curlcurlTestSolution(double x, double y, double z, int component, int dimension) {
+    if (dimension==3) {
+        // returns curl of divergenceTestSamples
+        switch (component) {
+        case 0:
+            return 3.0*y;
+        case 1:
+            return 3.0*x;
+        default:
+            return 0.0;
+        }
+    } else {
+        return 0;
+    }
+}
 
 /** Standard GMLS Example 
  *

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -623,7 +623,36 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
                             }
                         }
                     }
-              });
+                });
+            } else if (_operations(i) == TargetOperation::CurlCurlOfVectorPointEvaluation) {
+                Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
+                    for (int m0=0; m0<_sampling_multiplier; ++m0) { // input components
+                        for (int m1=0; m1<_sampling_multiplier; ++m1) { // output components
+                            int offset = getTargetOffsetIndexDevice(i, m0 /*in*/, m1 /*out*/, 0 /*no additional*/);
+                            switch (m1) {
+                                // manually compute the output components
+                                case 0:
+                                    // output component 0
+                                    P_target_row(offset, 11) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    P_target_row(offset, 12) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    P_target_row(offset, 20) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    break;
+                                case 1:
+                                    // output component 1
+                                    P_target_row(offset, 14) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    P_target_row(offset, 15) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    P_target_row(offset, 23) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    break;
+                                default:
+                                    // output component 2
+                                    P_target_row(offset, 17) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    P_target_row(offset, 18) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    P_target_row(offset, 25) = -2.0*std::pow(_epsilons(target_index), -2);
+                                    break;
+                            }
+                        }
+                    }
+                });
             }
             additional_evaluation_sites_handled = false; // additional non-target site evaluations handled
         } else {

--- a/src/Compadre_Operators.hpp
+++ b/src/Compadre_Operators.hpp
@@ -26,6 +26,8 @@ namespace Compadre {
         DivergenceOfVectorPointEvaluation,
         //! Point evaluation of the curl of a vector (results in a vector)
         CurlOfVectorPointEvaluation,
+        //! Point evaluation of the curl of a curl of a vector (results in a vector)
+        CurlCurlOfVectorPointEvaluation,
         //! Point evaluation of the partial with respect to x of a scalar
         PartialXOfScalarPointEvaluation,
         //! Point evaluation of the partial with respect to y of a scalar
@@ -38,7 +40,7 @@ namespace Compadre {
         //! Point evaluation of Gaussian curvature
         GaussianCurvaturePointEvaluation,
         //! Should be the total count of all available target functionals
-        COUNT=13,
+        COUNT=14,
     };
 
     //! Rank of target functional output for each TargetOperation 
@@ -53,6 +55,7 @@ namespace Compadre {
         2, ///< GradientOfVectorPointEvaluation
         0, ///< DivergenceOfVectorPointEvaluation
         1, ///< CurlOfVectorPointEvaluation
+        1, ///< CurlCurlOfVectorPointEvaluation
         0, ///< PartialXOfScalarPointEvaluation
         0, ///< PartialYOfScalarPointEvaluation
         0, ///< PartialZOfScalarPointEvaluation


### PR DESCRIPTION
Add curl and curl operators acting on div-free vector fields. Changes include:

1. Define new `enum` for operator inside `Compadre_Operators.hpp`
2. Add the evaluation of basis on curl and curl-curl operators inside `Compadre_GMLS_Targets.hpp`.
3. Add unit tests for these operators inside `examples/GMLS_DivergenceFree.cpp`.