### PR TITLE
Support many batches rather than only all-at-once

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -62,8 +62,8 @@ if (Compadre_EXAMPLES)
     ADD_TEST(NAME GMLS_Device_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "3" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Device_Dim3_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
     
-    ADD_TEST(NAME GMLS_Device_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "2" "1" "--kokkos-threads=2")
-    SET_TESTS_PROPERTIES(GMLS_Device_Dim2_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
+    ADD_TEST(NAME GMLS_Device_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "2" "1" "3" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(GMLS_Device_Dim2_QR PROPERTIES LABELS "UnitTest;unit;kokkos;batch" TIMEOUT 10)
     
     ADD_TEST(NAME GMLS_Device_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "1" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Device_Dim1_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)

--- a/examples/GMLS_Device.cpp
+++ b/examples/GMLS_Device.cpp
@@ -350,7 +350,7 @@ bool all_passed = true;
             (divergence_sampling_data_device, CurlOfVectorPointEvaluation);
     
     // retrieves polynomial coefficients instead of remapped field
-    auto scalar_coefficients = gmls_evaluator.applyFullPolynomialCoefficientsBasisToDataAllComponents<double**, Kokkos::HostSpace>
+    //auto scalar_coefficients = gmls_evaluator.applyFullPolynomialCoefficientsBasisToDataAllComponents<double**, Kokkos::HostSpace>
             (sampling_data_device);
     
     //! [Apply GMLS Alphas To Data]
@@ -376,8 +376,8 @@ bool all_passed = true;
         // this is a test that the scalar_coefficients 2d array returned hold valid entries
         // scalar_coefficients(i,1)*1./epsilon(i) is equivalent to the target operation acting 
         // on the polynomials applied to the polynomial coefficients
-        double GMLS_GradX = scalar_coefficients(i,1)*1./epsilon(i);
-                            //output_gradient(i,0);
+        double GMLS_GradX = //scalar_coefficients(i,1)*1./epsilon(i);
+                            output_gradient(i,0);
     
         // load partial y from gradient
         double GMLS_GradY = (dimension>1) ? output_gradient(i,1) : 0;

--- a/python/GMLS_Module.i
+++ b/python/GMLS_Module.i
@@ -22,9 +22,11 @@ import_array();
     try {
         $action
     } catch(std::exception &_e) {
-        SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+        PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+        SWIG_fail;
     } catch (...) {
-        SWIG_exception(SWIG_RuntimeError, "unknown exception");
+        PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+        SWIG_fail;
     }
 }
 

--- a/python/GMLS_Module_wrap.cxx
+++ b/python/GMLS_Module_wrap.cxx
@@ -3513,9 +3513,11 @@ SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_0(PyObject *SWIGUNUSEDPARM(se
     try {
       result = (Kokkos_Python *)new Kokkos_Python(arg1,arg2,arg3,arg4,arg5);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
@@ -3570,9 +3572,11 @@ SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_1(PyObject *SWIGUNUSEDPARM(se
     try {
       result = (Kokkos_Python *)new Kokkos_Python(arg1,arg2,arg3,arg4);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
@@ -3618,9 +3622,11 @@ SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_2(PyObject *SWIGUNUSEDPARM(se
     try {
       result = (Kokkos_Python *)new Kokkos_Python(arg1,arg2,arg3);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
@@ -3657,9 +3663,11 @@ SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_3(PyObject *SWIGUNUSEDPARM(se
     try {
       result = (Kokkos_Python *)new Kokkos_Python(arg1,arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
@@ -3687,9 +3695,11 @@ SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_4(PyObject *SWIGUNUSEDPARM(se
     try {
       result = (Kokkos_Python *)new Kokkos_Python(arg1);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
@@ -3708,9 +3718,11 @@ SWIGINTERN PyObject *_wrap_new_Kokkos_Python__SWIG_5(PyObject *SWIGUNUSEDPARM(se
     try {
       result = (Kokkos_Python *)new Kokkos_Python();
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_Kokkos_Python, SWIG_POINTER_NEW |  0 );
@@ -3876,9 +3888,11 @@ SWIGINTERN PyObject *_wrap_delete_Kokkos_Python(PyObject *SWIGUNUSEDPARM(self), 
     try {
       delete arg1;
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -3903,9 +3917,11 @@ SWIGINTERN PyObject *_wrap_initializeKokkos(PyObject *SWIGUNUSEDPARM(self), PyOb
     try {
       initializeKokkos();
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -3923,9 +3939,11 @@ SWIGINTERN PyObject *_wrap_finalizeKokkos(PyObject *SWIGUNUSEDPARM(self), PyObje
     try {
       finalizeKokkos();
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -3982,9 +4000,11 @@ SWIGINTERN PyObject *_wrap_new_GMLS_Python(PyObject *SWIGUNUSEDPARM(self), PyObj
     try {
       result = (GMLS_Python *)new GMLS_Python(arg1,arg2,arg3,arg4);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_NewPointerObj(SWIG_as_voidptr(result), SWIGTYPE_p_GMLS_Python, SWIG_POINTER_NEW |  0 );
@@ -4011,9 +4031,11 @@ SWIGINTERN PyObject *_wrap_delete_GMLS_Python(PyObject *SWIGUNUSEDPARM(self), Py
     try {
       delete arg1;
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4058,9 +4080,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_setWeightingOrder__SWIG_0(PyObject *SWIGU
     try {
       (arg1)->setWeightingOrder(arg2,arg3);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4096,9 +4120,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_setWeightingOrder__SWIG_1(PyObject *SWIGU
     try {
       (arg1)->setWeightingOrder(arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4186,9 +4212,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_setNeighbors(PyObject *SWIGUNUSEDPARM(sel
     try {
       (arg1)->setNeighbors(arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4216,9 +4244,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_getNeighborLists(PyObject *SWIGUNUSEDPARM
     try {
       result = (PyObject *)(arg1)->getNeighborLists();
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = result;
@@ -4248,9 +4278,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_setSourceSites(PyObject *SWIGUNUSEDPARM(s
     try {
       (arg1)->setSourceSites(arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4278,9 +4310,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_getSourceSites(PyObject *SWIGUNUSEDPARM(s
     try {
       result = (PyObject *)(arg1)->getSourceSites();
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = result;
@@ -4310,9 +4344,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_setTargetSites(PyObject *SWIGUNUSEDPARM(s
     try {
       (arg1)->setTargetSites(arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4340,9 +4376,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_getTargetSites(PyObject *SWIGUNUSEDPARM(s
     try {
       result = (PyObject *)(arg1)->getTargetSites();
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = result;
@@ -4372,9 +4410,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_setWindowSizes(PyObject *SWIGUNUSEDPARM(s
     try {
       (arg1)->setWindowSizes(arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4402,9 +4442,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_getWindowSizes(PyObject *SWIGUNUSEDPARM(s
     try {
       result = (PyObject *)(arg1)->getWindowSizes();
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = result;
@@ -4431,9 +4473,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_generatePointEvaluationStencil(PyObject *
     try {
       (arg1)->generatePointEvaluationStencil();
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4464,9 +4508,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_getPolynomialCoefficients(PyObject *SWIGU
     try {
       result = (PyObject *)(arg1)->getPolynomialCoefficients(arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = result;
@@ -4506,9 +4552,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_getAlphas0Tensor(PyObject *SWIGUNUSEDPARM
     try {
       result = (PyObject *)(arg1)->getAlphas0Tensor(arg2,arg3);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = result;
@@ -4550,9 +4598,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_applyStencil__SWIG_0(PyObject *SWIGUNUSED
     try {
       result = (PyObject *)(arg1)->applyStencil(arg2,arg3);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = result;
@@ -4583,9 +4633,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_applyStencil__SWIG_1(PyObject *SWIGUNUSED
     try {
       result = (PyObject *)(arg1)->applyStencil(arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = result;
@@ -4665,9 +4717,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_generateKDTree(PyObject *SWIGUNUSEDPARM(s
     try {
       (arg1)->generateKDTree(arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4742,9 +4796,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_generateNeighborListsFromKNNSearchAndSet_
     try {
       (arg1)->generateNeighborListsFromKNNSearchAndSet(arg2,arg3,arg4,arg5,arg6,arg7);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4810,9 +4866,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_generateNeighborListsFromKNNSearchAndSet_
     try {
       (arg1)->generateNeighborListsFromKNNSearchAndSet(arg2,arg3,arg4,arg5,arg6);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4869,9 +4927,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_generateNeighborListsFromKNNSearchAndSet_
     try {
       (arg1)->generateNeighborListsFromKNNSearchAndSet(arg2,arg3,arg4,arg5);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4919,9 +4979,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_generateNeighborListsFromKNNSearchAndSet_
     try {
       (arg1)->generateNeighborListsFromKNNSearchAndSet(arg2,arg3,arg4);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -4960,9 +5022,11 @@ SWIGINTERN PyObject *_wrap_GMLS_Python_generateNeighborListsFromKNNSearchAndSet_
     try {
       (arg1)->generateNeighborListsFromKNNSearchAndSet(arg2,arg3);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_Py_Void();
@@ -5181,9 +5245,11 @@ SWIGINTERN PyObject *_wrap_getNP(PyObject *SWIGUNUSEDPARM(self), PyObject *args)
     try {
       result = (int)getNP(arg1,arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_From_int(static_cast< int >(result));
@@ -5220,9 +5286,11 @@ SWIGINTERN PyObject *_wrap_getNN(PyObject *SWIGUNUSEDPARM(self), PyObject *args)
     try {
       result = (int)getNN(arg1,arg2);
     } catch(std::exception &_e) {
-      SWIG_exception_fail(SWIG_SystemError, (&_e)->what());
+      PyErr_SetString(PyExc_RuntimeError,(&_e)->what());
+      SWIG_fail;
     } catch (...) {
-      SWIG_exception(SWIG_RuntimeError, "unknown exception");
+      PyErr_SetString(PyExc_RuntimeError, "unknown exception");
+      SWIG_fail;
     }
   }
   resultobj = SWIG_From_int(static_cast< int >(result));

--- a/python/run_swig.sh
+++ b/python/run_swig.sh
@@ -1,4 +1,4 @@
 rm -rf GMLS_Module_wrap.cxx
 swig -python -c++ GMLS_Module.i
-cat python_lib_load_script.txt GMLS_Module.py > GMLS_Module.py.in;
+#cat python_lib_load_script.txt GMLS_Module.py > GMLS_Module.py.in;
 rm -rf GMLS_Module.py

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -1691,16 +1691,20 @@ public:
         this->resetCoefficientData();
     }
 
+    /*! \brief Generates polynomial coefficients by setting up and solving least squares problems
     //! Sets up the batch of GMLS problems to be solved for. Provides alpha values
     //! that can later be contracted against data or degrees of freedom to form a
     //! global linear system.
-    void generatePolynomialCoefficients();
+    //! \param number_of_batches    [in] - how many batches to break up the total workload into (for storage)
+    */
+    void generatePolynomialCoefficients(const int number_of_batches = 1);
 
-    //! Calculates target operations and applies the evaluations to the previously 
-    //! constructed polynomial coefficients. If polynomial coefficients were not
-    //! already calculated, then generatePolynomialCoefficients() will also be
-    //! called.
-    void generateAlphas();
+    /*! \brief Meant to calculate target operations and apply the evaluations to the previously 
+    //! constructed polynomial coefficients. But now that is inside of generatePolynomialCoefficients because
+    //! it must be to handle number_of_batches>1. Effectively, this just calls generatePolynomialCoefficients.
+    //! \param number_of_batches    [in] - how many batches to break up the total workload into (for storage)
+    */
+    void generateAlphas(const int number_of_batches = 1);
 
 ///@}
 

--- a/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
+++ b/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
@@ -8,7 +8,7 @@ namespace Compadre {
 KOKKOS_INLINE_FUNCTION
 void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type Q, scratch_matrix_right_type R, scratch_vector_type w, scratch_matrix_right_type P_target_row, const int target_NP) const {
 
-    const int target_index = teamMember.league_rank();
+    const int target_index = _initial_index_for_batch + teamMember.league_rank();
         
     const int num_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
             ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;

--- a/src/Compadre_GMLS_Basis.hpp
+++ b/src/Compadre_GMLS_Basis.hpp
@@ -580,7 +580,7 @@ void GMLS::createWeightsAndP(const member_type& teamMember, scratch_vector_type 
     /*
      * Creates sqrt(W)*P
      */
-    const int target_index = teamMember.league_rank();
+    const int target_index = _initial_index_for_batch + teamMember.league_rank();
 //    printf("specific order: %d\n", specific_order);
 //    {
 //        const int storage_size = (specific_order > 0) ? this->getNP(specific_order, dimension)-this->getNP(specific_order-1, dimension) : this->getNP(_poly_order, dimension);
@@ -664,7 +664,7 @@ void GMLS::createWeightsAndPForCurvature(const member_type& teamMember, scratch_
  * 2.) Used to calculate a polynomial of _curvature_poly_order, which we use to calculate curvature of the manifold
  */
 
-    const int target_index = teamMember.league_rank();
+    const int target_index = _initial_index_for_batch + teamMember.league_rank();
 
     // P is stored layout left, because that is what CUDA and LAPACK expect, and storing it
     // this way prevents copying data later

--- a/src/Compadre_GMLS_Targets.hpp
+++ b/src/Compadre_GMLS_Targets.hpp
@@ -24,7 +24,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
     bool additional_evaluation_sites_need_handled = 
         (_additional_evaluation_coordinates.extent(0) > 0) ? true : false; // additional evaluation sites are specified
 
-    const int target_index = teamMember.league_rank();
+    const int target_index = _initial_index_for_batch + teamMember.league_rank();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, P_target_row.extent(0)), [&] (const int j) {
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(teamMember, P_target_row.extent(1)),
@@ -671,7 +671,7 @@ void GMLS::computeTargetFunctionals(const member_type& teamMember, scratch_vecto
 KOKKOS_INLINE_FUNCTION
 void GMLS::computeCurvatureFunctionals(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, const scratch_matrix_right_type* V, const local_index_type local_neighbor_index) const {
 
-    const int target_index = teamMember.league_rank();
+    const int target_index = _initial_index_for_batch + teamMember.league_rank();
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, P_target_row.extent(0)), [&] (const int j) {
         Kokkos::parallel_for(Kokkos::ThreadVectorRange(teamMember, P_target_row.extent(1)),
@@ -718,7 +718,7 @@ KOKKOS_INLINE_FUNCTION
 void GMLS::computeTargetFunctionalsOnManifold(const member_type& teamMember, scratch_vector_type t1, scratch_vector_type t2, scratch_matrix_right_type P_target_row, scratch_matrix_right_type V, scratch_matrix_right_type G_inv, scratch_vector_type curvature_coefficients, scratch_vector_type curvature_gradients) const {
 
     // only designed for 2D manifold embedded in 3D space
-    const int target_index = teamMember.league_rank();
+    const int target_index = _initial_index_for_batch + teamMember.league_rank();
     const int target_NP = this->getNP(_poly_order, _dimensions-1, _reconstruction_space);
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, P_target_row.extent(0)), [&] (const int j) {

--- a/src/Compadre_KokkosParser.hpp
+++ b/src/Compadre_KokkosParser.hpp
@@ -1,7 +1,8 @@
 #ifndef _COMPADRE_KOKKOSPARSER_HPP_
 #define _COMPADRE_KOKKOSPARSER_HPP_
 
-#include <Compadre_Typedefs.hpp>
+#include "Compadre_Config.h"
+#include "Compadre_Typedefs.hpp"
 
 namespace Compadre {
 

--- a/src/Compadre_LinearAlgebra.cpp
+++ b/src/Compadre_LinearAlgebra.cpp
@@ -44,6 +44,7 @@ void batchQRFactorize(double *P, int lda, int nda, double *RHS, int ldb, int ndb
 
     compadre_assert_release(cublas_stat==CUBLAS_STATUS_SUCCESS && "cublasDgeqrfBatched failed");
     cudaDeviceSynchronize();
+    cudaFree(devInfo);
     Kokkos::Profiling::popRegion();
 
 

--- a/src/Compadre_LinearAlgebra_Declarations.hpp
+++ b/src/Compadre_LinearAlgebra_Declarations.hpp
@@ -63,7 +63,7 @@ namespace GMLS_LinearAlgebra {
         \param max_neighbors        [in] - integer for maximum neighbor over all targets
         \param neighbor_list_sizes  [in] - pointer to all neighbor list sizes for each target
     */
-    void batchQRFactorize(double *P, int lda, int nda, double *RHS, int ldb, int ndb, int M, int N, const int num_matrices, const size_t max_neighbors = 0, int * neighbor_list_sizes = NULL);
+    void batchQRFactorize(double *P, int lda, int nda, double *RHS, int ldb, int ndb, int M, int N, const int num_matrices, const size_t max_neighbors = 0, const int initial_index_of_batch = 0, int * neighbor_list_sizes = NULL);
 
     /*! \brief Calls LAPACK or CUBLAS to solve a batch of SVD problems
 
@@ -82,7 +82,7 @@ namespace GMLS_LinearAlgebra {
         \param max_neighbors        [in] - integer for maximum neighbor over all targets
         \param neighbor_list_sizes  [in] - pointer to all neighbor list sizes for each target
     */
-    void batchSVDFactorize(double *P, int lda, int nda, double *RHS, int ldb, int ndb, int M, int N, const int num_matrices, const size_t max_neighbors = 0, int * neighbor_list_sizes = NULL);
+    void batchSVDFactorize(double *P, int lda, int nda, double *RHS, int ldb, int ndb, int M, int N, const int num_matrices, const size_t max_neighbors = 0, const int initial_index_of_batch = 0, int * neighbor_list_sizes = NULL);
 
 }; // GMLS_LinearAlgebra
 }; // Compadre

--- a/src/Compadre_Typedefs.hpp
+++ b/src/Compadre_Typedefs.hpp
@@ -85,6 +85,10 @@ template<typename T>
 typename std::enable_if<2==T::rank,T>::type createView(std::string str, int dim_0, int dim_1)
 { return T(str, dim_0, dim_1); }
 
+//void compadre_rethrow_exception(std::exception &e, const std::string &extra_message) {
+//    std::cout << extra_message + "\n\n" + e.what() << std::endl;
+//}
+
 //! compadre_assert_release is used for assertions that should always be checked, but generally 
 //! are not expensive to verify or are not called frequently. 
 # define compadre_assert_release(condition) do {                                \


### PR DESCRIPTION
generateAlphas() and generatePolynomialCoefficients() now take an optional argument (const int number_of_batches), that allows the user to split the total load into smaller batches that can be executed in parallel. 

Originally, the toolkit relied on Kokkos::parallel_for to create batches/batch sizes, but because of the need to enter and exit device code multiple times, it was necessary to allocate enough space for all matrices needed for the computation and have them persist between calls.

For modest sized computations, this provided the best of both worlds, a persistent set of matrices as well as the ability to call code from the host (Cuda and LAPACK calls). However, when performing computations for a large number of targets, it is possible that all of these matrices can not be stored at once. Therefore, batching has been added as a way break up the total problem into smaller sets that can have their matrices fit in memory and persist between calls. This should alleviate memory-bound problems.