### PR TITLE
Added extreme debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ bob_begin_package()
 
 # Set to OFF for significantly faster performance and ON for error tracking
 bob_option(Compadre_DEBUG "Run Compadre Toolkit in DEBUG mode" ON)
+bob_option(Compadre_EXTREME_DEBUG "Run Compadre Toolkit in EXTREME DEBUG mode" OFF)
 
 # RPATH related settings
 # https://gitlab.kitware.com/cmake/community/wikis/doc/cmake/RPATH-handling
@@ -639,6 +640,7 @@ set(Compadre_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 
 set(Compadre_KEY_BOOLS
     Compadre_DEBUG
+    Compadre_EXTREME_DEBUG
     Compadre_USE_CUDA
     Compadre_USE_KokkosCore
     Compadre_USE_LAPACK

--- a/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
+++ b/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
@@ -29,18 +29,18 @@ void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vec
 
                                 talpha_ij += P_target_row(offset_index_jmke, l)*Q(i+m*this->getNNeighbors(target_index), l);
 
-                                compadre_kernel_assert_debug(P_target_row(offset_index_jmke, l)==P_target_row(offset_index_jmke, l) 
+                                compadre_kernel_assert_extreme_debug(P_target_row(offset_index_jmke, l)==P_target_row(offset_index_jmke, l) 
                                         && "NaN in P_target_row matrix.");
-                                compadre_kernel_assert_debug(Q(i+m*this->getNNeighbors(target_index), l)==Q(i+m*this->getNNeighbors(target_index), l)
+                                compadre_kernel_assert_extreme_debug(Q(i+m*this->getNNeighbors(target_index), l)==Q(i+m*this->getNNeighbors(target_index), l)
                                         && "NaN in Q coefficient matrix.");
 
                             } else if (_sampling_multiplier == 1) {
 
                                 talpha_ij += P_target_row(offset_index_jmke, l)*Q(i, l);
 
-                                compadre_kernel_assert_debug(P_target_row(offset_index_jmke, l)==P_target_row(offset_index_jmke, l) 
+                                compadre_kernel_assert_extreme_debug(P_target_row(offset_index_jmke, l)==P_target_row(offset_index_jmke, l) 
                                         && "NaN in P_target_row matrix.");
-                                compadre_kernel_assert_debug(Q(i,l)==Q(i,l) 
+                                compadre_kernel_assert_extreme_debug(Q(i,l)==Q(i,l) 
                                         && "NaN in Q coefficient matrix.");
 
                             } else {
@@ -49,7 +49,7 @@ void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vec
                         }, alpha_ij);
                         Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
                             _alphas(target_index, offset_index_jmke, i) = alpha_ij;
-                            compadre_kernel_assert_debug(alpha_ij==alpha_ij && "NaN in alphas.");
+                            compadre_kernel_assert_extreme_debug(alpha_ij==alpha_ij && "NaN in alphas.");
                         });
                     }
                 }
@@ -111,9 +111,9 @@ void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vec
                               [=] (int& l, double& t_alpha_ij) {
                                 t_alpha_ij += P_target_row(offset_index_jmke, l)*Q(m_neighbor_offset, l);
 
-                                compadre_kernel_assert_debug(P_target_row(offset_index_jmke, l)==P_target_row(offset_index_jmke, l) 
+                                compadre_kernel_assert_extreme_debug(P_target_row(offset_index_jmke, l)==P_target_row(offset_index_jmke, l) 
                                         && "NaN in P_target_row matrix.");
-                                compadre_kernel_assert_debug(Q(m_neighbor_offset, l)==Q(m_neighbor_offset, l) 
+                                compadre_kernel_assert_extreme_debug(Q(m_neighbor_offset, l)==Q(m_neighbor_offset, l) 
                                         && "NaN in Q coefficient matrix.");
 
                             }, alpha_ij);
@@ -122,16 +122,16 @@ void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vec
                               [=] (int& l, double& t_alpha_ij) {
                                 t_alpha_ij += P_target_row(offset_index_jmke, l)*Q(i,l);
 
-                                compadre_kernel_assert_debug(P_target_row(offset_index_jmke, l)==P_target_row(offset_index_jmke, l) 
+                                compadre_kernel_assert_extreme_debug(P_target_row(offset_index_jmke, l)==P_target_row(offset_index_jmke, l) 
                                         && "NaN in P_target_row matrix.");
-                                compadre_kernel_assert_debug(Q(i,l)==Q(i,l) 
+                                compadre_kernel_assert_extreme_debug(Q(i,l)==Q(i,l) 
                                         && "NaN in Q coefficient matrix.");
 
                             }, alpha_ij);
                         } 
                         Kokkos::single(Kokkos::PerThread(teamMember), [=] () {
                             _alphas(target_index, offset_index_jmke, i) = alpha_ij;
-                            compadre_kernel_assert_debug(alpha_ij==alpha_ij && "NaN in alphas.");
+                            compadre_kernel_assert_extreme_debug(alpha_ij==alpha_ij && "NaN in alphas.");
                         });
                     });
 

--- a/src/Compadre_GMLS_Basis.hpp
+++ b/src/Compadre_GMLS_Basis.hpp
@@ -631,7 +631,7 @@ void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type 
                     // no need to convert offsets to global indices because the sum will never be large
                     alt_P(i+my_num_neighbors*d, j) = delta[j] * std::sqrt(w(i+my_num_neighbors*d));
 
-                    compadre_kernel_assert_debug(delta[j]==delta[j] && "NaN in sqrt(W)*P matrix.");
+                    compadre_kernel_assert_extreme_debug(delta[j]==delta[j] && "NaN in sqrt(W)*P matrix.");
                 }
 
             } else {
@@ -640,7 +640,7 @@ void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type 
                     // no need to convert offsets to global indices because the sum will never be large
                     alt_P(i+my_num_neighbors*d, j) = delta[j];
 
-                    compadre_kernel_assert_debug(delta[j]==delta[j] && "NaN in P matrix.");
+                    compadre_kernel_assert_extreme_debug(delta[j]==delta[j] && "NaN in P matrix.");
                 }
             }
         }

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -125,4 +125,24 @@ typename std::enable_if<2==T::rank,T>::type createView(std::string str, int dim_
 //! compadre_kernel_assert_debug is similar to compadre_assert_debug, but is a call on the device, 
 //! namely inside of a function marked KOKKOS_INLINE_FUNCTION
 
+#ifdef COMPADRE_EXTREME_DEBUG
+# define compadre_assert_extreme_debug(condition) do {                                \
+    if ( ! (condition)) {                                               \
+      std::stringstream _ss_;                                           \
+      _ss_ << __FILE__ << ":" << __LINE__ << ": FAIL:\n" << #condition  \
+        << "\n";                                                        \
+        throw std::logic_error(_ss_.str());                             \
+    }                                                                   \
+  } while (0)
+# define compadre_kernel_assert_extreme_debug(condition) do { \
+    if ( ! (condition))                         \
+      Kokkos::abort(#condition);                \
+  } while (0)
+#else
+#  define compadre_assert_extreme_debug(condition)
+#  define compadre_kernel_assert_extreme_debug(condition)
+#endif
+//! compadre_kernel_assert_extreme_debug is similar to compadre_assert_debug, but is a call on the device, 
+//! namely inside of a function marked KOKKOS_INLINE_FUNCTION
+
 #endif


### PR DESCRIPTION
Enabled by CMake variable Compadre_EXTREME_DEBUG:BOOL=ON

By default, this is OFF.

Added compadre_kernel_assert_extreme_debug and compadre_assert_extreme_debug.

Checks on P matrix and on alpha generation were moved from regular debug to
extreme debug (very slow, but thorough).