### PR TITLE
Add parameters to check for problem type, solver type and boundary type in TOOLKIT

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,83 +49,83 @@ if (Compadre_EXAMPLES)
     endif()
 
     # Host views tests for GMLS
-    ADD_TEST(NAME GMLS_Host_Dim3_SVD COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Host_Test "4" "200" "3" "0" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Host_Dim3_SVD COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Host_Test "4" "200" "3" "0" "0" "0" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Host_Dim3_SVD PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
     
-    ADD_TEST(NAME GMLS_Host_Dim2_SVD COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Host_Test "4" "200" "2" "0" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Host_Dim2_SVD COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Host_Test "4" "200" "2" "0" "0" "0" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Host_Dim2_SVD PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
     
-    ADD_TEST(NAME GMLS_Host_Dim1_SVD COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Host_Test "4" "200" "1" "0" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Host_Dim1_SVD COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Host_Test "4" "200" "1" "0" "0" "0" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Host_Dim1_SVD PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
 
     # Device views tests for GMLS
-    ADD_TEST(NAME GMLS_Device_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "3" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Device_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "3" "1" "0" "0" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Device_Dim3_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
     
-    ADD_TEST(NAME GMLS_Device_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "2" "1" "3" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Device_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "2" "1" "0" "0" "3" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Device_Dim2_QR PROPERTIES LABELS "UnitTest;unit;kokkos;batch" TIMEOUT 10)
     
-    ADD_TEST(NAME GMLS_Device_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "1" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Device_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "1" "1" "0" "0" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Device_Dim1_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
 
     # Device views tests for GMLS - LU solver
-    ADD_TEST(NAME GMLS_Device_Dim3_LU COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "3" "2" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Device_Dim3_LU COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "4" "200" "3" "2" "0" "0" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Device_Dim3_LU PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
 
     # Device views tests for GMLS (vector basis)
-    ADD_TEST(NAME GMLS_Vector_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "3" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Vector_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "3" "1" "0" "0" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Vector_Dim3_QR PROPERTIES LABELS "UnitTest;unit;kokkos;vector" TIMEOUT 10)
     
-    ADD_TEST(NAME GMLS_Vector_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "2" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Vector_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "2" "1" "0" "0" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Vector_Dim2_QR PROPERTIES LABELS "UnitTest;unit;kokkos;vector" TIMEOUT 10)
     
-    ADD_TEST(NAME GMLS_Vector_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "1" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Vector_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Device_Test "3" "20" "1" "1" "0" "0" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Vector_Dim1_QR PROPERTIES LABELS "UnitTest;unit;kokkos;vector" TIMEOUT 10)
 
     # Device views tests for small batch GMLS, reusing GMLS class object
-    ADD_TEST(NAME GMLS_SmallBatchReuse_Device_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_SmallBatchReuse_Device_Test "4" "200" "2" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_SmallBatchReuse_Device_Dim2_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_SmallBatchReuse_Device_Test "4" "200" "2" "1" "0" "0" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_SmallBatchReuse_Device_Dim2_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
     
-    ADD_TEST(NAME GMLS_SmallBatchReuse_Device_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_SmallBatchReuse_Device_Test "4" "200" "1" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_SmallBatchReuse_Device_Dim1_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_SmallBatchReuse_Device_Test "4" "200" "1" "1" "0" "0" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_SmallBatchReuse_Device_Dim1_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
 
     # Multisite test for GMLS
-    ADD_TEST(NAME GMLS_MultiSite_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_MultiSite_Test "4" "200" "3" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_MultiSite_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_MultiSite_Test "4" "200" "3" "1" "0" "0" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_MultiSite_Dim3_QR PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
 
     # Staggered scheme test for GMLS on non-manifold
     # Note: Using even polynomial order may cause this test to fail
-    ADD_TEST(NAME GMLS_Staggered_Dim3_QR COMMAND ${CMAKD_CURRENT_BINARY_DIR}/GMLS_Staggered "3" "200" "3" "1" "--kokkos-threads=2")
+    ADD_TEST(NAME GMLS_Staggered_Dim3_QR COMMAND ${CMAKD_CURRENT_BINARY_DIR}/GMLS_Staggered "3" "200" "3" "1" "0" "0" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Staggered_Dim3_QR PROPERTIES LABELS "UnitTest;unit;kokkos;staggered" TIMEOUT 10)
 
     if (NOT Compadre_DEBUG)
       # This test is too slow in DEBUG (3x longer than all other tests combined)
       # Multisite manifold test for GMLS
-      #ADD_TEST(NAME GMLS_Manifold_MultiSite COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold_MultiSite_Test "3" "4" "--kokkos-threads=2")
+      #ADD_TEST(NAME GMLS_Manifold_MultiSite COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold_MultiSite_Test "3" "4" "0" "0" "--kokkos-threads=2")
       #SET_TESTS_PROPERTIES(GMLS_Manifold_MultiSite PROPERTIES LABELS "UnitTest;unit;kokkos;multi;manifold" TIMEOUT 10)
       # Python driven test of a C++ executable (Python changes command line arguments given to executable)
       CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/GMLS_Manifold_Multiple_Evaluation_Sites.py.in" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold_Multiple_Evaluation_Sites.py" @ONLY)
-      ADD_TEST(NAME GMLS_Manifold_MultiSite_Refinement_Study COMMAND "python" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold_Multiple_Evaluation_Sites.py" "3" "3")
+      ADD_TEST(NAME GMLS_Manifold_MultiSite_Refinement_Study COMMAND "python" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold_Multiple_Evaluation_Sites.py" "3" "3" "0" "0")
       SET_TESTS_PROPERTIES(GMLS_Manifold_MultiSite_Refinement_Study PROPERTIES LABELS "ConvergenceTest;convergence;manifold" TIMEOUT 60)
 
       # Divergence-free basis test for GMLS on non-manifold
       # Note: SVD is needed to be used here due to the null space introduced
-      ADD_TEST(NAME GMLS_DivergenceFree_Dim3_SVD COMMAND ${CMAKD_CURRENT_BINARY_DIR}/GMLS_Divergence_Test "3" "200" "3" "0" "--kokkos-threads=2")
+      ADD_TEST(NAME GMLS_DivergenceFree_Dim3_SVD COMMAND ${CMAKD_CURRENT_BINARY_DIR}/GMLS_Divergence_Test "3" "200" "3" "0" "0" "0" "--kokkos-threads=2")
       SET_TESTS_PROPERTIES(GMLS_DivergenceFree_Dim3_SVD PROPERTIES LABELS "UnitTest;unit;kokkos;divergencefree;svd" TIMEOUT 60)
     endif()
 
     #    # Manifold tests for GMLS
-    #    ADD_TEST(NAME GMLS_Manifold_Dim3 COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold_Test "4" "200" "3" "1" "--kokkos-threads=2")
+    #    ADD_TEST(NAME GMLS_Manifold_Dim3 COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold_Test "4" "200" "3" "1" "0" "0" "--kokkos-threads=2")
     #    SET_TESTS_PROPERTIES(GMLS_Manifold_Dim3 PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
 
     # Python driven test of a C++ executable (Python changes command line arguments given to executable)
     CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/GMLS_Manifold.py.in" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold.py" @ONLY)
-    ADD_TEST(NAME GMLS_Manifold_Refinement_Study COMMAND "python" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold.py" "3" "4")
+    ADD_TEST(NAME GMLS_Manifold_Refinement_Study COMMAND "python" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Manifold.py" "3" "4" "0" "0")
     SET_TESTS_PROPERTIES(GMLS_Manifold_Refinement_Study PROPERTIES LABELS "ConvergenceTest;convergence;manifold" TIMEOUT 20)
 
     # Python driven test of a C++ executable (Python changes command line arguments given to executable)
     CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/GMLS_Staggered_Manifold.py.in" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Staggered_Manifold.py" @ONLY)
-    ADD_TEST(NAME GMLS_Staggered_Manifold_Refinement_Study COMMAND "python" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Staggered_Manifold.py" "3" "4")
+    ADD_TEST(NAME GMLS_Staggered_Manifold_Refinement_Study COMMAND "python" "${CMAKE_CURRENT_BINARY_DIR}/GMLS_Staggered_Manifold.py" "3" "4" "0" "0")
     SET_TESTS_PROPERTIES(GMLS_Staggered_Manifold_Refinement_Study PROPERTIES LABELS "ConvergenceTest;convergence;manifold;staggered" TIMEOUT 20)
 
     # WORKING_DIRECTORY ${EXECUTABLE_OUTPUT_PATH} )

--- a/examples/GMLS_Device.cpp
+++ b/examples/GMLS_Device.cpp
@@ -43,12 +43,36 @@ bool all_passed = true;
 // otherwise, Views may be deallocating when we call Kokkos finalize() later
 {
 
-    // check if 6 arguments are given from the command line, the first being the program name
+    // check if 8 arguments are given from the command line, the first being the program name
     int number_of_batches = 1; // 1 batch by default
+    if (argc >= 8) {
+        int arg8toi = atoi(args[7]);
+        if (arg8toi > 0) {
+            number_of_batches = arg8toi;
+        }
+    }
+
+    // check if 7 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            boundary_type = arg7toi;
+        }
+    }
+
+    // check if 6 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 0; // Standard by default
     if (argc >= 6) {
         int arg6toi = atoi(args[5]);
         if (arg6toi > 0) {
-            number_of_batches = arg6toi;
+            problem_type = arg6toi;
         }
     }
     
@@ -56,6 +80,7 @@ bool all_passed = true;
     //  solver_type used for factorization in solving each GMLS problem:
     //      0 - SVD used for factorization in solving each GMLS problem
     //      1 - QR  used for factorization in solving each GMLS problem
+    //      2 - LU  used for factorization in solving each GMLS problem
     int solver_type = 1; // QR by default
     if (argc >= 5) {
         int arg5toi = atoi(args[4]);
@@ -277,15 +302,34 @@ bool all_passed = true;
     // solver name for passing into the GMLS class
     std::string solver_name;
     if (solver_type == 0) { // SVD
-      solver_name = "SVD";
+        solver_name = "SVD";
     } else if (solver_type == 1) { // QR
-      solver_name = "QR";
+        solver_name = "QR";
     } else if (solver_type == 2) { // LU
-      solver_name = "LU";
+        solver_name = "LU";
+    }
+
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
     }
     
     // initialize an instance of the GMLS class 
-    GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample, order, solver_name.c_str(), 2 /*manifold order*/, dimension);
+    GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample,
+                 order, dimension,
+                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 2 /*manifold order*/);
     
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
     //

--- a/examples/GMLS_DivergenceFree.cpp
+++ b/examples/GMLS_DivergenceFree.cpp
@@ -41,12 +41,36 @@ bool all_passed = true;
 // code block to reduce scope for all Kokkos View allocations
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
+    // check if 7 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            boundary_type = arg7toi;
+        }
+    }
+
+    // check if 6 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 0; // Standard by default
+    if (argc >= 6) {
+        int arg6toi = atoi(args[5]);
+        if (arg6toi > 0) {
+            problem_type = arg6toi;
+        }
+    }
 
     // check if 5 arguments are given from the command line, the first being the program name
     //  solver_type used for factorization in solving each GMLS problem:
     //      0 - SVD used for factorization in solving each GMLS problem
     //      1 - QR  used for factorization in solving each GMLS problem
-    int solver_type = 1;
+    //      2 - LU  used for factorization in solving each GMLS problem
+    int solver_type = 1; // QR by default
     if (argc >= 5) {
         int arg5toi = atoi(args[4]);
         if (arg5toi > 0) {
@@ -252,6 +276,24 @@ bool all_passed = true;
         solver_name = "SVD";
     } else if (solver_type == 1) { // QR
         solver_name = "QR";
+    } else if (solver_type == 2) { // LU
+        solver_name = "LU";
+    }
+
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
     }
 
     // initialize an instance of the GMLS class
@@ -259,8 +301,9 @@ bool all_passed = true;
     // Vector basis to perform GMLS on divergence free basis
     GMLS vector_divfree_basis_gmls(DivergenceFreeVectorTaylorPolynomial,
                                    VectorPointSample,
-                                   order, solver_name.c_str(),
-                                   0 /*manifold order*/ , dimension);
+                                   order, dimension,
+                                   solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                                   0 /*manifold order*/);
 
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
     //

--- a/examples/GMLS_Host.cpp
+++ b/examples/GMLS_Host.cpp
@@ -30,7 +30,36 @@ int main (int argc, char* args[])
 bool all_passed = true;
 
 {
-    int solver_type = 0;
+    // check if 7 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            boundary_type = arg7toi;
+        }
+    }
+
+    // check if 6 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 0; // Standard by default
+    if (argc >= 6) {
+        int arg6toi = atoi(args[5]);
+        if (arg6toi > 0) {
+            problem_type = arg6toi;
+        }
+    }
+
+    // check if 5 arguments are given from the command line, the first being the program name
+    //  solver_type used for factorization in solving each GMLS problem:
+    //      0 - SVD used for factorization in solving each GMLS problem
+    //      1 - QR  used for factorization in solving each GMLS problem
+    //      2 - LU  used for factorization in solving each GMLS problem
+    int solver_type = 1; // QR by default
     if (argc >= 5) {
         int arg5toi = atoi(args[4]);
         if (arg5toi > 0) {
@@ -135,14 +164,35 @@ bool all_passed = true;
     Kokkos::Profiling::popRegion();
     timer.reset();
 
+    // solver name for passing into the GMLS class
     std::string solver_name;
     if (solver_type == 0) { // SVD
         solver_name = "SVD";
     } else if (solver_type == 1) { // QR
         solver_name = "QR";
+    } else if (solver_type == 2) { // LU
+        solver_name = "LU";
     }
 
-    GMLS my_GMLS(order, solver_name.c_str(), 2 /*manifold order*/, dimension);
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
+    }
+
+    GMLS my_GMLS(order, dimension,
+                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 2 /*manifold order*/);
     my_GMLS.setProblemData(neighbor_lists, source_coords, target_coords, epsilon);
     my_GMLS.setWeightingPower(10);
 

--- a/examples/GMLS_Manifold.cpp
+++ b/examples/GMLS_Manifold.cpp
@@ -38,13 +38,50 @@ Kokkos::initialize(argc, args);
 // code block to reduce scope for all Kokkos View allocations
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
+    // check if 8 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 8) {
+        int arg8toi = atoi(args[7]);
+        if (arg8toi > 0) {
+            boundary_type = arg8toi;
+        }
+    }
+
+    // check if 7 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 1; // Manifold for this example
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            problem_type = arg7toi;
+        }
+    }
+
     // check if 6 arguments are given from the command line, the first being the program name
-    //  N_pts_on_sphere used to determine spatial resolution
-    int N_pts_on_sphere = 1000; // QR by default
+    //  solver_type used for factorization in solving each GMLS problem:
+    //      0 - SVD used for factorization in solving each GMLS problem
+    //      1 - QR  used for factorization in solving each GMLS problem
+    //      2 - LU  used for factorization in solving each GMLS problem
+    int solver_type = 1; // QR by default
     if (argc >= 6) {
         int arg6toi = atoi(args[5]);
         if (arg6toi > 0) {
-            N_pts_on_sphere = arg6toi;
+            solver_type = arg6toi;
+        }
+    }
+
+    // check if 5 arguments are given from the command line, the first being the program name
+    //  N_pts_on_sphere used to determine spatial resolution
+    int N_pts_on_sphere = 1000; // 1000 points by default
+    if (argc >= 5) {
+        int arg5toi = atoi(args[4]);
+        if (arg5toi > 0) {
+            N_pts_on_sphere = arg5toi;
         }
     }
     
@@ -275,11 +312,35 @@ Kokkos::initialize(argc, args);
     
     // solver name for passing into the GMLS class
     std::string solver_name;
-    solver_name = "MANIFOLD";
+    if (solver_type == 0) { // SVD
+        solver_name = "SVD";
+    } else if (solver_type == 1) { // QR
+        solver_name = "QR";
+    } else if (solver_type == 2) { // LU
+        solver_name = "LU";
+    }
+
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
+    }
     
     // initialize an instance of the GMLS class for problems with a scalar basis and 
     // traditional point sampling as the sampling functional
-    GMLS my_GMLS_scalar(order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_scalar(order, dimension,
+                        solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                        order /*manifold order*/);
     
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
     //
@@ -332,7 +393,11 @@ Kokkos::initialize(argc, args);
     // evaluation of that vector as the sampling functional
     // VectorTaylorPolynomial indicates that the basis will be a polynomial with as many components as the
     // dimension of the manifold. This differs from another possibility, which follows this class.
-    GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial, ManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial, ManifoldVectorPointSample,
+                        order, dimension,
+                        solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                        order /*manifold order*/);
+
     my_GMLS_vector.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     std::vector<TargetOperation> lro_vector(2);
     lro_vector[0] = VectorPointEvaluation;
@@ -368,7 +433,11 @@ Kokkos::initialize(argc, args);
     //  In the print-out for this program, we include the timings and errors on this and VectorTaylorPolynomial
     //  in order to demonstrate that they produce exactly the same answer, but that one is much more efficient.
     //
-    GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial,ManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, ManifoldVectorPointSample,
+                                         order, dimension,
+                                         solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                                         order /*manifold order*/);
+
     my_GMLS_vector_of_scalar_clones.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     std::vector<TargetOperation> lro_vector_of_scalar_clones(2);
     lro_vector_of_scalar_clones[0] = VectorPointEvaluation;

--- a/examples/GMLS_Manifold.py.in
+++ b/examples/GMLS_Manifold.py.in
@@ -35,7 +35,7 @@ for operator in target_operators:
 
 for grid_num in range(grids):
     with open(os.devnull, 'w') as devnull:
-        output_commands = ["@CMAKE_CURRENT_BINARY_DIR@/GMLS_Manifold_Test","%d"%porder,"%d"%num_target_sites,"3","1","%d"%(20*num_target_sites*pow(4,grid_num))]
+        output_commands = ["@CMAKE_CURRENT_BINARY_DIR@/GMLS_Manifold_Test","%d"%porder,"%d"%num_target_sites,"3","%d"%(20*num_target_sites*pow(4,grid_num)),"1"]
         print(output_commands)
         output = subprocess.check_output(output_commands, stderr=devnull)
         #print(output)

--- a/examples/GMLS_Manifold.py.in
+++ b/examples/GMLS_Manifold.py.in
@@ -35,7 +35,7 @@ for operator in target_operators:
 
 for grid_num in range(grids):
     with open(os.devnull, 'w') as devnull:
-        output_commands = ["@CMAKE_CURRENT_BINARY_DIR@/GMLS_Manifold_Test","%d"%porder,"%d"%num_target_sites,"3","%d"%(20*num_target_sites*pow(4,grid_num)),"1"]
+        output_commands = ["@CMAKE_CURRENT_BINARY_DIR@/GMLS_Manifold_Test","%d"%porder,"%d"%num_target_sites,"3","%d"%(20*num_target_sites*pow(4,grid_num)),"1","0","0"]
         print(output_commands)
         output = subprocess.check_output(output_commands, stderr=devnull)
         #print(output)

--- a/examples/GMLS_Manifold_Multiple_Evaluation_Sites.cpp
+++ b/examples/GMLS_Manifold_Multiple_Evaluation_Sites.cpp
@@ -68,13 +68,50 @@ Kokkos::initialize(argc, args);
 // code block to reduce scope for all Kokkos View allocations
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
+    // check if 8 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 8) {
+        int arg8toi = atoi(args[7]);
+        if (arg8toi > 0) {
+            boundary_type = arg8toi;
+        }
+    }
+
+    // check if 7 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 1; // Manifold for this example
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            problem_type = arg7toi;
+        }
+    }
+
     // check if 6 arguments are given from the command line, the first being the program name
-    //  N_pts_on_sphere used to determine spatial resolution
-    int N_pts_on_sphere = 1000; // QR by default
+    //  solver_type used for factorization in solving each GMLS problem:
+    //      0 - SVD used for factorization in solving each GMLS problem
+    //      1 - QR  used for factorization in solving each GMLS problem
+    //      2 - LU  used for factorization in solving each GMLS problem
+    int solver_type = 1; // QR by default
     if (argc >= 6) {
         int arg6toi = atoi(args[5]);
         if (arg6toi > 0) {
-            N_pts_on_sphere = arg6toi;
+            solver_type = arg6toi;
+        }
+    }
+
+    // check if 5 arguments are given from the command line, the first being the program name
+    //  N_pts_on_sphere used to determine spatial resolution
+    int N_pts_on_sphere = 1000; // 1000 points by default
+    if (argc >= 5) {
+        int arg5toi = atoi(args[4]);
+        if (arg5toi > 0) {
+            N_pts_on_sphere = arg5toi;
         }
     }
     
@@ -304,11 +341,35 @@ Kokkos::initialize(argc, args);
     
     // solver name for passing into the GMLS class
     std::string solver_name;
-    solver_name = "MANIFOLD";
+    if (solver_type == 0) { // SVD
+        solver_name = "SVD";
+    } else if (solver_type == 1) { // QR
+        solver_name = "QR";
+    } else if (solver_type == 2) { // LU
+        solver_name = "LU";
+    }
+
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
+    }
     
     // initialize an instance of the GMLS class for problems with a scalar basis and 
     // traditional point sampling as the sampling functional
-    GMLS my_GMLS_scalar(order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_scalar(order, dimension,
+                        solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                        order /*manifold order*/);
     
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
     //
@@ -364,7 +425,11 @@ Kokkos::initialize(argc, args);
     // evaluation of that vector as the sampling functional
     // VectorTaylorPolynomial indicates that the basis will be a polynomial with as many components as the
     // dimension of the manifold. This differs from another possibility, which follows this class.
-    GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial,VaryingManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial, VaryingManifoldVectorPointSample,
+                          order, dimension,
+                          solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                          order /*manifold order*/);
+
     my_GMLS_vector.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     my_GMLS_vector.setAdditionalEvaluationSitesData(neighbor_lists_device, source_coords_device);
     std::vector<TargetOperation> lro_vector(2);
@@ -401,7 +466,11 @@ Kokkos::initialize(argc, args);
     //  In the print-out for this program, we include the timings and errors on this and VectorTaylorPolynomial
     //  in order to demonstrate that they produce exactly the same answer, but that one is much more efficient.
     //
-    GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial,VaryingManifoldVectorPointSample, order, solver_name.c_str(), order /*manifold order*/, dimension);
+    GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, VaryingManifoldVectorPointSample,
+                                         order, dimension,
+                                         solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                                         order /*manifold order*/);
+
     my_GMLS_vector_of_scalar_clones.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
     my_GMLS_vector_of_scalar_clones.setAdditionalEvaluationSitesData(neighbor_lists_device, source_coords_device);
     std::vector<TargetOperation> lro_vector_of_scalar_clones(2);

--- a/examples/GMLS_Manifold_Multiple_Evaluation_Sites.py.in
+++ b/examples/GMLS_Manifold_Multiple_Evaluation_Sites.py.in
@@ -35,7 +35,7 @@ for operator in target_operators:
 
 for grid_num in range(grids):
     with open(os.devnull, 'w') as devnull:
-        output_commands = ["@CMAKE_CURRENT_BINARY_DIR@/GMLS_Manifold_MultiSite_Test","%d"%porder,"%d"%num_target_sites,"3","1","%d"%(20*num_target_sites*pow(4,grid_num))]
+        output_commands = ["@CMAKE_CURRENT_BINARY_DIR@/GMLS_Manifold_MultiSite_Test","%d"%porder,"%d"%num_target_sites,"3","1","%d"%(20*num_target_sites*pow(4,grid_num)),"0","0"]
         print(output_commands)
         output = subprocess.check_output(output_commands, stderr=devnull)
         #print(output)

--- a/examples/GMLS_Multiple_Evaluation_Sites.cpp
+++ b/examples/GMLS_Multiple_Evaluation_Sites.cpp
@@ -42,11 +42,35 @@ bool all_passed = true;
 // code block to reduce scope for all Kokkos View allocations
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
-    
+    // check if 7 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            boundary_type = arg7toi;
+        }
+    }
+
+    // check if 6 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 0; // Standard by default
+    if (argc >= 6) {
+        int arg6toi = atoi(args[5]);
+        if (arg6toi > 0) {
+            problem_type = arg6toi;
+        }
+    }
+
     // check if 5 arguments are given from the command line, the first being the program name
     //  solver_type used for factorization in solving each GMLS problem:
     //      0 - SVD used for factorization in solving each GMLS problem
     //      1 - QR  used for factorization in solving each GMLS problem
+    //      2 - LU  used for factorization in solving each GMLS problem
     int solver_type = 1; // QR by default
     if (argc >= 5) {
         int arg5toi = atoi(args[4]);
@@ -302,11 +326,32 @@ bool all_passed = true;
         solver_name = "SVD";
     } else if (solver_type == 1) { // QR
         solver_name = "QR";
+    } else if (solver_type == 2) { // LU
+        solver_name = "LU";
+    }
+
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
     }
     
     // initialize an instance of the GMLS class 
-    GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample, order, solver_name.c_str(), 2 /*manifold order*/, dimension);
-    
+    GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample,
+                 order, dimension,
+                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 2 /*manifold order*/);
+
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
     //
     // neighbor lists have the format:

--- a/examples/GMLS_SmallBatchReuse_Device.cpp
+++ b/examples/GMLS_SmallBatchReuse_Device.cpp
@@ -48,11 +48,35 @@ bool all_passed = true;
 // code block to reduce scope for all Kokkos View allocations
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
+    // check if 7 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            boundary_type = arg7toi;
+        }
+    }
+
+    // check if 6 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 0; // Standard by default
+    if (argc >= 6) {
+        int arg6toi = atoi(args[5]);
+        if (arg6toi > 0) {
+            problem_type = arg6toi;
+        }
+    }
     
     // check if 5 arguments are given from the command line, the first being the program name
     //  solver_type used for factorization in solving each GMLS problem:
     //      0 - SVD used for factorization in solving each GMLS problem
     //      1 - QR  used for factorization in solving each GMLS problem
+    //      2 - LU  used for factorization in solving each GMLS problem
     int solver_type = 1; // QR by default
     if (argc >= 5) {
         int arg5toi = atoi(args[4]);
@@ -230,10 +254,31 @@ bool all_passed = true;
         solver_name = "SVD";
     } else if (solver_type == 1) { // QR
         solver_name = "QR";
+    } else if (solver_type == 2) { // LU
+        solver_name = "LU";
+    }
+
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
     }
     
     // initialize an instance of the GMLS class 
-    GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample, order, solver_name.c_str(), 2 /*manifold order*/, dimension);
+    GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample,
+                 order, dimension,
+                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 2 /*manifold order*/);
     
     // create a vector of target operations
     std::vector<TargetOperation> lro(5);

--- a/examples/GMLS_Staggered.cpp
+++ b/examples/GMLS_Staggered.cpp
@@ -41,11 +41,35 @@ bool all_passed = true;
 // code block to reduce scope for all Kokkos View allocations
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
+    // check if 7 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            boundary_type = arg7toi;
+        }
+    }
+
+    // check if 6 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 0; // Standard by default
+    if (argc >= 6) {
+        int arg6toi = atoi(args[5]);
+        if (arg6toi > 0) {
+            problem_type = arg6toi;
+        }
+    }
 
     // check if 5 arguments are given from the command line, the first being the program name
     //  solver_type used for factorization in solving each GMLS problem:
     //      0 - SVD used for factorization in solving each GMLS problem
     //      1 - QR  used for factorization in solving each GMLS problem
+    //      2 - LU  used for factorization in solving each GMLS problem
     int solver_type = 1; // QR by default
     if (argc >= 5) {
         int arg5toi = atoi(args[4]);
@@ -244,22 +268,42 @@ bool all_passed = true;
         solver_name = "SVD";
     } else if (solver_type == 1) { // QR
         solver_name = "QR";
+    } else if (solver_type == 2) { // LU
+        solver_name = "LU";
+    }
+
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
     }
     
     // initialize an instance of the GMLS class
     // NULL in manifold order indicates non-manifold case
     // First, analytica gradient on scalar polynomial basis
     GMLS scalar_basis_gmls(ScalarTaylorPolynomial,
-                 StaggeredEdgeAnalyticGradientIntegralSample,
-                 order, solver_name.c_str(),
-                 0 /*manifold order*/ , dimension);
+                           StaggeredEdgeAnalyticGradientIntegralSample,
+                           order, dimension,
+                           solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                           0 /*manifold order*/);
 
     // Another class performing Gaussian quadrature integration on vector polynomial basis
     GMLS vector_basis_gmls(VectorTaylorPolynomial,
                            StaggeredEdgeIntegralSample,
                            StaggeredEdgeAnalyticGradientIntegralSample,
-                           order, solver_name.c_str(),
-                           0 /*manifold order*/ , dimension);
+                           order, dimension,
+                           solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                           0 /*manifold order*/);
 
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
     //

--- a/examples/GMLS_Staggered_Manifold.py.in
+++ b/examples/GMLS_Staggered_Manifold.py.in
@@ -35,7 +35,7 @@ for operator in target_operators:
 
 for grid_num in range(grids):
     with open(os.devnull, 'w') as devnull:
-        output_commands = ["@CMAKE_CURRENT_BINARY_DIR@/GMLS_Staggered_Manifold_Test","%d"%porder,"%d"%num_target_sites,"3","1","%d"%(20*num_target_sites*pow(4,grid_num))]
+        output_commands = ["@CMAKE_CURRENT_BINARY_DIR@/GMLS_Staggered_Manifold_Test","%d"%porder,"%d"%num_target_sites,"3","%d"%(20*num_target_sites*pow(4,grid_num)),"1"]
         print(output_commands)
         output = subprocess.check_output(output_commands, stderr=devnull)
         #print(output)

--- a/examples/GMLS_Vector.cpp
+++ b/examples/GMLS_Vector.cpp
@@ -41,11 +41,35 @@ bool all_passed = true;
 // code block to reduce scope for all Kokkos View allocations
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
-    
+    // check if 7 arguments are given from the command line, the first being the program name
+    //  boundary_type used in solving each GMLS problem:
+    //      0 - Dirichlet used in solving each GMLS problem
+    //      1 - Neumann used in solving each GMLS problem
+    int boundary_type = 0; // Dirichlet by default
+    if (argc >= 7) {
+        int arg7toi = atoi(args[6]);
+        if (arg7toi > 0) {
+            boundary_type = arg7toi;
+        }
+    }
+
+    // check if 6 arguments are given from the command line, the first being the program name
+    // problem_type used in solving each GMLS problem:
+    //      0 - Standard GMLS problem
+    //      1 - Manifold GMLS problem
+    int problem_type = 0; // Standard by default
+    if (argc >= 6) {
+        int arg6toi = atoi(args[5]);
+        if (arg6toi > 0) {
+            problem_type = arg6toi;
+        }
+    }
+
     // check if 5 arguments are given from the command line, the first being the program name
     //  solver_type used for factorization in solving each GMLS problem:
     //      0 - SVD used for factorization in solving each GMLS problem
     //      1 - QR  used for factorization in solving each GMLS problem
+    //      2 - LU  used for factorization in solving each GMLS problem
     int solver_type = 1; // QR by default
     if (argc >= 5) {
         int arg5toi = atoi(args[4]);
@@ -280,11 +304,32 @@ bool all_passed = true;
         solver_name = "SVD";
     } else if (solver_type == 1) { // QR
         solver_name = "QR";
+    } else if (solver_type == 2) { // LU
+        solver_name = "LU";
+    }
+
+    // problem name for passing into the GMLS class
+    std::string problem_name;
+    if (problem_type == 0) { // Standard
+        problem_name = "STANDARD";
+    } else if (problem_type == 1) { // Manifold
+        problem_name = "MANIFOLD";
+    }
+
+    // boundary name for passing into the GMLS class
+    std::string boundary_name;
+    if (boundary_type == 0) { // Dirichlet
+        boundary_name = "DIRICHLET";
+    } else if (boundary_type == 1) { // Neumann
+        boundary_name = "NEUMANN";
     }
     
     // initialize an instance of the GMLS class 
-    GMLS my_GMLS(VectorTaylorPolynomial, VectorPointSample, order, solver_name.c_str(), 2 /*manifold order*/, dimension);
-    
+    GMLS my_GMLS(VectorTaylorPolynomial, VectorPointSample,
+                 order, dimension,
+                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 2 /*manifold order*/);
+
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
     //
     // neighbor lists have the format:

--- a/src/Compadre_Evaluator.hpp
+++ b/src/Compadre_Evaluator.hpp
@@ -362,7 +362,7 @@ public:
 
         typedef Kokkos::View<output_data_type, output_array_layout, output_memory_space> output_view_type;
 
-        auto problem_type = _gmls->getDenseSolverType();
+        auto problem_type = _gmls->getProblemType();
         auto global_dimensions = _gmls->getGlobalDimensions();
         auto output_dimension_of_operator = _gmls->getOutputDimensionOfOperation(lro);
         auto input_dimension_of_operator = _gmls->getInputDimensionOfOperation(lro);
@@ -652,7 +652,7 @@ public:
 
         typedef Kokkos::View<output_data_type, output_array_layout, output_memory_space> output_view_type;
 
-        auto problem_type = _gmls->getDenseSolverType();
+        auto problem_type = _gmls->getProblemType();
         auto global_dimensions = _gmls->getGlobalDimensions();
         auto output_dimension_of_operator = _gmls->getOutputDimensionOfOperation(lro);
         auto input_dimension_of_operator = _gmls->getInputDimensionOfOperation(lro);

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -116,7 +116,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
     int this_num_cols = _basis_multiplier*_NP;
     int manifold_NP = 0;
 
-    if (_dense_solver_type == DenseSolverType::MANIFOLD) {
+    if (_problem_type == ProblemType::MANIFOLD) {
         // these dimensions already calculated differ in the case of manifolds
         manifold_NP = this->getNP(_curvature_poly_order, _dimensions-1, ReconstructionSpace::ScalarTaylorPolynomial);
         _NP = this->getNP(_poly_order, _dimensions-1, _reconstruction_space);
@@ -204,7 +204,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
         Kokkos::deep_copy(_P, 0.0);
         Kokkos::deep_copy(_w, 0.0);
         
-        if (_dense_solver_type == DenseSolverType::MANIFOLD) {
+        if (_problem_type == ProblemType::MANIFOLD) {
 
             /*
              *    MANIFOLD Problems
@@ -330,7 +330,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
          */
 
 
-        if (_dense_solver_type == DenseSolverType::MANIFOLD) {
+        if (_problem_type == ProblemType::MANIFOLD) {
 
             /*
              *    MANIFOLD Problems
@@ -1114,7 +1114,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
             });
         });
     } else if (_data_sampling_functional == StaggeredEdgeIntegralSample) {
-        compadre_kernel_assert_debug(_dense_solver_type==DenseSolverType::MANIFOLD && "StaggeredEdgeIntegralSample prestencil weight only written for manifolds.");
+        compadre_kernel_assert_debug(_problem_type==ProblemType::MANIFOLD && "StaggeredEdgeIntegralSample prestencil weight only written for manifolds.");
         Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this->getNNeighbors(target_index)), [=] (const int m) {
             Kokkos::single(Kokkos::PerThread(teamMember), [&] () {
                 for (int quadrature = 0; quadrature<_number_of_quadrature_points; ++quadrature) {

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -998,6 +998,9 @@ void GMLS::operator()(const AssembleManifoldPsqrtW&, const member_type& teamMemb
         }
     });
 
+    // Quang will put LU here
+    // Q will need conditionally set like Coeffs was
+
     teamMember.team_barrier();
 }
 

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -778,19 +778,20 @@ public:
          const std::string dense_solver_type = std::string("QR"),
          const std::string problem_type = std::string("STANDARD"),
          const std::string boundary_type = std::string("DIRICHLET"),
-         const int manifold_curvature_poly_order = 2) : GMLS(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, VectorPointSample, VectorPointSample, poly_order, dimensions, dense_solver_type, problem_type, boundary_type, manifold_curvature_poly_order) {}
+         const int manifold_curvature_poly_order = 2)
+      : GMLS(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, VectorPointSample, VectorPointSample, poly_order, dimensions, dense_solver_type, problem_type, boundary_type, manifold_curvature_poly_order) {}
 
     //! Constructor for the case when nonstandard sampling functionals or reconstruction spaces
     //! are to be used. Reconstruction space and sampling strategy can only be set at instantiation.
     GMLS(ReconstructionSpace reconstruction_space,
-            SamplingFunctional dual_sampling_strategy,
-            const int poly_order,
-            const int dimensions = 3,
-            const std::string dense_solver_type = std::string("QR"),
-            const std::string problem_type = std::string("STANDARD"),
-            const std::string boundary_type = std::string("DIRICHLET"),
-            const int manifold_curvature_poly_order = 2)
-                : GMLS(reconstruction_space, dual_sampling_strategy, dual_sampling_strategy, poly_order, dimensions, dense_solver_type, problem_type, boundary_type, manifold_curvature_poly_order) {}
+         SamplingFunctional dual_sampling_strategy,
+         const int poly_order,
+         const int dimensions = 3,
+         const std::string dense_solver_type = std::string("QR"),
+         const std::string problem_type = std::string("STANDARD"),
+         const std::string boundary_type = std::string("DIRICHLET"),
+         const int manifold_curvature_poly_order = 2)
+      : GMLS(reconstruction_space, dual_sampling_strategy, dual_sampling_strategy, poly_order, dimensions, dense_solver_type, problem_type, boundary_type, manifold_curvature_poly_order) {}
 
     //! Destructor
     ~GMLS(){

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -685,6 +685,8 @@ public:
                         && (data_sampling_strategy == VectorPointSample)) ? ManifoldVectorPointSample : data_sampling_strategy)
             {
 
+        // Quang put the assertion here
+
         // seed random number generator pool
         _random_number_pool = pool_type(1);
 

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -703,7 +703,13 @@ public:
                         && (data_sampling_strategy == VectorPointSample)) ? ManifoldVectorPointSample : data_sampling_strategy)
             {
 
-        // Quang put the assertion here
+        // Asserting available problems and solvers
+        if ((_problem_type == ProblemType::MANIFOLD) && (_dense_solver_type == DenseSolverType::LU)) {
+            compadre_kernel_assert_release((false) && "LU solver hasn't been implemented for manifold problems yet.");
+        }
+        if (_boundary_type == BoundaryType::NEUMANN) {
+            compadre_kernel_assert_release((false) && "Neumann boundary type hasn't been implemented yet.");
+        }
 
         // seed random number generator pool
         _random_number_pool = pool_type(1);

--- a/src/Compadre_GMLS_Basis.hpp
+++ b/src/Compadre_GMLS_Basis.hpp
@@ -249,7 +249,7 @@ void GMLS::calcPij(double* delta, const int target_index, int neighbor_index, co
             }
         }
     } else if (polynomial_sampling_functional == StaggeredEdgeIntegralSample) {
-          if (_dense_solver_type == DenseSolverType::MANIFOLD) {
+          if (_problem_type == ProblemType::MANIFOLD) {
               double cutoff_p = _epsilons(target_index);
               int alphax, alphay;
               double alphaf;

--- a/src/Compadre_Operators.hpp
+++ b/src/Compadre_Operators.hpp
@@ -183,6 +183,14 @@ namespace Compadre {
         MANIFOLD, 
     };
 
+    //! Problem type, that optionally can handle manifolds
+    enum BoundaryType {
+        //! Dirichlet BC Type
+        DIRICHLET,
+        //! Neumann BC Type
+        NEUMANN,
+    };
+
     //! Available weighting kernel function types
     enum WeightingFunctionType {
         Power,

--- a/src/Compadre_Operators.hpp
+++ b/src/Compadre_Operators.hpp
@@ -183,7 +183,7 @@ namespace Compadre {
         MANIFOLD, 
     };
 
-    //! Problem type, that optionally can handle manifolds
+    //! Boundary type, to determine whether it's Dirichlet or Neumann
     enum BoundaryType {
         //! Dirichlet BC Type
         DIRICHLET,

--- a/src/Compadre_Operators.hpp
+++ b/src/Compadre_Operators.hpp
@@ -164,17 +164,23 @@ namespace Compadre {
         //! For polynomial dotted with tangent
         FaceTangentPointSample = make_sampling_functional(1,0,false,false,(int)Identity);
 
-    //! Dense solver type, that optionally can also handle manifolds
+    //! Dense solver type
     enum DenseSolverType {
         //! QR factorization performed on P*sqrt(w) matrix
         QR, 
         //! SVD factorization performed on P*sqrt(w) matrix
         SVD, 
+        //! LU factorization performed on P^T*W*P matrix
+        LU, 
+    };
+
+    //! Problem type, that optionally can handle manifolds
+    enum ProblemType {
+        //! Standard GMLS problem type
+        STANDARD, 
         //! Solve GMLS problem on a manifold (will use QR or SVD to solve the resultant GMLS 
         //! problem dependent on SamplingNontrivialNullspace
         MANIFOLD, 
-        //! LU factorization performed on P^T*W*P matrix
-        LU, 
     };
 
     //! Available weighting kernel function types


### PR DESCRIPTION
* Add `problem_type`, `solver_type` and `boundary_type` as extra arguments to the `GMLS` class.

* Redefine the `enum` inside `Compadre_Evaluators.hpp`

* Adjust the `*.cpp` and `*.py.in` files inside `examples` to use the new interface of the `GMLS` class.

* Add explicit input arguments into `examples/CMakeLists.txt` to illustrate the use of additional parameters.

* Add assertion in the constructor of `GMLS` class to indicate the current state of implementation.