### PR TITLE
Removed dual DOF manager styles, so now only "blocked" exists

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -186,7 +186,7 @@ if (CompadreHarness_EXAMPLES AND CompadreHarness_USE_Trilinos)
 
     # MANIFOLD OPERATOR CONVERGENCE TESTS
 
-    ADD_TEST(NAME ManifoldTest COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 1 ${CMAKE_CURRENT_BINARY_DIR}/laplaceBeltrami.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/laplace_beltrami/parameters_basic.xml" "--kokkos-threads=1") # tests whatever is specified in parameters_basic
+    ADD_TEST(NAME ManifoldTest COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 2 ${CMAKE_CURRENT_BINARY_DIR}/laplaceBeltrami.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/laplace_beltrami/parameters_basic.xml" "--kokkos-threads=1") # tests whatever is specified in parameters_basic
     SET_TESTS_PROPERTIES(ManifoldTest PROPERTIES LABELS "lapbel")
     
     ADD_TEST(NAME ManifoldScalarTest COMMAND "python" "${CMAKE_CURRENT_BINARY_DIR}/../test_data/utilities/manifold_operator_convergence.py" "4" "2" "0") # 4 polynomial order, 2 successive meshes, 0-scalar interpolation

--- a/examples/Compadre_BasisFunction.cpp
+++ b/examples/Compadre_BasisFunction.cpp
@@ -297,7 +297,7 @@ int main (int argc, char* args[]) {
                 dim,
                 parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense solver type"),
                 parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                 parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder")));
     
         _GMLS->setProblemData(kokkos_neighbor_lists_host,

--- a/physics/Compadre_AdvectionDiffusion_BoundaryConditions.cpp
+++ b/physics/Compadre_AdvectionDiffusion_BoundaryConditions.cpp
@@ -33,7 +33,7 @@ void AdvectionDiffusionBoundaryConditions::flagBoundaries() {
 
 void AdvectionDiffusionBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
 
-    // DIRICHLET boundaries dealt with through SIP
+    // NO_CONSTRAINT boundaries dealt with through SIP
 
 
 	//Teuchos::RCP<Compadre::AnalyticFunction> function;

--- a/physics/Compadre_AdvectionDiffusion_Operator.cpp
+++ b/physics/Compadre_AdvectionDiffusion_Operator.cpp
@@ -178,7 +178,7 @@ void AdvectionDiffusionPhysics::computeMatrix(local_index_type field_one, local_
     // GMLS operator
     GMLS my_GMLS(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
                  2 /* dimension */,
-                 "QR", "STANDARD", "DIRICHLET");
+                 "QR", "STANDARD", "NO_CONSTRAINT");
     my_GMLS.setProblemData(kokkos_neighbor_lists_host,
                     kokkos_augmented_source_coordinates_host,
                     kokkos_target_coordinates,

--- a/physics/Compadre_AdvectionDiffusion_Operator.cpp
+++ b/physics/Compadre_AdvectionDiffusion_Operator.cpp
@@ -40,14 +40,13 @@ Teuchos::RCP<crs_graph_type> AdvectionDiffusionPhysics::computeGraph(local_index
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
 	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	//#pragma omp parallel for
     for(local_index_type i = 0; i < nlocal; i++) {
         local_index_type num_neighbors = neighborhood->getNeighbors(i).size();
         for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-            local_index_type row = local_to_dof_map[i][field_one][k];
+            local_index_type row = local_to_dof_map(i, field_one, k);
 
             Teuchos::Array<local_index_type> col_data(num_neighbors * fields[field_two]->nDim());
             Teuchos::ArrayView<local_index_type> cols = Teuchos::ArrayView<local_index_type>(col_data);
@@ -55,7 +54,7 @@ Teuchos::RCP<crs_graph_type> AdvectionDiffusionPhysics::computeGraph(local_index
 
             for (local_index_type l = 0; l < num_neighbors; l++) {
                 for (local_index_type n = 0; n < fields[field_two]->nDim(); ++n) {
-                    col_data[l*fields[field_two]->nDim() + n] = local_to_dof_map[static_cast<local_index_type>(neighbors[l].first)][field_two][n];
+                    col_data[l*fields[field_two]->nDim() + n] = local_to_dof_map(static_cast<local_index_type>(neighbors[l].first), field_two, n);
                 }
             }
             //#pragma omp critical
@@ -78,16 +77,12 @@ void AdvectionDiffusionPhysics::computeMatrix(local_index_type field_one, local_
 
     TEUCHOS_TEST_FOR_EXCEPT_MSG(this->_A.is_null(), "Tpetra CrsMatrix for Physics not yet specified.");
 
-    bool blocked_matrix = _parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked");
-
     //Loop over all particles, convert to GMLS data types, solve problem, and insert into matrix:
 
     const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
-    const local_index_type ntotalfielddimensions = this->_particles->getFieldManagerConst()->getTotalFieldDimensions();
     const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
     const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-    const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-            _dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
     const host_view_type bc_id = this->_particles->getFlags()->getLocalView<host_view_type>();
 
 
@@ -232,11 +227,11 @@ void AdvectionDiffusionPhysics::computeMatrix(local_index_type field_one, local_
 
         //Put the values of alpha in the proper place in the global matrix
         for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-            local_index_type row = local_to_dof_map[i][field_one][k];
+            local_index_type row = local_to_dof_map(i, field_one, k);
 
             for (local_index_type l = 0; l < num_neighbors; l++) {
                 for (local_index_type n = 0; n < fields[field_two]->nDim(); ++n) {
-                    col_data(l*fields[field_two]->nDim() + n) = local_to_dof_map[static_cast<local_index_type>(neighbors[l].first)][field_two][n];
+                    col_data(l*fields[field_two]->nDim() + n) = local_to_dof_map(static_cast<local_index_type>(neighbors[l].first), field_two, n);
                     if (n==k) { // same field, same component
 
                         // have interaction between two basis functions
@@ -247,7 +242,7 @@ void AdvectionDiffusionPhysics::computeMatrix(local_index_type field_one, local_
 
                         // implicitly this is dof = particle#*ntotalfielddimension so this is just getting the particle number from dof
                         // and checking its boundary condition
-                        local_index_type corresponding_particle_id = blocked_matrix ? row/fields[field_one]->nDim() : row/ntotalfielddimensions;
+                        local_index_type corresponding_particle_id = row/fields[field_one]->nDim();
                         if (bc_id(corresponding_particle_id, 0) != 0) {
                             if (i==static_cast<local_index_type>(neighbors[l].first)) {
                                 val_data(l*fields[field_two]->nDim() + n) = 1.0;

--- a/physics/Compadre_AdvectionDiffusion_Sources.cpp
+++ b/physics/Compadre_AdvectionDiffusion_Sources.cpp
@@ -30,13 +30,12 @@ void AdvectionDiffusionSources::evaluateRHS(local_index_type field_one, local_in
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
 		// get dof corresponding to field
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			const local_index_type dof = local_to_dof_map[i][field_one][k];
+			const local_index_type dof = local_to_dof_map(i, field_one, k);
 			xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
 			if (bc_id(i,0)==0) rhs_vals(dof,0) = -function->evalScalarLaplacian(pt);
 		}

--- a/physics/Compadre_GMLS_CurlCurl_BoundaryConditions.cpp
+++ b/physics/Compadre_GMLS_CurlCurl_BoundaryConditions.cpp
@@ -48,13 +48,12 @@ void GMLS_CurlCurlBoundaryConditions::applyBoundaries(local_index_type field_one
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+	const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
 		// get dof corresponding to field
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			const local_index_type dof = local_to_dof_map[i][field_one][k];
+			const local_index_type dof = local_to_dof_map(i, field_one, k);
 			xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
 			if (bc_id(i,0)==1) rhs_vals(dof,0) = function->evalVector(pt)[k];
 		}

--- a/physics/Compadre_GMLS_CurlCurl_Operator.cpp
+++ b/physics/Compadre_GMLS_CurlCurl_Operator.cpp
@@ -40,8 +40,7 @@ Teuchos::RCP<crs_graph_type> GMLS_CurlCurlPhysics::computeGraph(local_index_type
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
 	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	// generate the interpolation operator and call the coefficients needed (storing them)
 	const coords_type* target_coords = this->_coords;
@@ -58,7 +57,7 @@ Teuchos::RCP<crs_graph_type> GMLS_CurlCurlPhysics::computeGraph(local_index_type
 	for(local_index_type i = 0; i < nlocal; i++) {
 		local_index_type num_neighbors = neighborhood->getNeighbors(i).size();
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			local_index_type row = local_to_dof_map[i][field_one][k];
+			local_index_type row = local_to_dof_map(i, field_one, k);
 
 			Teuchos::Array<local_index_type> col_data(max_num_neighbors * fields[field_two]->nDim());
 			Teuchos::ArrayView<local_index_type> cols = Teuchos::ArrayView<local_index_type>(col_data);
@@ -66,7 +65,7 @@ Teuchos::RCP<crs_graph_type> GMLS_CurlCurlPhysics::computeGraph(local_index_type
 
 			for (local_index_type l = 0; l < num_neighbors; l++) {
 				for (local_index_type n = 0; n < fields[field_two]->nDim(); ++n) {
-					col_data[l*fields[field_two]->nDim() + n] = local_to_dof_map[static_cast<local_index_type>(neighbors[l].first)][field_two][n];
+					col_data[l*fields[field_two]->nDim() + n] = local_to_dof_map(static_cast<local_index_type>(neighbors[l].first), field_two, n);
 				}
 			}
 			//#pragma omp critical
@@ -92,8 +91,8 @@ void GMLS_CurlCurlPhysics::computeMatrix(local_index_type field_one, local_index
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
 	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 	const host_view_type bc_id = this->_particles->getFlags()->getLocalView<host_view_type>();
 
 
@@ -197,11 +196,11 @@ void GMLS_CurlCurlPhysics::computeMatrix(local_index_type field_one, local_index
 
 		//Put the values of alpha in the proper place in the global matrix
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-                    local_index_type row = local_to_dof_map[i][field_one][k];
+                    local_index_type row = local_to_dof_map(i, field_one, k);
 
                     for (local_index_type l = 0; l < num_neighbors; l++) {
                         for (local_index_type n = 0; n < fields[field_two]->nDim(); ++n) {
-                            col_data(l*fields[field_two]->nDim() + n) = local_to_dof_map[static_cast<local_index_type>(neighbors[l].first)][field_two][n];
+                            col_data(l*fields[field_two]->nDim() + n) = local_to_dof_map(static_cast<local_index_type>(neighbors[l].first), field_two, n);
                             // implicitly this is dof = particle#*ntotalfielddimension so this is just getting the particle number from dof
                             // and checking its boundary condition
                             if (bc_id(i, 0) == 1) {

--- a/physics/Compadre_GMLS_CurlCurl_Operator.cpp
+++ b/physics/Compadre_GMLS_CurlCurl_Operator.cpp
@@ -168,7 +168,7 @@ void GMLS_CurlCurlPhysics::computeMatrix(local_index_type field_one, local_index
                      VectorPointSample,
                      _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
                      3 /* dimension */,
-                     "SVD", "STANDARD", "DIRICHLET");
+                     "SVD", "STANDARD", "NO_CONSTRAINT");
 	my_GMLS.setProblemData(kokkos_neighbor_lists_host,
 					kokkos_augmented_source_coordinates_host,
 					kokkos_target_coordinates,

--- a/physics/Compadre_GMLS_CurlCurl_Sources.cpp
+++ b/physics/Compadre_GMLS_CurlCurl_Sources.cpp
@@ -35,13 +35,12 @@ void GMLS_CurlCurlSources::evaluateRHS(local_index_type field_one, local_index_t
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
 		// get dof corresponding to field
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			const local_index_type dof = local_to_dof_map[i][field_one][k];
+			const local_index_type dof = local_to_dof_map(i, field_one, k);
 			xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
 			if (bc_id(i,0)==0) rhs_vals(dof,0) = function->evalVector(pt)[k];
 		}

--- a/physics/Compadre_GMLS_PinnedLaplacian_BoundaryConditions.cpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_BoundaryConditions.cpp
@@ -47,13 +47,12 @@ void GMLS_PinnedLaplacianBoundaryConditions::applyBoundaries(local_index_type fi
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+	const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
 		// get dof corresponding to field
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			const local_index_type dof = local_to_dof_map[i][field_one][k];
+			const local_index_type dof = local_to_dof_map(i, field_one, k);
 			xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
 			if (bc_id(i,0)==1) rhs_vals(dof,0) = function->evalScalar(pt);
 		}

--- a/physics/Compadre_GMLS_PinnedLaplacian_Operator.cpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_Operator.cpp
@@ -40,14 +40,13 @@ Teuchos::RCP<crs_graph_type> GMLS_LaplacianPhysics::computeGraph(local_index_typ
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
 	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	//#pragma omp parallel for
 	for(local_index_type i = 0; i < nlocal; i++) {
 		local_index_type num_neighbors = neighborhood->getNeighbors(i).size();
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			local_index_type row = local_to_dof_map[i][field_one][k];
+			local_index_type row = local_to_dof_map(i, field_one, k);
 
 			Teuchos::Array<local_index_type> col_data(num_neighbors * fields[field_two]->nDim());
 			Teuchos::ArrayView<local_index_type> cols = Teuchos::ArrayView<local_index_type>(col_data);
@@ -55,7 +54,7 @@ Teuchos::RCP<crs_graph_type> GMLS_LaplacianPhysics::computeGraph(local_index_typ
 
 			for (local_index_type l = 0; l < num_neighbors; l++) {
 				for (local_index_type n = 0; n < fields[field_two]->nDim(); ++n) {
-					col_data[l*fields[field_two]->nDim() + n] = local_to_dof_map[static_cast<local_index_type>(neighbors[l].first)][field_two][n];
+					col_data[l*fields[field_two]->nDim() + n] = local_to_dof_map(static_cast<local_index_type>(neighbors[l].first), field_two, n);
 				}
 			}
 			//#pragma omp critical
@@ -78,16 +77,13 @@ void GMLS_LaplacianPhysics::computeMatrix(local_index_type field_one, local_inde
 
 	TEUCHOS_TEST_FOR_EXCEPT_MSG(this->_A.is_null(), "Tpetra CrsMatrix for Physics not yet specified.");
 
-	bool blocked_matrix = _parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked");
-
 	//Loop over all particles, convert to GMLS data types, solve problem, and insert into matrix:
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const local_index_type ntotalfielddimensions = this->_particles->getFieldManagerConst()->getTotalFieldDimensions();
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
 	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 	const host_view_type bc_id = this->_particles->getFlags()->getLocalView<host_view_type>();
 
 
@@ -198,15 +194,15 @@ void GMLS_LaplacianPhysics::computeMatrix(local_index_type field_one, local_inde
 
 		//Put the values of alpha in the proper place in the global matrix
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			local_index_type row = local_to_dof_map[i][field_one][k];
+			local_index_type row = local_to_dof_map(i, field_one, k);
 
 			for (local_index_type l = 0; l < num_neighbors; l++) {
 				for (local_index_type n = 0; n < fields[field_two]->nDim(); ++n) {
-					col_data(l*fields[field_two]->nDim() + n) = local_to_dof_map[static_cast<local_index_type>(neighbors[l].first)][field_two][n];
+					col_data(l*fields[field_two]->nDim() + n) = local_to_dof_map(static_cast<local_index_type>(neighbors[l].first), field_two, n);
 					if (n==k) { // same field, same component
 						// implicitly this is dof = particle#*ntotalfielddimension so this is just getting the particle number from dof
 						// and checking its boundary condition
-						local_index_type corresponding_particle_id = blocked_matrix ? row/fields[field_one]->nDim() : row/ntotalfielddimensions;
+						local_index_type corresponding_particle_id = row/fields[field_one]->nDim();
 						if (bc_id(corresponding_particle_id, 0) != 0) {
 							if (i==static_cast<local_index_type>(neighbors[l].first)) {
 								val_data(l*fields[field_two]->nDim() + n) = 1.0;

--- a/physics/Compadre_GMLS_PinnedLaplacian_Operator.cpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_Operator.cpp
@@ -162,7 +162,7 @@ void GMLS_LaplacianPhysics::computeMatrix(local_index_type field_one, local_inde
                      3 /* dimension */,
                      "QR" /* dense sovler type */,
                      "STANDARD" /* problem type */,
-                     "DIRICHLET");
+                     "NO_CONSTRAINT");
 	my_GMLS.setProblemData(kokkos_neighbor_lists_host,
 			       kokkos_augmented_source_coordinates_host,
 			       kokkos_target_coordinates,

--- a/physics/Compadre_GMLS_PinnedLaplacian_Sources.cpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_Sources.cpp
@@ -34,13 +34,12 @@ void GMLS_PinnedLaplacianSources::evaluateRHS(local_index_type field_one, local_
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
 		// get dof corresponding to field
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			const local_index_type dof = local_to_dof_map[i][field_one][k];
+			const local_index_type dof = local_to_dof_map(i, field_one, k);
 			xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
 			if (bc_id(i,0)==0) rhs_vals(dof,0) = function->evalScalarLaplacian(pt);
 		}

--- a/physics/Compadre_GMLS_StaggeredAnalytic_PinnedLaplacian_Operator.cpp
+++ b/physics/Compadre_GMLS_StaggeredAnalytic_PinnedLaplacian_Operator.cpp
@@ -162,7 +162,7 @@ void GMLS_StaggeredAnalytic_LaplacianPhysics::computeMatrix(local_index_type fie
                      StaggeredEdgeAnalyticGradientIntegralSample,
                      _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
                      3 /* dimension */,
-                     "QR", "STANDARD", "DIRICHLET");
+                     "QR", "STANDARD", "NO_CONSTRAINT");
 	my_GMLS.setProblemData(kokkos_neighbor_lists_host,
                                kokkos_augmented_source_coordinates_host,
                                kokkos_target_coordinates,

--- a/physics/Compadre_GMLS_StaggeredIntegral_PinnedLaplacian_Operator.cpp
+++ b/physics/Compadre_GMLS_StaggeredIntegral_PinnedLaplacian_Operator.cpp
@@ -163,7 +163,7 @@ void GMLS_StaggeredIntegral_LaplacianPhysics::computeMatrix(local_index_type fie
                      StaggeredEdgeAnalyticGradientIntegralSample,
                      _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
                      3 /* dimension */,
-                     "QR", "STANDARD", "DIRICHLET");
+                     "QR", "STANDARD", "NO_CONSTRAINT");
 	my_GMLS.setProblemData(kokkos_neighbor_lists_host,
                                kokkos_augmented_source_coordinates_host,
                                kokkos_target_coordinates,

--- a/physics/Compadre_GMLS_StaggeredIntegral_PinnedLaplacian_Operator.cpp
+++ b/physics/Compadre_GMLS_StaggeredIntegral_PinnedLaplacian_Operator.cpp
@@ -40,14 +40,13 @@ Teuchos::RCP<crs_graph_type> GMLS_StaggeredIntegral_LaplacianPhysics::computeGra
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
 	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	//#pragma omp parallel for
 	for(local_index_type i = 0; i < nlocal; i++) {
 		local_index_type num_neighbors = neighborhood->getNeighbors(i).size();
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			local_index_type row = local_to_dof_map[i][field_one][k];
+			local_index_type row = local_to_dof_map(i, field_one, k);
 
 			Teuchos::Array<local_index_type> col_data(num_neighbors * fields[field_two]->nDim());
 			Teuchos::ArrayView<local_index_type> cols = Teuchos::ArrayView<local_index_type>(col_data);
@@ -55,7 +54,7 @@ Teuchos::RCP<crs_graph_type> GMLS_StaggeredIntegral_LaplacianPhysics::computeGra
 
 			for (local_index_type l = 0; l < num_neighbors; l++) {
 				for (local_index_type n = 0; n < fields[field_two]->nDim(); ++n) {
-					col_data[l*fields[field_two]->nDim() + n] = local_to_dof_map[static_cast<local_index_type>(neighbors[l].first)][field_two][n];
+					col_data[l*fields[field_two]->nDim() + n] = local_to_dof_map(static_cast<local_index_type>(neighbors[l].first), field_two, n);
 				}
 			}
 			//#pragma omp critical
@@ -78,16 +77,13 @@ void GMLS_StaggeredIntegral_LaplacianPhysics::computeMatrix(local_index_type fie
 
 	TEUCHOS_TEST_FOR_EXCEPT_MSG(this->_A.is_null(), "Tpetra CrsMatrix for Physics not yet specified.");
 
-	bool blocked_matrix = _parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked");
-
 	//Loop over all particles, convert to GMLS data types, solve problem, and insert into matrix:
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const local_index_type ntotalfielddimensions = this->_particles->getFieldManagerConst()->getTotalFieldDimensions();
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
 	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 	const host_view_type bc_id = this->_particles->getFlags()->getLocalView<host_view_type>();
 
 
@@ -199,15 +195,15 @@ void GMLS_StaggeredIntegral_LaplacianPhysics::computeMatrix(local_index_type fie
 
 		//Put the values of alpha in the proper place in the global matrix
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			local_index_type row = local_to_dof_map[i][field_one][k];
+			local_index_type row = local_to_dof_map(i, field_one, k);
 
 			for (local_index_type l = 0; l < num_neighbors; l++) {
 				for (local_index_type n = 0; n < fields[field_two]->nDim(); ++n) {
-					col_data(l*fields[field_two]->nDim() + n) = local_to_dof_map[static_cast<local_index_type>(neighbors[l].first)][field_two][n];
+					col_data(l*fields[field_two]->nDim() + n) = local_to_dof_map(static_cast<local_index_type>(neighbors[l].first), field_two, n);
 					if (n==k) { // same field, same component
 						// implicitly this is dof = particle#*ntotalfielddimension so this is just getting the particle number from dof
 						// and checking its boundary condition
-						local_index_type corresponding_particle_id = blocked_matrix ? row/fields[field_one]->nDim() : row/ntotalfielddimensions;
+						local_index_type corresponding_particle_id = row/fields[field_one]->nDim();
 						if (bc_id(corresponding_particle_id, 0) != 0) {
 							if (i==static_cast<local_index_type>(neighbors[l].first)) {
 								val_data(l*fields[field_two]->nDim() + n) = 1.0;

--- a/physics/Compadre_LagrangianShallowWater_BoundaryConditions.cpp
+++ b/physics/Compadre_LagrangianShallowWater_BoundaryConditions.cpp
@@ -44,13 +44,12 @@ void LagrangianShallowWaterBoundaryConditions::applyBoundaries(local_index_type 
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			this->_particles->getDOFManagerConst()->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
 		// get dof corresponding to field
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			const local_index_type dof = local_to_dof_map[i][field_one][k];
+			const local_index_type dof = local_to_dof_map(i, field_one, k);
 			xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
 			if (bc_id(i,0)==1) rhs_vals(dof,0) = function->evalScalar(pt);
 		}

--- a/physics/Compadre_LagrangianShallowWater_Operator.cpp
+++ b/physics/Compadre_LagrangianShallowWater_Operator.cpp
@@ -101,8 +101,7 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
 	TEUCHOS_TEST_FOR_EXCEPT_MSG(this->_b.is_null(), "Tpetra multivector for Physics not yet specified.");
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			this->_particles->getDOFManagerConst()->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 	const host_view_type bc_id = this->_particles->getFlags()->getLocalView<host_view_type>();
 	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
@@ -498,7 +497,7 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
 
 
 				for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-					local_index_type row = local_to_dof_map[i][field_one][k];
+					local_index_type row = local_to_dof_map(i, field_one, k);
 
 					b_data(row,0) = 0;
 
@@ -638,7 +637,7 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
                 scratch_matrix_right_type td
                         (tangent_directions.data() + i*3*3, 3, 3);
 
-				local_index_type row = local_to_dof_map[i][field_one][0];
+				local_index_type row = local_to_dof_map(i, field_one, 0);
 
 				double reconstructed_h = 0;
 				double reconstructed_div_v = 0;
@@ -855,7 +854,7 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
 //				force[2] -= dot_product * normal_direction.z;
 
 				for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-					local_index_type row = local_to_dof_map[i][field_one][k];
+					local_index_type row = local_to_dof_map(i, field_one, k);
 					if (k==0) {
 						b_data(row, 0) = force[0];
 					} else if (k==1) {

--- a/physics/Compadre_LagrangianShallowWater_Operator.cpp
+++ b/physics/Compadre_LagrangianShallowWater_Operator.cpp
@@ -177,7 +177,7 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
                             target_coords->nDim(),
                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                             _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 	my_scalar_GMLS.setProblemData(
 			kokkos_neighbor_lists_host,
@@ -195,7 +195,7 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
                             target_coords->nDim(),
                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                             _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 
 	my_vector_GMLS.setProblemData(
@@ -223,7 +223,7 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
                             target_coords->nDim(),
                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                             _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 
 		my_GMLS_staggered_grad.setProblemData(
@@ -567,7 +567,7 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
                                 target_coords->nDim(),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 		my_GMLS_staggered_div.setProblemData(
 			kokkos_neighbor_lists_host,

--- a/physics/Compadre_LaplaceBeltrami_BoundaryConditions.cpp
+++ b/physics/Compadre_LaplaceBeltrami_BoundaryConditions.cpp
@@ -45,8 +45,7 @@ void LaplaceBeltramiBoundaryConditions::applyBoundaries(local_index_type field_o
 
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	if (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("solution") && field_two == _particles->getFieldManagerConst()->getIDOfFieldFromName("solution")) {
 
@@ -55,7 +54,7 @@ void LaplaceBeltramiBoundaryConditions::applyBoundaries(local_index_type field_o
 
 			const local_index_type components_of_field_for_rhs = 1;
 			for (local_index_type k = 0; k < components_of_field_for_rhs; ++k) {
-				const local_index_type dof = local_to_dof_map[i][field_one][k];
+				const local_index_type dof = local_to_dof_map(i, field_one, k);
 				xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
 	//			if (bc_id(i,0)==0) rhs_vals(dof,0) = function->evalScalar(pt);
 	//			if (bc_id(i,0)==1) rhs_vals(dof,0) = 1;//function->evalScalar(pt);

--- a/physics/Compadre_LaplaceBeltrami_Operator.cpp
+++ b/physics/Compadre_LaplaceBeltrami_Operator.cpp
@@ -422,7 +422,7 @@ if (field_one == solution_field_id && field_two == solution_field_id) {
                              target_coords->nDim(),
                              _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense solver type"),
                              _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                              _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 
 //		GMLS my_GMLS (ReconstructionSpace::VectorTaylorPolynomial,
@@ -518,7 +518,7 @@ if (field_one == solution_field_id && field_two == solution_field_id) {
                              target_coords->nDim(),
                              _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense solver type"),
                              _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                             _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                              _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 
 //		GMLS my_GMLS (ReconstructionSpace::VectorTaylorPolynomial,
@@ -631,7 +631,7 @@ if (field_one == solution_field_id && field_two == solution_field_id) {
                                 target_coords->nDim(),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense solver type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 		my_GMLS_staggered_grad.setProblemData(
 				kokkos_neighbor_lists_host,
@@ -653,7 +653,7 @@ if (field_one == solution_field_id && field_two == solution_field_id) {
                                 target_coords->nDim(),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense solver type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 		my_GMLS_staggered_div.setProblemData(
 				kokkos_neighbor_lists_host,
@@ -832,7 +832,7 @@ if (field_one == solution_field_id && field_two == solution_field_id) {
                                 target_coords->nDim(),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense solver type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 		my_GMLS_staggered_grad.setProblemData(
 				kokkos_neighbor_lists_host,
@@ -854,7 +854,7 @@ if (field_one == solution_field_id && field_two == solution_field_id) {
                                 target_coords->nDim(),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense solver type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                                 _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
 		my_GMLS_staggered_div.setProblemData(
 				kokkos_neighbor_lists_host,

--- a/physics/Compadre_LaplaceBeltrami_Sources.cpp
+++ b/physics/Compadre_LaplaceBeltrami_Sources.cpp
@@ -36,8 +36,7 @@ void LaplaceBeltramiSources::evaluateRHS(local_index_type field_one, local_index
 	host_view_type pts = this->_coords->getPts()->getLocalView<host_view_type>();
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	if (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("solution") && field_two == _particles->getFieldManagerConst()->getIDOfFieldFromName("solution")) {
 
@@ -45,7 +44,7 @@ void LaplaceBeltramiSources::evaluateRHS(local_index_type field_one, local_index
 		// get dof corresponding to field
 		const local_index_type components_of_field_for_rhs = 1;
 		for (local_index_type k = 0; k < components_of_field_for_rhs; ++k) {
-			const local_index_type dof = local_to_dof_map[i][field_one][k];
+			const local_index_type dof = local_to_dof_map(i, field_one, k);
 			xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
 
 //			if (std::abs((1.0-pts(i,0))*(1.0-pts(i,0)))+std::abs((0.0-pts(i,1))*(0.0+pts(i,1)))+std::abs((0.0-pts(i,2))*(0.0+pts(i,2)))<1.0e-1) {

--- a/physics/Compadre_PinnedGraphLaplacian_BoundaryConditions.cpp
+++ b/physics/Compadre_PinnedGraphLaplacian_BoundaryConditions.cpp
@@ -33,13 +33,12 @@ void PinnedGraphLaplacianBoundaryConditions::applyBoundaries(local_index_type fi
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
 		// get dof corresponding to field
 		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-			const local_index_type dof = local_to_dof_map[i][field_one][k];
+			const local_index_type dof = local_to_dof_map(i, field_one, k);
 			if (bc_id(i,0)==1) rhs_vals(dof,0) = 50.0;
 			if (bc_id(i,0)==2) rhs_vals(dof,0) = 0.0;
 		}

--- a/physics/Compadre_PinnedGraphLaplacian_Sources.cpp
+++ b/physics/Compadre_PinnedGraphLaplacian_Sources.cpp
@@ -25,15 +25,13 @@ void PinnedGraphLaplacianSources::evaluateRHS(local_index_type field_one, local_
 
 	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
 	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-			_dof_data->getDOFMap();
-
+    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
 	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
 		// get dof corresponding to field
 		if (bc_id(i,0)==0) { // bc_id is by particle
 			for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-				const local_index_type dof = local_to_dof_map[i][field_one][k];
+				const local_index_type dof = local_to_dof_map(i, field_one, k);
 				rhs_vals(dof,0) = 0.0;
 			}
 		}

--- a/src/CompadreHarness_Typedefs.hpp
+++ b/src/CompadreHarness_Typedefs.hpp
@@ -51,6 +51,7 @@ namespace Compadre {
 
     typedef Tpetra::Vector<scalar_type, local_index_type, global_index_type> vec_scalar_type;
     typedef Tpetra::Import<local_index_type, global_index_type> importer_type;
+    typedef Tpetra::Export<local_index_type, global_index_type> exporter_type;
 
     typedef typename mvec_scalar_type::dual_view_type dual_view_scalar_type;
     typedef typename mvec_local_index_type::dual_view_type dual_view_local_index_type;
@@ -76,6 +77,8 @@ namespace Compadre {
 
     typedef Tpetra::Operator<scalar_type, local_index_type,
                                 global_index_type, node_type> op_type;
+
+    typedef Kokkos::View<local_index_type***, Kokkos::DefaultHostExecutionSpace> local_dof_map_view_type;
 
 #ifdef TRILINOS_LINEAR_SOLVES
     typedef Thyra::MultiVectorBase<scalar_type> thyra_mvec_type;

--- a/src/Compadre_DOFData.cpp
+++ b/src/Compadre_DOFData.cpp
@@ -32,11 +32,11 @@ local_index_type DOFData::getDOFFromLID(const local_index_type particle_num,
 		const local_index_type field_num, const local_index_type component_num) const {
 	// access to LOCAL dof# from particle x field x component
 	// includes dofs for halo particles
-	TEUCHOS_TEST_FOR_EXCEPT_MSG(&_particle_field_component_to_dof_map==NULL, "generateDOFMap() never called");
-	return _particle_field_component_to_dof_map[particle_num][field_num][component_num];
+	TEUCHOS_TEST_FOR_EXCEPT_MSG(_particle_field_component_to_dof_map.data()==NULL, "generateDOFMap() never called");
+	return _particle_field_component_to_dof_map(particle_num, field_num, component_num);
 }
 
-const std::vector<std::vector<std::vector<local_index_type> > >& DOFData::getDOFMap() const {
+local_dof_map_view_type DOFData::getDOFMap() const {
 	return _particle_field_component_to_dof_map;
 }
 
@@ -54,7 +54,7 @@ void DOFData::setColMap(Teuchos::RCP<map_type> map, local_index_type idx) { // o
 	else _dof_col_map[idx] = map;
 }
 
-void DOFData::setDOFMap(std::vector<std::vector<std::vector<local_index_type> > > particle_field_component_to_dof_map) {
+void DOFData::setDOFMap(local_dof_map_view_type particle_field_component_to_dof_map) {
 	_particle_field_component_to_dof_map = particle_field_component_to_dof_map;
 }
 

--- a/src/Compadre_DOFData.hpp
+++ b/src/Compadre_DOFData.hpp
@@ -13,7 +13,7 @@ class DOFData {
 		Teuchos::RCP<Teuchos::ParameterList> _parameters;
 		std::vector<Teuchos::RCP<map_type> > _dof_row_map; // contains only dofs local to this processor
 		std::vector<Teuchos::RCP<map_type> > _dof_col_map; // contains only dofs local to this processor and in the halo
-		std::vector<std::vector<std::vector<local_index_type> > > _particle_field_component_to_dof_map;
+        local_dof_map_view_type _particle_field_component_to_dof_map;
 
 	public:
 
@@ -30,7 +30,7 @@ class DOFData {
 
 		local_index_type getDOFFromLID(const local_index_type particle_num, const local_index_type field_num, const local_index_type component_num) const;
 
-		const std::vector<std::vector<std::vector<local_index_type> > >& getDOFMap() const;
+		local_dof_map_view_type getDOFMap() const;
 
 		local_index_type getNumberOfFields() const {
 			return _dof_row_map.size();
@@ -40,7 +40,7 @@ class DOFData {
 
 		void setColMap(Teuchos::RCP<map_type> map, local_index_type idx=-1);
 
-		void setDOFMap(std::vector<std::vector<std::vector<local_index_type> > > particle_field_component_to_dof_map);
+		void setDOFMap(local_dof_map_view_type  particle_field_component_to_dof_map);
 
 };
 

--- a/src/Compadre_DOFManager.hpp
+++ b/src/Compadre_DOFManager.hpp
@@ -50,7 +50,7 @@ class DOFManager {
 			return this->_particle_dof_data->getDOFFromLID(particle_num, field_num, component_num);
 		}
 
-		const std::vector<std::vector<std::vector<local_index_type> > >& getDOFMap() const {
+		local_dof_map_view_type getDOFMap() const {
 			return this->_particle_dof_data->getDOFMap();
 		}
 

--- a/src/Compadre_FieldManager.cpp
+++ b/src/Compadre_FieldManager.cpp
@@ -141,78 +141,27 @@ void FieldManager::updateFieldsFromVector(Teuchos::RCP<mvec_type> source, local_
 	Teuchos::RCP<const map_type> particle_map = _particles->getCoordsConst()->getMapConst(false /* no halo */);
 	const_gid_view_type particle_gids_locally_owned = particle_map->getMyGlobalIndices();
 
-	if (field_num == -1 && !(_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked"))) { // update everything in the normal way from this vector
-		// update all fields from vector
+	TEUCHOS_TEST_FOR_EXCEPT_MSG(field_num==-1, "field_num must be specified for updateFieldsFromVector.");
 
-		// If field_num not given, then the implication is that all fields should
-		// be copied, which requires that the dof_data for the particle set
-		// and the vector be the same. Here, we check that this is true:
+	// Determine if the vector given to fill the field is larger than the # of entries in the field, in
+	// which case we assume it is a global vector of all fields, and we find the appropriate offset.
+	// Otherwise if they are the same size, we assume the vector is only for this field.
 
-		const local_index_type vector_row_map_entries = source->getMap()->getNodeNumElements();
-		const local_index_type field_row_map_entries = _particles->getDOFManagerConst()->getRowMap(0)->getNodeNumElements();
-		TEUCHOS_TEST_FOR_EXCEPT_MSG(vector_row_map_entries != field_row_map_entries, "For unblocked DOFs, DOF data for fields do not match the vector provided.");
+	// blocked update (vector used to update only contains this field)
 
-		host_view_type source_data = source->getLocalView<host_view_type>();
+	host_view_type field_vals = _fields[field_num]->getLocalVectorVals()->getLocalView<host_view_type>(); // just this fields current info
 
-		// copy data from source to field_vals
-		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,_fields.size()), KOKKOS_LAMBDA(const int i) {
-			host_view_type field_vals = _fields[i]->getLocalVectorVals()->getLocalView<host_view_type>(); // just this field's old info
-			for (size_t j=0; j<particle_gids_locally_owned.extent(0); j++) {
-				for (local_index_type k=0; k<_fields[i]->nDim(); k++) {
-					// assumes dofs from every field are on this vector
-					field_vals(j,k) = source_data(j*this->getTotalFieldDimensions() + this->getFieldOffset(i) + k,0);
-				}
-			}
-			_fields[i]->syncMemory();
-		});
+	host_view_type source_data = source->getLocalView<host_view_type>(); // this field's new info
 
-		this->updateFieldsHaloData();
-
-	} else if (field_num!=-1 && !(_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked"))) {
-
-		// all info available in this vector, but choosing to only update one field
-
-		host_view_type field_vals = _fields[field_num]->getLocalVectorVals()->getLocalView<host_view_type>(); // just this field's old info
-
-		host_view_type source_data = source->getLocalView<host_view_type>(); // contains all fields' new info
-
-		const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-				vector_dof_data->getDOFMap();
-
-		// copy data from source to field_vals
-		for (size_t i=0; i<particle_gids_locally_owned.extent(0); ++i) {
-			for (local_index_type j=0; j<_fields[field_num]->nDim(); j++) {
-				const local_index_type dof = local_to_dof_map[i][field_num][j]; // index of first entry for this field
-				field_vals(i,j) = source_data(dof,0);
-			}
+	// copy data from source to field_vals
+	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,particle_gids_locally_owned.dimension_0()), KOKKOS_LAMBDA(const int i) {
+		for (local_index_type j=0; j<_fields[field_num]->nDim(); j++) {
+			field_vals(i,j) = source_data(i*this->_fields[field_num]->nDim() + j,0);
 		}
+	});
 
-		_fields[field_num]->syncMemory();
+	this->updateFieldsHaloData(field_num);
 
-		this->updateFieldsHaloData(field_num);
-
-	} else if (field_num!=-1) { // specific field from a blocked DOF data
-
-		// Determine if the vector given to fill the field is larger than the # of entries in the field, in
-		// which case we assume it is a global vector of all fields, and we find the appropriate offset.
-		// Otherwise if they are the same size, we assume the vector is only for this field.
-
-		// blocked update (vector used to update only contains this field)
-
-		host_view_type field_vals = _fields[field_num]->getLocalVectorVals()->getLocalView<host_view_type>(); // just this fields current info
-
-		host_view_type source_data = source->getLocalView<host_view_type>(); // this field's new info
-
-		// copy data from source to field_vals
-		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,particle_gids_locally_owned.dimension_0()), KOKKOS_LAMBDA(const int i) {
-			for (local_index_type j=0; j<_fields[field_num]->nDim(); j++) {
-				field_vals(i,j) = source_data(i*this->_fields[field_num]->nDim() + j,0);
-			}
-		});
-
-		this->updateFieldsHaloData(field_num);
-
-	}
 }
 
 void FieldManager::updateVectorFromFields(Teuchos::RCP<mvec_type> target, local_index_type field_num, Teuchos::RCP<const dof_data_type> vector_dof_data) const {
@@ -226,68 +175,20 @@ void FieldManager::updateVectorFromFields(Teuchos::RCP<mvec_type> target, local_
 	Teuchos::RCP<const map_type> particle_map = _particles->getCoordsConst()->getMapConst(false /* no halo */);
 	const_gid_view_type particle_gids_locally_owned = particle_map->getMyGlobalIndices();
 
-	if (field_num == -1 && !(_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked"))) { // update everything in the normal way from this vector
-		// update all fields from vector
+	TEUCHOS_TEST_FOR_EXCEPT_MSG(field_num==-1, "field_num must be specified for updateVectorFromFields.");
 
-		// If field_num not given, then the implication is that all fields should
-		// be copied, which requires that the dof_data for the particle set
-		// and the vector be the same. Here, we check that this is true:
+	// blocked update (vector used to update only contains this field)
 
-		const local_index_type vector_row_map_entries = target->getMap()->getNodeNumElements();
-		const local_index_type field_row_map_entries = _particles->getDOFManagerConst()->getRowMap(0)->getNodeNumElements();
-		TEUCHOS_TEST_FOR_EXCEPT_MSG(vector_row_map_entries != field_row_map_entries, "For unblocked DOFs, DOF data for fields do not match the vector provided.");
+	host_view_type field_vals = _fields[field_num]->getLocalVectorVals()->getLocalView<host_view_type>(); // just this fields current info
 
-		host_view_type target_data = target->getLocalView<host_view_type>();
+	host_view_type target_data = target->getLocalView<host_view_type>(); // this field's new info
 
-		// copy data from source to field_vals
-		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,_fields.size()), KOKKOS_LAMBDA(const int i) {
-			host_view_type field_vals = _fields[i]->getLocalVectorVals()->getLocalView<host_view_type>(); // just this field's old info
-			for (size_t j=0; j<particle_gids_locally_owned.dimension_0(); j++) {
-				for (local_index_type k=0; k<_fields[i]->nDim(); k++) {
-					// assumes dofs from every field are on this vector
-					target_data(j*this->getTotalFieldDimensions() + this->getFieldOffset(i) + k,0) = field_vals(j,k);
-				}
-			}
-		});
-
-
-	} else if (field_num!=-1 && !(_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked"))) {
-		// TODO: create test for this capability
-
-		// all info available in this vector, but choosing to only update one field
-
-		host_view_type field_vals = _fields[field_num]->getLocalVectorVals()->getLocalView<host_view_type>(); // just this field's old info
-
-		host_view_type target_data = target->getLocalView<host_view_type>(); // contains all fields' new info
-
-		const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-				vector_dof_data->getDOFMap();
-
-		// copy data from source to field_vals
-		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,particle_gids_locally_owned.dimension_0()), KOKKOS_LAMBDA(const int i) {
-			host_view_type field_vals = _fields[field_num]->getLocalVectorVals()->getLocalView<host_view_type>();
-			for (local_index_type j=0; j<_fields[field_num]->nDim(); j++) {
-				const local_index_type dof = local_to_dof_map[i][field_num][j];
-				target_data(dof,0) = field_vals(i,j);
-			}
-		});
-
-	} else {
-
-		// blocked update (vector used to update only contains this field)
-
-		host_view_type field_vals = _fields[field_num]->getLocalVectorVals()->getLocalView<host_view_type>(); // just this fields current info
-
-		host_view_type target_data = target->getLocalView<host_view_type>(); // this field's new info
-
-		// copy data from source to field_vals
-		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,particle_gids_locally_owned.dimension_0()), KOKKOS_LAMBDA(const int i) {
-			for (local_index_type j=0; j<_fields[field_num]->nDim(); j++) {
-				target_data(i*this->_fields[field_num]->nDim() + j,0) = field_vals(i,j);
-			}
-		});
-
-	}
+	// copy data from source to field_vals
+	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,particle_gids_locally_owned.dimension_0()), KOKKOS_LAMBDA(const int i) {
+		for (local_index_type j=0; j<_fields[field_num]->nDim(); j++) {
+			target_data(i*this->_fields[field_num]->nDim() + j,0) = field_vals(i,j);
+		}
+	});
 }
 
 const std::vector<Teuchos::RCP<FieldManager::field_type> >& FieldManager::getVectorOfFields() const {

--- a/src/Compadre_OptimizationManager.hpp
+++ b/src/Compadre_OptimizationManager.hpp
@@ -30,7 +30,7 @@ struct OptimizationObject {
     scalar_type _global_lower_bound;
     scalar_type _global_upper_bound;
 
-    OptimizationObject(OptimizationAlgorithm optimization_algorithm = NONE, bool single_linear_bound_constraint = true, 
+    OptimizationObject(OptimizationAlgorithm optimization_algorithm = NONE, bool single_linear_bound_constraint = true,
             bool bounds_preservation = true, scalar_type global_lower_bound = std::numeric_limits<scalar_type>::lowest(), 
             scalar_type global_upper_bound = std::numeric_limits<scalar_type>::max()) :
         _optimization_algorithm(optimization_algorithm), _single_linear_bound_constraint(single_linear_bound_constraint),

--- a/src/Compadre_ParameterManager.cpp
+++ b/src/Compadre_ParameterManager.cpp
@@ -99,7 +99,7 @@ void ParameterManager::setDefaultParameters() {
 	remapList->set("neighbors needed multiplier", 1.2);
 	remapList->set("dense solver type", "QR");
 	remapList->set("problem type", "STANDARD");
-	remapList->set("boundary type", "DIRICHLET");
+	remapList->set("constraint type", "NO_CONSTRAINT");
 	remapList->set("weighting power", (local_index_type)8);
 	remapList->set("weighting type", "power");
 	// weighting type for covariance matrix from which a tangent plane to the manifold is derived

--- a/src/Compadre_ProblemExplicitTransientT.cpp
+++ b/src/Compadre_ProblemExplicitTransientT.cpp
@@ -800,12 +800,12 @@ void ProblemExplicitTransientT::solve(local_index_type rk_order, scalar_type t_0
 									host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
 									host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
 
-									const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
+									const local_dof_map_view_type local_to_dof_map =
 											this->_particles->getDOFManagerConst()->getDOFMap();
 
 									for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
 										for (local_index_type l=0; l<3; ++l) {
-											local_index_type vdof = local_to_dof_map[k][field_one][l];
+											local_index_type vdof = local_to_dof_map(k, field_one, l);
 											reference_data(vdof,0) = 0;
 											rk_offsets_data(vdof,0) = 0;
 											updated_data(vdof,0) = 0;

--- a/src/Compadre_ProblemT.cpp
+++ b/src/Compadre_ProblemT.cpp
@@ -110,13 +110,12 @@ void ProblemT::initialize(scalar_type initial_simulation_time) {
     // has type "Global" rather than "Banded", then it is not supported
     // for the nonblocked style (because nonblocked assumes all
     // field are of the "Banded" style)
-    // In the future, could export a blocked matrix to a single matrix 
-    // block as a way of enforcing the unblocked approach
+    // Putting this in a single matrix implies having a row DOF that is
+    // shared between multiple processors, which breaks Amesos2, Ifpack2, etc...
     for (InteractingFields interaction:_field_interactions) {
         auto src_sparsity_type = _particles->getFieldManager()->getFieldByID(interaction.src_fieldnum)->getFieldSparsityType();
         auto trg_sparsity_type = _particles->getFieldManager()->getFieldByID(interaction.trg_fieldnum)->getFieldSparsityType();
         TEUCHOS_TEST_FOR_EXCEPT_MSG(_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==false && (src_sparsity_type == FieldSparsityType::Global), "Non-blocked matrix system incompatible with global FieldSparsityType.");
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==false && (trg_sparsity_type == FieldSparsityType::Global), "Non-blocked matrix system incompatible with global FieldSparsityType.");
     }
 
 
@@ -172,37 +171,20 @@ void ProblemT::initialize(scalar_type initial_simulation_time) {
     }
 
     // now that we know actual # of blocks we can build a DOF data with the DOF manager
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-        // regenerate DOF information, because we have a local ordering specific to our field interactions
-        _problem_dof_data = _particles->getDOFManager()->generateDOFMap(_block_row_to_field_map);
-    } else {
-        // otherwise we need to generate the information for the requested fields
-        _problem_dof_data = _particles->getDOFManager()->generateDOFMap(_block_row_to_field_map);
-    }
+    // regenerate DOF information, because we have a local ordering specific to our field interactions
+    _problem_dof_data = _particles->getDOFManager()->generateDOFMap(_block_row_to_field_map);
 
     // now that we know actual # of blocks, we can set up the graphs, and row and column maps
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-        row_map.resize(row_count);
-        col_map.resize(col_count);
-        _b.resize(row_count);
-        _A = std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > (row_count, std::vector<Teuchos::RCP<crs_matrix_type> > (col_count, Teuchos::null));
-        A_graph = std::vector<std::vector<Teuchos::RCP<crs_graph_type> > > (row_count, std::vector<Teuchos::RCP<crs_graph_type> > (col_count, Teuchos::null));
-        row_map = std::vector<Teuchos::RCP<const map_type> > (row_count, Teuchos::null);
-        col_map = std::vector<Teuchos::RCP<const map_type> > (col_count, Teuchos::null);
+    row_map.resize(row_count);
+    col_map.resize(col_count);
+    _b.resize(row_count);
+    _A = std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > (row_count, std::vector<Teuchos::RCP<crs_matrix_type> > (col_count, Teuchos::null));
+    A_graph = std::vector<std::vector<Teuchos::RCP<crs_graph_type> > > (row_count, std::vector<Teuchos::RCP<crs_graph_type> > (col_count, Teuchos::null));
+    row_map = std::vector<Teuchos::RCP<const map_type> > (row_count, Teuchos::null);
+    col_map = std::vector<Teuchos::RCP<const map_type> > (col_count, Teuchos::null);
 
-        for (InteractingFields field_interaction : _field_interactions) {
-            buildMaps(field_interaction.src_fieldnum, field_interaction.trg_fieldnum);
-        }
-    } else {
-        row_map.resize(1);
-        col_map.resize(1);
-        _b.resize(1);
-        _A = std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > (1, std::vector<Teuchos::RCP<crs_matrix_type> > (1, Teuchos::null));
-        A_graph = std::vector<std::vector<Teuchos::RCP<crs_graph_type> > > (1, std::vector<Teuchos::RCP<crs_graph_type> > (1, Teuchos::null));
-        row_map = std::vector<Teuchos::RCP<const map_type> > (1, Teuchos::null);
-        col_map = std::vector<Teuchos::RCP<const map_type> > (1, Teuchos::null);
-
-        buildMaps();
+    for (InteractingFields field_interaction : _field_interactions) {
+        buildMaps(field_interaction.src_fieldnum, field_interaction.trg_fieldnum);
     }
 
     // first is graph construction
@@ -210,42 +192,31 @@ void ProblemT::initialize(scalar_type initial_simulation_time) {
         local_index_type field_one = field_interaction.src_fieldnum;
         local_index_type field_two = field_interaction.trg_fieldnum;
 
-        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-        local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+        local_index_type row_block = _field_to_block_row_map[field_one];
+        local_index_type col_block = _field_to_block_col_map[field_two];
 
         // build the graph
 
         this->buildGraphs(field_one, field_two);
 
         // complete each block after graph computed
-        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-            A_graph[row_block][col_block]->fillComplete(_problem_dof_data->getRowMap(col_block), _problem_dof_data->getRowMap(row_block));
-        }
-    }
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==false) {
-        A_graph[0][0]->fillComplete();
+        A_graph[row_block][col_block]->fillComplete(_problem_dof_data->getRowMap(col_block), _problem_dof_data->getRowMap(row_block));
     }
 
     for (InteractingFields field_interaction : _field_interactions) {
         local_index_type field_one = field_interaction.src_fieldnum;
         local_index_type field_two = field_interaction.trg_fieldnum;
 
-        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-        local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+        local_index_type row_block = _field_to_block_row_map[field_one];
+        local_index_type col_block = _field_to_block_col_map[field_two];
 
         assembleBCS(field_one, field_two);
         assembleRHS(field_one, field_two);
         assembleOperator(field_one, field_two);
-        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-            if (_A[row_block][col_block]->isFillActive())
-                _A[row_block][col_block]->fillComplete(_problem_dof_data->getRowMap(col_block), _problem_dof_data->getRowMap(row_block));
+        if (_A[row_block][col_block]->isFillActive()) {
+            _A[row_block][col_block]->fillComplete(_problem_dof_data->getRowMap(col_block), _problem_dof_data->getRowMap(row_block));
         }
     }
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==false) {
-        if (_A[0][0]->isFillActive())
-            _A[0][0]->fillComplete();
-    }
-
 }
 
 void ProblemT::solve() {
@@ -283,13 +254,9 @@ void ProblemT::solve() {
     for (InteractingFields field_interaction : _field_interactions) {
         local_index_type field_one = field_interaction.src_fieldnum;
 
-        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+        local_index_type row_block = _field_to_block_row_map[field_one];
 
-        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-            _particles->getFieldManager()->updateFieldsFromVector(_solver->getSolution(row_block), field_one, _problem_dof_data);
-        } else {
-            _particles->getFieldManager()->updateFieldsFromVector(_solver->getSolution(), field_one, _problem_dof_data);
-        }
+        _particles->getFieldManager()->updateFieldsFromVector(_solver->getSolution(row_block), field_one, _problem_dof_data);
     }
 }
 
@@ -298,63 +265,38 @@ void ProblemT::buildMaps(local_index_type field_one, local_index_type field_two)
     local_index_type row_block = _field_to_block_row_map[field_one];
     local_index_type col_block = _field_to_block_col_map[field_two];
 
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-        if (row_map[row_block].is_null()) {
-            row_map[row_block] = _problem_dof_data->getRowMap(row_block);
-        }
-        if (col_map[col_block].is_null()) {
-            col_map[col_block] = _problem_dof_data->getColMap(col_block);
-        }
-    } else {
-        if (row_map[0].is_null()) {
-            row_map[0] = _problem_dof_data->getRowMap(); // get all dofs
-        }
-        if (col_map[0].is_null()) {
-            col_map[0] = _problem_dof_data->getColMap();
-        }
+    if (row_map[row_block].is_null()) {
+        row_map[row_block] = _problem_dof_data->getRowMap(row_block);
+    }
+    if (col_map[col_block].is_null()) {
+        col_map[col_block] = _problem_dof_data->getColMap(col_block);
     }
 }
 
 void ProblemT::buildGraphs(local_index_type field_one, local_index_type field_two) {
     if (field_two<0) field_two = field_one;
-    local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-    local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+    local_index_type row_block = _field_to_block_row_map[field_one];
+    local_index_type col_block = _field_to_block_col_map[field_two];
 
     TEUCHOS_TEST_FOR_EXCEPT_MSG(_OP.is_null(), "Physics not set before assembleOperator() called.");
     _OP->setParameters(*_parameters);
 
     _OP->setDOFData(_problem_dof_data);
 
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")) {
-        if (row_map[row_block].is_null()) {
-            buildMaps(field_one, field_two);
-        }
-        if (A_graph[row_block][col_block].is_null()) {
-            local_index_type field_one_dim = _particles->getFieldManagerConst()->getFieldByID(field_one)->nDim();
-            local_index_type field_two_dim = _particles->getFieldManagerConst()->getFieldByID(field_two)->nDim();
-            A_graph[row_block][col_block] = Teuchos::rcp(new crs_graph_type (row_map[row_block], col_map[col_block], _particles->getNeighborhood()->getMaxNumNeighbors()*field_one_dim*field_two_dim, Tpetra::StaticProfile));
-        }
-        // _OP sets the initial graph and may change it
-        _OP->setGraph(A_graph[row_block][col_block]);
-        _OP->setRowMap(row_map[row_block]);
-        _OP->setColMap(col_map[col_block]);
-        // the resulting, potentially changed graph, is now returned
-        A_graph[row_block][col_block] = _OP->computeGraph(field_one, field_two);
-    } else {
-        if (row_map[0].is_null()) {
-            buildMaps();
-        }
-        if (A_graph[0][0].is_null()) {
-            local_index_type sum_num_field_dim = _particles->getFieldManagerConst()->getTotalFieldDimensions();
-            A_graph[0][0] = Teuchos::rcp(new crs_graph_type (row_map[0], col_map[0], _particles->getNeighborhood()->getMaxNumNeighbors()*sum_num_field_dim*sum_num_field_dim, Tpetra::StaticProfile));
-        }
-        // _OP sets the initial graph and may change it
-        _OP->setGraph(A_graph[0][0]);
-        _OP->setRowMap(row_map[row_block]);
-        _OP->setColMap(col_map[col_block]);
-        // the resulting, potentially changed graph, is now returned
-        A_graph[0][0] = _OP->computeGraph(field_one, field_two);
+    if (row_map[row_block].is_null()) {
+        buildMaps(field_one, field_two);
     }
+    if (A_graph[row_block][col_block].is_null()) {
+        local_index_type field_one_dim = _particles->getFieldManagerConst()->getFieldByID(field_one)->nDim();
+        local_index_type field_two_dim = _particles->getFieldManagerConst()->getFieldByID(field_two)->nDim();
+        A_graph[row_block][col_block] = Teuchos::rcp(new crs_graph_type (row_map[row_block], col_map[col_block], _particles->getNeighborhood()->getMaxNumNeighbors()*field_one_dim*field_two_dim, Tpetra::StaticProfile));
+    }
+    // _OP sets the initial graph and may change it
+    _OP->setGraph(A_graph[row_block][col_block]);
+    _OP->setRowMap(row_map[row_block]);
+    _OP->setColMap(col_map[col_block]);
+    // the resulting, potentially changed graph, is now returned
+    A_graph[row_block][col_block] = _OP->computeGraph(field_one, field_two);
 }
 
 void ProblemT::buildSolver() {
@@ -376,23 +318,13 @@ void ProblemT::assembleOperator(local_index_type field_one, local_index_type fie
     TEUCHOS_TEST_FOR_EXCEPT_MSG(_OP.is_null(), "Physics not set before assembleOperator() called.");
     _OP->setParameters(*_parameters);
 
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-        if (_A[row_block][col_block].is_null()) {
-            _A[row_block][col_block] = Teuchos::rcp(new crs_matrix_type (A_graph[row_block][col_block]));
+    if (_A[row_block][col_block].is_null()) {
+        _A[row_block][col_block] = Teuchos::rcp(new crs_matrix_type (A_graph[row_block][col_block]));
 //            local_index_type field_one_dim = _particles->getFieldManagerConst()->getFieldByID(field_one)->nDim();
 //            local_index_type field_two_dim = _particles->getFieldManagerConst()->getFieldByID(field_two)->nDim();
 //            _A[row_block][col_block] = Teuchos::rcp(new crs_matrix_type (row_map[row_block], col_map[col_block], _particles->getNeighborhood()->getMaxNumNeighbors()*field_one_dim*field_two_dim));
-        }
-        _OP->setMatrix(_A[row_block][col_block]);
-    } else {
-        if (_A[0][0].is_null()) {
-            _A[0][0] = Teuchos::rcp(new crs_matrix_type (A_graph[0][0]));
-//            local_index_type field_one_dim = _particles->getFieldManagerConst()->getFieldByID(field_one)->nDim();
-//            local_index_type field_two_dim = _particles->getFieldManagerConst()->getFieldByID(field_two)->nDim();
-//            _A[0][0] = Teuchos::rcp(new crs_matrix_type (row_map[0], col_map[0], _particles->getNeighborhood()->getMaxNumNeighbors()*field_one_dim*field_two_dim));
-            _OP->setMatrix(_A[0][0]);
-        }
     }
+    _OP->setMatrix(_A[row_block][col_block]);
     _OP->computeMatrix(field_one, field_two);
 }
 
@@ -404,19 +336,11 @@ void ProblemT::assembleRHS(local_index_type field_one, local_index_type field_tw
 
     _RHS->setParameters(*_parameters);
 
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-        if (_b[row_block].is_null()) {
-            bool setToZero = true;
-            _b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
-        }
-        _RHS->setMultiVector(_b[row_block]);
-    } else {
-        if (_b[0].is_null()) {
-            bool setToZero = true;
-            _b[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
-        }
-        _RHS->setMultiVector(_b[0]);
+    if (_b[row_block].is_null()) {
+        bool setToZero = true;
+        _b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
     }
+    _RHS->setMultiVector(_b[row_block]);
     _RHS->setDOFData(_problem_dof_data);
     _RHS->evaluateRHS(field_one, field_two, 0.0);
 }
@@ -429,21 +353,12 @@ void ProblemT::assembleBCS(local_index_type field_one, local_index_type field_tw
 
     _BCS->setParameters(*_parameters);
 
-    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-        // fill out this row block of b
-        if (_b[row_block].is_null()) {
-            bool setToZero = true;
-            _b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
-        }
-        _BCS->setMultiVector(_b[row_block]);
-    } else {
-        // generate b if in the zero, zero block
-        if (_b[0].is_null()) {
-            bool setToZero = true;
-            _b[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
-        }
-        _BCS->setMultiVector(_b[0]);
+    // fill out this row block of b
+    if (_b[row_block].is_null()) {
+        bool setToZero = true;
+        _b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
     }
+    _BCS->setMultiVector(_b[row_block]);
     _BCS->setDOFData(_problem_dof_data);
     _BCS->flagBoundaries();
     _BCS->applyBoundaries(field_one, field_two, 0.0);

--- a/src/Compadre_RemapManager.cpp
+++ b/src/Compadre_RemapManager.cpp
@@ -149,7 +149,7 @@ void RemapManager::execute(bool keep_neighborhoods, bool use_physical_coords) {
                         _parameters->get<Teuchos::ParameterList>("remap").get<int>("dimensions"),
                         _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense solver type"),
                         _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                        _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("boundary type"),
+                        _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
                         _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder")));
     
                 _GMLS->setProblemData(kokkos_neighbor_lists_host,

--- a/src/Compadre_SolverT.cpp
+++ b/src/Compadre_SolverT.cpp
@@ -22,112 +22,336 @@
 
 #include <Stratimikos_MueLuHelpers.hpp>
 
+#include <set>
 
 namespace Compadre {
 
+void SolverT::amalgamateBlockMatrices(std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > A, 
+        std::vector<Teuchos::RCP<mvec_type> > b) {
+
+    // This function can handle row map != range map (row dof shared between many processors, 
+    // but owned by only one). However, even though the matrix is correct, it can't be handled
+    // properly by Amesos2, Ifpack2, or MueLu with more than one level of coarsening.
+    
+    // There is an assumption on row and column maps provided from the blocks, namely that 
+    // locally owned DOFs are ordered first, then non-owned DOFs appear afterwards.
+
+    Teuchos::RCP<map_type> new_row_map;
+    Teuchos::RCP<map_type> new_range_map;
+    std::vector<local_index_type> valid_j_for_i(A.size());
+
+    { // creates new_row_map and new_range_map
+
+        // for each row, do a merge over columns
+        std::set<global_index_type> all_range_indices;
+        std::set<global_index_type> all_row_indices;
+        std::set<global_index_type> ghost_row_indices;
+
+        for (size_t i=0; i<A.size(); ++i) {
+            for (size_t j=0; j<A[0].size(); ++j) {
+                if (!A[i][j].is_null()) {
+                    auto range_indices = A[i][j]->getRangeMap()->getMyGlobalIndices();
+                    auto row_indices = A[i][j]->getRowMap()->getMyGlobalIndices();
+
+                    for (size_t k=0; k<range_indices.extent(0); ++k) {
+                        all_range_indices.insert(range_indices(k));
+                    }
+
+                    all_row_indices.insert(row_indices(0));
+                    bool increasing = true;
+                    for (size_t k=1; k<row_indices.extent(0); ++k) {
+                        increasing &= (row_indices(k) >=  row_indices(k-1));
+                        if (increasing) {
+                            all_row_indices.insert(row_indices(k));
+                        } else {
+                            ghost_row_indices.insert(row_indices(k));
+                        }
+                    }
+                }
+            }
+        }
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(ghost_row_indices.size()>0, "Row map != Range map will not work with most solvers.");
+
+	    Kokkos::View<global_index_type*, Kokkos::HostSpace> new_row_local_indices("local row indices", all_row_indices.size() + ghost_row_indices.size());
+	    Kokkos::View<global_index_type*, Kokkos::HostSpace> new_range_local_indices("local range indices", all_row_indices.size());
+        auto iter = all_row_indices.begin();
+        for (size_t i=0; i<all_row_indices.size(); ++i) {
+            new_range_local_indices(i) = *iter;
+            ++iter;
+        }
+        iter = all_row_indices.begin();
+        for (size_t i=0; i<all_row_indices.size(); ++i) {
+            new_row_local_indices(i) = *iter;
+            ++iter;
+        }
+        iter = ghost_row_indices.begin();
+        for (size_t i=0; i<ghost_row_indices.size(); ++i) {
+            new_row_local_indices(all_row_indices.size() + i) = *iter;
+            ++iter;
+        }
+
+        new_row_map = Teuchos::rcp(new map_type(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), 
+                new_row_local_indices, 0 /*index base*/, _comm));
+        new_range_map = Teuchos::rcp(new map_type(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), 
+                new_range_local_indices, 0 /*index base*/, _comm));
+    } 
+
+    Teuchos::RCP<map_type> new_col_map;
+    Teuchos::RCP<map_type> new_domain_map;
+    std::vector<local_index_type> valid_i_for_j(A[0].size());
+
+    { // creates new_col_map and new_domain_map
+
+        std::set<global_index_type> all_domain_indices;
+        std::set<global_index_type> all_col_indices;
+        std::set<global_index_type> ghost_col_indices;
+
+        for (size_t i=0; i<A.size(); ++i) {
+            for (size_t j=0; j<A[0].size(); ++j) {
+                if (!A[i][j].is_null()) {
+
+                    auto domain_indices = A[i][j]->getDomainMap()->getMyGlobalIndices();
+                    auto col_indices = A[i][j]->getColMap()->getMyGlobalIndices();
+
+                    for (size_t k=0; k<domain_indices.extent(0); ++k) {
+                        all_domain_indices.insert(domain_indices(k));
+                    }
+
+                    all_col_indices.insert(col_indices(0));
+                    bool increasing = true;
+                    for (size_t k=1; k<col_indices.extent(0); ++k) {
+                        increasing &= (col_indices(k) >=  col_indices(k-1));
+                        if (increasing) {
+                            all_col_indices.insert(col_indices(k));
+                        } else {
+                            ghost_col_indices.insert(col_indices(k));
+                        }
+                    }
+                }
+            }
+        }
+	    Kokkos::View<global_index_type*, Kokkos::HostSpace> new_col_local_indices("local col indices", all_col_indices.size() + ghost_col_indices.size());
+	    Kokkos::View<global_index_type*, Kokkos::HostSpace> new_domain_local_indices("local domain indices", all_col_indices.size());
+        auto iter = all_col_indices.begin();
+        for (size_t i=0; i<all_col_indices.size(); ++i) {
+            new_domain_local_indices(i) = *iter;
+            ++iter;
+        }
+        iter = all_col_indices.begin();
+        for (size_t i=0; i<all_col_indices.size(); ++i) {
+            new_col_local_indices(i) = *iter;
+            ++iter;
+        }
+        iter = ghost_col_indices.begin();
+        for (size_t i=0; i<ghost_col_indices.size(); ++i) {
+            new_col_local_indices(all_col_indices.size() + i) = *iter;
+            ++iter;
+        }
+
+        new_col_map = Teuchos::rcp(new map_type(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), 
+                new_col_local_indices, 0 /*index base*/, _comm));
+        new_domain_map = Teuchos::rcp(new map_type(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), 
+                new_domain_local_indices, 0 /*index base*/, _comm));
+    }
+
+    // get size for maximum entries per row
+    local_index_type max_entries_per_row_over_all_rows = 0;
+    for (size_t i=0; i<A.size(); ++i) {
+        local_index_type max_entries_this_row = 0;
+        for (size_t j=0; j<A[i].size(); ++j) {
+            if (!A[i][j].is_null()) {
+                max_entries_this_row += A[i][j]->getCrsGraph()->getGlobalMaxNumRowEntries();
+            }
+        }
+        //max_entries_per_row_over_all_rows = std::max(max_entries_per_row_over_all_rows, max_entries_this_row);
+        max_entries_per_row_over_all_rows += max_entries_this_row;
+    }
+
+    // create giant graph using new maps
+    auto A_single_block_graph = Teuchos::rcp(new crs_graph_type(new_row_map, new_col_map, max_entries_per_row_over_all_rows, Tpetra::StaticProfile));
+
+    _row_exporters.resize(A.size()); // from each block row to global
+    _range_exporters.resize(A.size()); // from each block row to global
+    _col_exporters.resize(A.size()); // from each block col to global
+    _domain_exporters.resize(A.size()); // from each block col to global
+
+    for (size_t i=0; i<A.size(); ++i) {
+        _row_exporters[i].resize(A[0].size()); // from each block row to global
+        _range_exporters[i].resize(A[0].size()); // from each block row to global
+        _col_exporters[i].resize(A[0].size()); // from each block row to global
+        _domain_exporters[i].resize(A[0].size()); // from each block row to global
+        for (size_t j=0; j<A[0].size(); ++j) {
+            if (!A[i][j].is_null()) {
+                _row_exporters[i][j] = Teuchos::rcp(new exporter_type(A[i][j]->getRowMap(), new_row_map));
+                _range_exporters[i][j] = Teuchos::rcp(new exporter_type(A[i][j]->getRangeMap(), new_range_map));
+            }
+        }
+    }
+    for (size_t j=0; j<A[0].size(); ++j) {
+        for (size_t i=0; i<A.size(); ++i) {
+            if (!A[i][j].is_null()) {
+                _col_exporters[i][j] = Teuchos::rcp(new exporter_type(A[i][j]->getColMap(), new_col_map));
+                _domain_exporters[i][j] = Teuchos::rcp(new exporter_type(A[i][j]->getDomainMap(), new_domain_map));
+            }
+        }
+    }
+
+    for (size_t i=0; i<A.size(); ++i) {
+        for (size_t j=0; j<A[0].size(); ++j) {
+            if (!A[i][j].is_null()) {
+                A_single_block_graph->doExport(*(A[i][j]->getCrsGraph()), *(_row_exporters[i][j]), Tpetra::INSERT);
+            }
+        }
+    }
+    A_single_block_graph->fillComplete(new_domain_map, new_range_map);
+
+    _A_single_block = Teuchos::rcp(new crs_matrix_type(A_single_block_graph));
+    for (size_t i=0; i<A.size(); ++i) {
+        for (size_t j=0; j<A[0].size(); ++j) {
+            if (!A[i][j].is_null()) {
+                _A_single_block->doExport(*(A[i][j]), *(_row_exporters[i][j]), Tpetra::INSERT);
+            }
+        }
+    }
+    _A_single_block->fillComplete(new_domain_map, new_range_map);
+
+    _x_single_block = Teuchos::rcp(new mvec_type(_A_single_block->getDomainMap(),1,true/*set to zero*/));
+    _b_single_block = Teuchos::rcp(new mvec_type(_A_single_block->getRangeMap(),1,true/*set to zero*/));
+    for (size_t i=0; i<A.size(); ++i) {
+        _b_single_block->doExport(*(b[i]), *(_range_exporters[i][i]), Tpetra::INSERT);
+    }
+
+}
+
+void SolverT::prepareMatrices() {
+
+    // determines if blocks of matrices need amalgamated into one giant matrix
+    // calls for the amalgamation if necessary
+    // checks if an iterative approach is used, and sets up Thyra objects if it is
+        
+    TEUCHOS_TEST_FOR_EXCEPT_MSG( _parameter_filename.empty() && _parameters->get<std::string>("type")!="direct", 
+            "Parameters not set before solve() called." );
+
+    // direct solvers only work on a single block system
+    // if not blocked, then a single matrix must be constructed from blocks
+    _consolidate_blocks = _A_tpetra.size()>1 
+        && (_parameters->get<std::string>("type")=="direct" || !(_parameters->get<bool>("blocked")));
+   
+    if (_consolidate_blocks) {
+	    this->amalgamateBlockMatrices(_A_tpetra, _b_tpetra);
+    }
+
+    if (_parameters->get<std::string>("type")!="direct") {
+        _A_thyra = Thyra::defaultBlockedLinearOp<scalar_type>();
+        if (_consolidate_blocks) {
+            _A_thyra->beginBlockFill(1,1);
+            auto range_space = Thyra::tpetraVectorSpace<scalar_type>( _A_single_block->getRangeMap() );
+            auto domain_space = Thyra::tpetraVectorSpace<scalar_type>( _A_single_block->getDomainMap() );
+            auto crs_as_operator = 
+                Teuchos::rcp_implicit_cast<Tpetra::Operator<scalar_type, local_index_type, global_index_type> >(_A_single_block);
+            auto tpetra_operator = Thyra::tpetraLinearOp<scalar_type>(range_space,domain_space,crs_as_operator);
+            _A_thyra->setBlock(0, 0, tpetra_operator);
+            _A_thyra->endBlockFill();
+            _b_thyra.resize(1);
+            Teuchos::RCP<const Thyra::TpetraVectorSpace<scalar_type,local_index_type,global_index_type,node_type> > range 
+                = Thyra::tpetraVectorSpace<scalar_type>(_A_single_block->getRangeMap());
+            _b_thyra[0] = Thyra::tpetraVector(range, Teuchos::rcp_static_cast<vec_scalar_type>(_b_single_block));
+        } else {
+            _A_thyra->beginBlockFill(_A_tpetra.size(), _A_tpetra[0].size());
+            for (size_t i=0; i<_A_tpetra.size(); i++) {
+                for (size_t j=0; j<_A_tpetra[0].size(); j++) {
+                    if (!(_A_tpetra[i][j].is_null())) {
+                        auto range_space = Thyra::tpetraVectorSpace<scalar_type>( _A_tpetra[i][j]->getRangeMap() );
+                        auto domain_space = Thyra::tpetraVectorSpace<scalar_type>( _A_tpetra[i][j]->getDomainMap() );
+                        auto crs_as_operator = 
+                            Teuchos::rcp_implicit_cast<Tpetra::Operator<scalar_type, local_index_type, global_index_type> >(_A_tpetra[i][j]);
+                        auto tpetra_operator = Thyra::tpetraLinearOp<scalar_type>(range_space,domain_space,crs_as_operator);
+                        _A_thyra->setBlock(i, j, tpetra_operator);
+                    }
+                }
+            }
+            _A_thyra->endBlockFill();
+            _b_thyra.resize(_b_tpetra.size());
+            for (size_t i=0; i<_b_tpetra.size(); i++) {
+                Teuchos::RCP<const Thyra::TpetraVectorSpace<scalar_type,local_index_type,global_index_type,node_type> > range 
+                    = Thyra::tpetraVectorSpace<scalar_type>(_A_tpetra[i][i]->getRangeMap());
+                _b_thyra[i] = Thyra::tpetraVector(range, Teuchos::rcp_static_cast<vec_scalar_type>(_b_tpetra[i]));
+            }
+        }
+    }
+}
 
 SolverT::SolverT( const Teuchos::RCP<const Teuchos::Comm<int> > comm, std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > A, std::vector<Teuchos::RCP<mvec_type> > b) :
-        _comm(comm)
+        _comm(comm), _consolidate_blocks(false)
 {
+
     _A_tpetra = std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > (A.size(), std::vector<Teuchos::RCP<crs_matrix_type> >(A[0].size(), Teuchos::null));
-    _A = Thyra::defaultBlockedLinearOp<scalar_type>();
-    _A->beginBlockFill(A.size(), A[0].size());
     for (size_t i=0; i<A.size(); i++) {
         _A_tpetra.resize(A[i].size());
         for (size_t j=0; j<A[0].size(); j++) {
             if (!(A[i][j].is_null())) {
-
-                auto range_space = Thyra::tpetraVectorSpace<scalar_type>( A[i][j]->getRangeMap() );
-                auto domain_space = Thyra::tpetraVectorSpace<scalar_type>( A[i][j]->getDomainMap() );
-                auto crs_as_operator = 
-                    Teuchos::rcp_implicit_cast<Tpetra::Operator<scalar_type, local_index_type, global_index_type> >(A[i][j]);
-                auto tpetra_operator = Thyra::tpetraLinearOp<scalar_type>(range_space,domain_space,crs_as_operator);
-
-                //if (i!=j) {
-                //    auto out = Teuchos::getFancyOStream(Teuchos::rcpFromRef(std::cout));
-                //    //tpetra_operator->describe(*out, Teuchos::VERB_EXTREME);
-                //    auto t_mvec = mvec_type(A[i][j]->getDomainMap(),1);
-                //    auto y_mvec = mvec_type(A[i][j]->getRangeMap(),1);
-                //    t_mvec.putScalar(1.0);
-                //    A[i][j]->apply(t_mvec, y_mvec);
-                //    A[i][j]->getRangeMap()->describe(*out, Teuchos::VERB_EXTREME);
-                //    A[i][j]->getDomainMap()->describe(*out, Teuchos::VERB_EXTREME);
-                //    t_mvec.describe(*out, Teuchos::VERB_EXTREME);
-                //    y_mvec.describe(*out, Teuchos::VERB_EXTREME);
-                //    A[i][j]->describe(*out, Teuchos::VERB_EXTREME);
-                //}
-
-                _A->setBlock(i, j, tpetra_operator);
                 _A_tpetra[i][j] = A[i][j];
             }
         }
     }
-    _A->endBlockFill();
 
-    _b.resize(b.size());
     _b_tpetra.resize(b.size());
     for (size_t i=0; i<b.size(); i++) {
-        Teuchos::RCP<const Thyra::TpetraVectorSpace<scalar_type,local_index_type,global_index_type,node_type> > range = Thyra::tpetraVectorSpace<scalar_type>(_A_tpetra[i][i]->getRangeMap());
-        _b[i] = Thyra::tpetraVector(range, Teuchos::rcp_static_cast<vec_scalar_type>(b[i]));
         _b_tpetra[i] = b[i];
     }
 }
 
 void SolverT::solve() {
-    TEUCHOS_TEST_FOR_EXCEPT_MSG( _parameter_filename.empty() && _parameters->get<std::string>("type")!="direct", "Parameters not set before solve() called." );
 
-    // ASSUMES SQUARE (col and row #blocks have same cardinality)
-    _x.resize(_b.size());
-    std::vector<Teko::MultiVector> x(_b.size()); // if this has to be size 1 for nonblocked, then it must be for b also
+
+    TEUCHOS_TEST_FOR_EXCEPT_MSG( _parameter_filename.empty() && _parameters->get<std::string>("type")!="direct", 
+            "Parameters not set before solve() called." );
 
     const bool setToZero = true;
-    if (_parameters->get<bool>("blocked")) {
-        for (size_t i=0; i<_b.size(); i++) {
-            _x[i] = Teuchos::rcp(new mvec_type(_A_tpetra[i][i]->getDomainMap(),1,setToZero));
-            TEUCHOS_TEST_FOR_EXCEPT_MSG(_A_tpetra[i][i]->getDomainMap()==Teuchos::null, "Domain map null.");
-
-            Teuchos::RCP<const Thyra::TpetraVectorSpace<scalar_type,local_index_type,global_index_type,node_type> > domain = Thyra::tpetraVectorSpace<scalar_type>(_A_tpetra[i][i]->getDomainMap());
-            x[i] = Thyra::tpetraVector(domain, Teuchos::rcp_static_cast<vec_scalar_type>(_x[i]));
-
-            TEUCHOS_TEST_FOR_EXCEPT_MSG(x[i].is_null(), "Cast failed.");
-        }
-    } else {
-        _x[0] = Teuchos::rcp(new mvec_type(_A_tpetra[0][0]->getDomainMap(),1,setToZero));
-        Teuchos::RCP<const Thyra::TpetraVectorSpace<scalar_type,local_index_type,global_index_type,node_type> > domain = Thyra::tpetraVectorSpace<scalar_type>(_A_tpetra[0][0]->getDomainMap());
-        x[0] = Thyra::tpetraVector(domain, Teuchos::rcp_static_cast<vec_scalar_type>(_x[0]));
-
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(x[0].is_null(), "Cast failed.");
+    _x_tpetra.resize(_A_tpetra[0].size());
+    for (size_t i=0; i<_A_tpetra[0].size(); i++) {
+        _x_tpetra[i] = Teuchos::rcp(new mvec_type(_A_tpetra[i][i]->getDomainMap(),1,setToZero));
     }
 
-    Teko::MultiVector Thyra_b = Teko::buildBlockedMultiVector(_b);
-    Teko::MultiVector Thyra_x = Teko::buildBlockedMultiVector(x);
-
-    // Diagnostics:
-   // auto out = Teuchos::getFancyOStream(Teuchos::rcpFromRef(std::cout));
-   // Thyra_x->describe(*out, Teuchos::VERB_EXTREME);
-   // Thyra_b->describe(*out, Teuchos::VERB_EXTREME);
-   // _A->describe(*out, Teuchos::VERB_EXTREME);
-
-    Thyra::SolveStatus<scalar_type> status;
-
-
     if (_parameters->get<std::string>("type")=="direct") {
-        TEUCHOS_TEST_FOR_EXCEPT_MSG(_parameters->get<bool>("blocked"), "Blocked matrix used is incompatible with direct solves.");
-        // Ensure that you do not configure for a direct solve and then call an iterative solver
 
         // Constructor from Factory
         Teuchos::RCP<Amesos2::Solver<crs_matrix_type,mvec_type> > solver;
         try{
-            solver = Amesos2::create<crs_matrix_type,mvec_type>("KLU", _A_tpetra[0][0], _x[0], _b_tpetra[0]);
+            // either _consolidate_blocks is true or the blocked matrices are 1x1
+            if (_consolidate_blocks) {
+                solver = Amesos2::create<crs_matrix_type,mvec_type>("KLU", _A_single_block, _x_single_block, _b_single_block);
+            } else { // _A_tpetra.size()==1
+                solver = Amesos2::create<crs_matrix_type,mvec_type>("KLU", _A_tpetra[0][0], _x_tpetra[0], _b_tpetra[0]);
+            }
         } catch (std::invalid_argument e){
             std::cout << e.what() << std::endl;
         }
-
         solver->solve();
         auto out = Teuchos::getFancyOStream(Teuchos::rcpFromRef(std::cout));
         solver->printTiming(*out, Teuchos::VERB_LOW);
 
     } else if (_parameters->get<std::string>("type")=="iterative") {
+
+        // _b_thyra is sized for _consolidate_blocks or not
+        std::vector<Teko::MultiVector> x_teko(_b_thyra.size()); 
+        if (_consolidate_blocks) {
+            Teuchos::RCP<const Thyra::TpetraVectorSpace<scalar_type,local_index_type,global_index_type,node_type> > domain 
+                = Thyra::tpetraVectorSpace<scalar_type>(_A_single_block->getDomainMap());
+            x_teko[0] = Thyra::tpetraVector(domain, Teuchos::rcp_static_cast<vec_scalar_type>(_x_single_block));
+            TEUCHOS_TEST_FOR_EXCEPT_MSG(x_teko[0].is_null(), "Cast failed.");
+        } else {
+            for (size_t i=0; i<_b_thyra.size(); i++) {
+                Teuchos::RCP<const Thyra::TpetraVectorSpace<scalar_type,local_index_type,global_index_type,node_type> > domain 
+                    = Thyra::tpetraVectorSpace<scalar_type>(_A_tpetra[i][i]->getDomainMap());
+                x_teko[i] = Thyra::tpetraVector(domain, Teuchos::rcp_static_cast<vec_scalar_type>(_x_tpetra[i]));
+                TEUCHOS_TEST_FOR_EXCEPT_MSG(x_teko[i].is_null(), "Cast failed.");
+            }
+        }
+
+        Thyra::SolveStatus<scalar_type> status;
+        Teko::MultiVector Thyra_b = Teko::buildBlockedMultiVector(_b_thyra);
+        Teko::MultiVector Thyra_x = Teko::buildBlockedMultiVector(x_teko);
 
         Teuchos::RCP<Teuchos::ParameterList> precList;
         // read in xml file from "file" into ParameterList
@@ -170,7 +394,7 @@ void SolverT::solve() {
         lowsFactory->setVerbLevel(Teuchos::VERB_HIGH);
 
         Teuchos::RCP<Thyra::LinearOpWithSolveBase<scalar_type> > th_invA
-            = Thyra::linearOpWithSolve(*lowsFactory, Teuchos::rcp_dynamic_cast<const thyra_linearop_type>(_A));
+            = Thyra::linearOpWithSolve(*lowsFactory, Teuchos::rcp_dynamic_cast<const thyra_linearop_type>(_A_thyra));
 
         Thyra::assign(Thyra_x.ptr(), 0.0);
         status
@@ -178,9 +402,17 @@ void SolverT::solve() {
 
         *out << "\nSolve status:\n" << status;
 
-//        // DIAGNOSTIC for multiply b by A and storing in x
-//        Thyra::apply<scalar_type>(*Teuchos::rcp_dynamic_cast<const thyra_linearop_type>(_A), Thyra::NOTRANS, *Thyra_b, Thyra_x.ptr());
+//      // DIAGNOSTIC for multiply b by A and storing in x
+//      Thyra::apply<scalar_type>(*Teuchos::rcp_dynamic_cast<const thyra_linearop_type>(_A_thyra), Thyra::NOTRANS, *Thyra_b, Thyra_x.ptr());
 
+    }
+
+    if (_consolidate_blocks) {
+        // move solution from _x_single_block to _x_tpetra
+        for (size_t i=0; i<_x_tpetra.size(); i++) {
+            _x_tpetra[i]->doImport(*_x_single_block, *(_domain_exporters[i][i]), Tpetra::REPLACE);
+            //_x_tpetra[i]->describe(*out, Teuchos::VERB_EXTREME);
+        }
     }
 
 //  TODO: fix this up for blocked and unblocked case
@@ -188,7 +420,7 @@ void SolverT::solve() {
 //    if (_parameters->get<bool>("save residual over solution")) {
 //        // writes residual over top of the solution variable
 //        Teuchos::RCP<mvec_type> Ax = Teuchos::rcp(new mvec_type(*x, Teuchos::View)); // shallow copy, so it writes over the solution
-//        _A->apply(*x,*Ax);
+//        _A_thyra->apply(*x,*Ax);
 //        Ax->update(-1.0, *_b, 1.0);
 //        if (_comm->getRank() == 0) std::cout << "WARNING: Over-writing solution variables with the residual." << std::endl;
 //    }
@@ -197,12 +429,7 @@ void SolverT::solve() {
 Teuchos::RCP<mvec_type> SolverT::getSolution(local_index_type idx) const {
 
     Teuchos::RCP<mvec_type> return_ptr;
-
-    if (_parameters->get<bool>("blocked")) {
-        return_ptr = _x[idx];
-    } else {
-        return_ptr = _x[0];
-    }
+    return_ptr = _x_tpetra[idx];
 
     return return_ptr;
 

--- a/src/Compadre_SolverT.hpp
+++ b/src/Compadre_SolverT.hpp
@@ -25,11 +25,25 @@ class SolverT {
 		Teuchos::RCP<Teuchos::ParameterList> _parameters;
 		std::string _parameter_filename;
 		const Teuchos::RCP<const Teuchos::Comm<int> > _comm;
-		Teuchos::RCP<thyra_block_op_type> _A;
-		std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > _A_tpetra;
-		std::vector<Teuchos::RCP<thyra_mvec_type> > _b;
+
+		Teuchos::RCP<thyra_block_op_type> _A_thyra;
+        std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > _A_tpetra;
+        Teuchos::RCP<crs_matrix_type> _A_single_block;
+
+		std::vector<Teuchos::RCP<thyra_mvec_type> > _b_thyra;
 		std::vector<Teuchos::RCP<mvec_type> > _b_tpetra;
-		std::vector<Teuchos::RCP<mvec_type> > _x;
+        Teuchos::RCP<mvec_type> _b_single_block;
+
+		std::vector<Teuchos::RCP<thyra_mvec_type> > _x_thyra;
+		std::vector<Teuchos::RCP<mvec_type> > _x_tpetra;
+        Teuchos::RCP<mvec_type> _x_single_block;
+
+        std::vector<std::vector<Teuchos::RCP<exporter_type> > > _row_exporters;
+        std::vector<std::vector<Teuchos::RCP<exporter_type> > > _range_exporters;
+        std::vector<std::vector<Teuchos::RCP<exporter_type> > > _col_exporters;
+        std::vector<std::vector<Teuchos::RCP<exporter_type> > > _domain_exporters;
+
+        bool _consolidate_blocks;
 
 	public:
 
@@ -41,11 +55,21 @@ class SolverT {
 		void setParameters(Teuchos::ParameterList& parameters) {
 			_parameters = Teuchos::rcp(&parameters, false);
 			_parameter_filename = _parameters->get<std::string>("file");
+            this->prepareMatrices();
 		}
 
 		Teuchos::RCP<mvec_type> getSolution(local_index_type idx = -1) const;
 
 		void solve();
+
+    protected:
+
+        void amalgamateBlockMatrices(std::vector<std::vector<Teuchos::RCP<crs_matrix_type> > > A, 
+                                        std::vector<Teuchos::RCP<mvec_type> > b);
+
+        // called by setParameters, requires knowledge of solution method
+        void prepareMatrices();
+
 
 };
 

--- a/test_data/parameter_lists/canga/parameters_lower.xml
+++ b/test_data/parameter_lists/canga/parameters_lower.xml
@@ -22,7 +22,7 @@
     <Parameter name="optimization algorithm" type="string" value="NONE"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
   </ParameterList>
   <ParameterList name="neighborhood">
     <Parameter name="method" type="string" value="nanoflann"/>

--- a/test_data/parameter_lists/canga/parameters_lower_compare.xml
+++ b/test_data/parameter_lists/canga/parameters_lower_compare.xml
@@ -26,7 +26,7 @@
     <Parameter name="neighbors needed multiplier" type="double" value="2.4"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
     <Parameter name="optimization algorithm" type="string" value="NONE"/>
     <Parameter name="source weighting field name" type="string" value="grid_area"/>
     <Parameter name="target weighting field name" type="string" value="grid_area"/>

--- a/test_data/parameter_lists/canga/parameters_template.xml
+++ b/test_data/parameter_lists/canga/parameters_template.xml
@@ -21,7 +21,7 @@
     <Parameter name="neighbors needed multiplier" type="double" value="2.8"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
     <Parameter name="optimization algorithm" type="string" value="NONE"/>
     <Parameter name="source weighting field name" type="string" value="grid_area"/>
     <Parameter name="target weighting field name" type="string" value="grid_area"/>

--- a/test_data/parameter_lists/canga/parameters_upper.xml
+++ b/test_data/parameter_lists/canga/parameters_upper.xml
@@ -23,7 +23,7 @@
     <Parameter name="optimization algorithm" type="string" value="NONE"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
   </ParameterList>
   <ParameterList name="neighborhood">
     <Parameter name="method" type="string" value="nanoflann"/>

--- a/test_data/parameter_lists/canga/parameters_upper_compare.xml
+++ b/test_data/parameter_lists/canga/parameters_upper_compare.xml
@@ -27,7 +27,7 @@
     <Parameter name="neighbors needed multiplier" type="double" value="2.4"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
     <Parameter name="optimization algorithm" type="string" value="NONE"/>
     <Parameter name="source weighting field name" type="string" value="grid_area"/>
     <Parameter name="target weighting field name" type="string" value="grid_area"/>

--- a/test_data/parameter_lists/laplace_beltrami/parameters_basic.xml
+++ b/test_data/parameter_lists/laplace_beltrami/parameters_basic.xml
@@ -31,7 +31,7 @@
     <Parameter name="neighbors needed multiplier" type="double" value="2.8"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
     <Parameter name="weighting power" type="int" value="12"/>
     <Parameter name="curvature weighting power" type="int" value="12"/>
     <Parameter name="quadrature points" type="int" value="2"/>

--- a/test_data/parameter_lists/laplace_beltrami/parameters_basic.xml
+++ b/test_data/parameter_lists/laplace_beltrami/parameters_basic.xml
@@ -46,6 +46,6 @@
   </ParameterList>
   <ParameterList name="halo">
     <Parameter name="dynamic" type="bool" value="true"/>
-    <Parameter name="multiplier" type="double" value="4.0"/>
+    <Parameter name="multiplier" type="double" value="16.0"/>
   </ParameterList>
 </ParameterList>

--- a/test_data/parameter_lists/laplace_beltrami/parameters_five_strip_for_paper.xml
+++ b/test_data/parameter_lists/laplace_beltrami/parameters_five_strip_for_paper.xml
@@ -22,7 +22,7 @@
     <Parameter name="neighbors needed multiplier" type="double" value="1.0" />
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
     <Parameter name="weighting power" type="int" value="12" />
     <Parameter name="curvature weighting power" type="int" value="12" />
     <Parameter name="quadrature points" type="int" value="3" />

--- a/test_data/parameter_lists/laplace_beltrami/parameters_template.xml
+++ b/test_data/parameter_lists/laplace_beltrami/parameters_template.xml
@@ -25,7 +25,7 @@
     <Parameter name="neighbors needed multiplier" type="double" value="1.0"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
     <Parameter name="weighting power" type="int" value="4"/>
     <Parameter name="curvature weighting power" type="int" value="4"/>
     <Parameter name="quadrature points" type="int" value="3"/>

--- a/test_data/parameter_lists/shallow_water/parameters_case2.xml
+++ b/test_data/parameter_lists/shallow_water/parameters_case2.xml
@@ -10,7 +10,7 @@
     <Parameter name="neighbors needed multiplier" type="double" value="2.8"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
   </ParameterList>
   <ParameterList name="neighborhood">
     <Parameter name="method" type="string" value="nanoflann"/>

--- a/test_data/parameter_lists/shallow_water/parameters_case5.xml
+++ b/test_data/parameter_lists/shallow_water/parameters_case5.xml
@@ -10,7 +10,7 @@
     <Parameter name="neighbors needed multiplier" type="double" value="2.8"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
     <Parameter name="problem type" type="string" value="MANIFOLD"/>
-    <Parameter name="boundary type" type="string" value="DIRICHLET"/>
+    <Parameter name="constraint type" type="string" value="NONE"/>
     <Parameter name="weighting power" type="int" value="10"/>
   </ParameterList>
   <ParameterList name="neighborhood">

--- a/toolkit/examples/GMLS_Device.cpp
+++ b/toolkit/examples/GMLS_Device.cpp
@@ -53,14 +53,14 @@ bool all_passed = true;
     }
 
     // check if 7 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 7) {
         int arg7toi = atoi(args[6]);
         if (arg7toi > 0) {
-            boundary_type = arg7toi;
+            constraint_type = arg7toi;
         }
     }
 
@@ -318,17 +318,17 @@ bool all_passed = true;
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
     
     // initialize an instance of the GMLS class 
     GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample,
                  order, dimension,
-                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                  2 /*manifold order*/);
     
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes

--- a/toolkit/examples/GMLS_DivergenceFree.cpp
+++ b/toolkit/examples/GMLS_DivergenceFree.cpp
@@ -42,14 +42,14 @@ bool all_passed = true;
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
     // check if 7 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 7) {
         int arg7toi = atoi(args[6]);
         if (arg7toi > 0) {
-            boundary_type = arg7toi;
+            constraint_type = arg7toi;
         }
     }
 
@@ -289,11 +289,11 @@ bool all_passed = true;
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
 
     // initialize an instance of the GMLS class
@@ -302,7 +302,7 @@ bool all_passed = true;
     GMLS vector_divfree_basis_gmls(DivergenceFreeVectorTaylorPolynomial,
                                    VectorPointSample,
                                    order, dimension,
-                                   solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                                   solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                                    0 /*manifold order*/);
 
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes

--- a/toolkit/examples/GMLS_Host.cpp
+++ b/toolkit/examples/GMLS_Host.cpp
@@ -31,14 +31,14 @@ bool all_passed = true;
 
 {
     // check if 7 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 7) {
         int arg7toi = atoi(args[6]);
         if (arg7toi > 0) {
-            boundary_type = arg7toi;
+            constraint_type = arg7toi;
         }
     }
 
@@ -183,15 +183,15 @@ bool all_passed = true;
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
 
     GMLS my_GMLS(order, dimension,
-                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                  2 /*manifold order*/);
     my_GMLS.setProblemData(neighbor_lists, source_coords, target_coords, epsilon);
     my_GMLS.setWeightingPower(10);

--- a/toolkit/examples/GMLS_Manifold.cpp
+++ b/toolkit/examples/GMLS_Manifold.cpp
@@ -39,14 +39,14 @@ Kokkos::initialize(argc, args);
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
     // check if 8 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 8) {
         int arg8toi = atoi(args[7]);
         if (arg8toi > 0) {
-            boundary_type = arg8toi;
+            constraint_type = arg8toi;
         }
     }
 
@@ -329,17 +329,17 @@ Kokkos::initialize(argc, args);
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
     
     // initialize an instance of the GMLS class for problems with a scalar basis and 
     // traditional point sampling as the sampling functional
     GMLS my_GMLS_scalar(order, dimension,
-                        solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                        solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                         order /*manifold order*/);
     
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
@@ -395,7 +395,7 @@ Kokkos::initialize(argc, args);
     // dimension of the manifold. This differs from another possibility, which follows this class.
     GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial, ManifoldVectorPointSample,
                         order, dimension,
-                        solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                        solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                         order /*manifold order*/);
 
     my_GMLS_vector.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
@@ -435,7 +435,7 @@ Kokkos::initialize(argc, args);
     //
     GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, ManifoldVectorPointSample,
                                          order, dimension,
-                                         solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                                         solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                                          order /*manifold order*/);
 
     my_GMLS_vector_of_scalar_clones.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);

--- a/toolkit/examples/GMLS_Manifold_Multiple_Evaluation_Sites.cpp
+++ b/toolkit/examples/GMLS_Manifold_Multiple_Evaluation_Sites.cpp
@@ -69,14 +69,14 @@ Kokkos::initialize(argc, args);
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
     // check if 8 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 8) {
         int arg8toi = atoi(args[7]);
         if (arg8toi > 0) {
-            boundary_type = arg8toi;
+            constraint_type = arg8toi;
         }
     }
 
@@ -358,17 +358,17 @@ Kokkos::initialize(argc, args);
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
     
     // initialize an instance of the GMLS class for problems with a scalar basis and 
     // traditional point sampling as the sampling functional
     GMLS my_GMLS_scalar(order, dimension,
-                        solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                        solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                         order /*manifold order*/);
     
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
@@ -427,7 +427,7 @@ Kokkos::initialize(argc, args);
     // dimension of the manifold. This differs from another possibility, which follows this class.
     GMLS my_GMLS_vector(ReconstructionSpace::VectorTaylorPolynomial, VaryingManifoldVectorPointSample,
                           order, dimension,
-                          solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                          solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                           order /*manifold order*/);
 
     my_GMLS_vector.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
@@ -468,7 +468,7 @@ Kokkos::initialize(argc, args);
     //
     GMLS my_GMLS_vector_of_scalar_clones(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, VaryingManifoldVectorPointSample,
                                          order, dimension,
-                                         solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                                         solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                                          order /*manifold order*/);
 
     my_GMLS_vector_of_scalar_clones.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);

--- a/toolkit/examples/GMLS_Multiple_Evaluation_Sites.cpp
+++ b/toolkit/examples/GMLS_Multiple_Evaluation_Sites.cpp
@@ -43,14 +43,14 @@ bool all_passed = true;
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
     // check if 7 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 7) {
         int arg7toi = atoi(args[6]);
         if (arg7toi > 0) {
-            boundary_type = arg7toi;
+            constraint_type = arg7toi;
         }
     }
 
@@ -339,17 +339,17 @@ bool all_passed = true;
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
     
     // initialize an instance of the GMLS class 
     GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample,
                  order, dimension,
-                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                  2 /*manifold order*/);
 
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes

--- a/toolkit/examples/GMLS_SmallBatchReuse_Device.cpp
+++ b/toolkit/examples/GMLS_SmallBatchReuse_Device.cpp
@@ -49,14 +49,14 @@ bool all_passed = true;
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
     // check if 7 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 7) {
         int arg7toi = atoi(args[6]);
         if (arg7toi > 0) {
-            boundary_type = arg7toi;
+            constraint_type = arg7toi;
         }
     }
 
@@ -267,17 +267,17 @@ bool all_passed = true;
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
     
     // initialize an instance of the GMLS class 
     GMLS my_GMLS(VectorOfScalarClonesTaylorPolynomial, VectorPointSample,
                  order, dimension,
-                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                  2 /*manifold order*/);
     
     // create a vector of target operations

--- a/toolkit/examples/GMLS_Staggered.cpp
+++ b/toolkit/examples/GMLS_Staggered.cpp
@@ -42,14 +42,14 @@ bool all_passed = true;
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
     // check if 7 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 7) {
         int arg7toi = atoi(args[6]);
         if (arg7toi > 0) {
-            boundary_type = arg7toi;
+            constraint_type = arg7toi;
         }
     }
 
@@ -281,11 +281,11 @@ bool all_passed = true;
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
     
     // initialize an instance of the GMLS class
@@ -294,7 +294,7 @@ bool all_passed = true;
     GMLS scalar_basis_gmls(ScalarTaylorPolynomial,
                            StaggeredEdgeAnalyticGradientIntegralSample,
                            order, dimension,
-                           solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                           solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                            0 /*manifold order*/);
 
     // Another class performing Gaussian quadrature integration on vector polynomial basis
@@ -302,7 +302,7 @@ bool all_passed = true;
                            StaggeredEdgeIntegralSample,
                            StaggeredEdgeAnalyticGradientIntegralSample,
                            order, dimension,
-                           solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                           solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                            0 /*manifold order*/);
 
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes

--- a/toolkit/examples/GMLS_Staggered_Manifold.cpp
+++ b/toolkit/examples/GMLS_Staggered_Manifold.cpp
@@ -39,14 +39,14 @@ Kokkos::initialize(argc, args);
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
     // check if 8 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 8) {
         int arg8toi = atoi(args[7]);
         if (arg8toi > 0) {
-            boundary_type = arg8toi;
+            constraint_type = arg8toi;
         }
     }
 
@@ -303,18 +303,18 @@ Kokkos::initialize(argc, args);
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
     
     // initialize an instance of the GMLS class
     GMLS my_GMLS_vector_1(ReconstructionSpace::VectorTaylorPolynomial,
                           StaggeredEdgeIntegralSample,
                           order, dimension,
-                          solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                          solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                           order /*manifold order*/);
     
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes
@@ -360,7 +360,7 @@ Kokkos::initialize(argc, args);
                           StaggeredEdgeIntegralSample,
                           StaggeredEdgeAnalyticGradientIntegralSample,
                           order, dimension,
-                          solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                          solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                           order /*manifold order*/);
 
     my_GMLS_vector_2.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);
@@ -379,7 +379,7 @@ Kokkos::initialize(argc, args);
     GMLS my_GMLS_scalar(ReconstructionSpace::ScalarTaylorPolynomial,
                         StaggeredEdgeAnalyticGradientIntegralSample,
                         order, dimension,
-                        solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                        solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                         order /*manifold order*/);
 
     my_GMLS_scalar.setProblemData(neighbor_lists_device, source_coords_device, target_coords_device, epsilon_device);

--- a/toolkit/examples/GMLS_Vector.cpp
+++ b/toolkit/examples/GMLS_Vector.cpp
@@ -42,14 +42,14 @@ bool all_passed = true;
 // otherwise, Views may be deallocating when we call Kokkos::finalize() later
 {
     // check if 7 arguments are given from the command line, the first being the program name
-    //  boundary_type used in solving each GMLS problem:
-    //      0 - Dirichlet used in solving each GMLS problem
-    //      1 - Neumann used in solving each GMLS problem
-    int boundary_type = 0; // Dirichlet by default
+    //  constraint_type used in solving each GMLS problem:
+    //      0 - No constraints used in solving each GMLS problem
+    //      1 - Neumann Gradient Scalar used in solving each GMLS problem
+    int constraint_type = 0; // No constraints by default
     if (argc >= 7) {
         int arg7toi = atoi(args[6]);
         if (arg7toi > 0) {
-            boundary_type = arg7toi;
+            constraint_type = arg7toi;
         }
     }
 
@@ -317,17 +317,17 @@ bool all_passed = true;
     }
 
     // boundary name for passing into the GMLS class
-    std::string boundary_name;
-    if (boundary_type == 0) { // Dirichlet
-        boundary_name = "DIRICHLET";
-    } else if (boundary_type == 1) { // Neumann
-        boundary_name = "NEUMANN";
+    std::string constraint_name;
+    if (constraint_type == 0) { // No constraints
+        constraint_name = "NO_CONSTRAINT";
+    } else if (constraint_type == 1) { // Neumann Gradient Scalar
+        constraint_name = "NEUMANN_GRAD_SCALAR";
     }
     
     // initialize an instance of the GMLS class 
     GMLS my_GMLS(VectorTaylorPolynomial, VectorPointSample,
                  order, dimension,
-                 solver_name.c_str(), problem_name.c_str(), boundary_name.c_str(),
+                 solver_name.c_str(), problem_name.c_str(), constraint_name.c_str(),
                  2 /*manifold order*/);
 
     // pass in neighbor lists, source coordinates, target coordinates, and window sizes

--- a/toolkit/python/GMLS_Python.hpp
+++ b/toolkit/python/GMLS_Python.hpp
@@ -65,14 +65,14 @@ public:
 
     GMLS_Python(const int poly_order, std::string dense_solver_type, const int curvature_poly_order, const int dimensions) {
 
-        gmls_object = new Compadre::GMLS(poly_order, dimensions, dense_solver_type, "STANDARD", "DIRICHLET", curvature_poly_order);
+        gmls_object = new Compadre::GMLS(poly_order, dimensions, dense_solver_type, "STANDARD", "NO_CONSTRAINT", curvature_poly_order);
 
     }
 
     GMLS_Python(const int poly_order, const int dimensions, std::string dense_solver_type = "QR", 
-            std::string problem_type = "STANDARD", std::string boundary_type = "DIRICHLET", const int curvature_poly_order = 2) {
+            std::string problem_type = "STANDARD", std::string constraint_type = "NO_CONSTRAINT", const int curvature_poly_order = 2) {
 
-        gmls_object = new Compadre::GMLS(poly_order, dimensions, dense_solver_type, problem_type, boundary_type, curvature_poly_order);
+        gmls_object = new Compadre::GMLS(poly_order, dimensions, dense_solver_type, problem_type, constraint_type, curvature_poly_order);
 
     }
 

--- a/toolkit/src/Compadre_GMLS.cpp
+++ b/toolkit/src/Compadre_GMLS.cpp
@@ -477,17 +477,18 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
         // no copy from Psqrt to PsqrtW_LL since they point to the same memory (already existed)
         // they just stride differently (or viewed differently in layout)
         // copy and row-scale from PsqrtW_LL -> PTW_LL_Transpose
-        for (int i=0; i < this_num_cols; i++) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this_num_cols), [=] (const int i) {
             for (int j=0; j < max_num_rows; j++) {
                 // Transpose the matrix and multiply by sqrt(w) to have PTW
                 PW_Transpose_LL(i, j) = PsqrtW_LL(j, i)*std::sqrt(w(j));
             }
-        }
+        });
+        teamMember.team_barrier();
 
         // Now copy the flat 1D memory over
-        for (int i=0; i < this_num_cols*max_num_rows; i++) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this_num_cols*max_num_rows), [=] (const int i) {
             PsqrtW_LL_flat(i) = PW_Transpose_LL_flat(i);
-        }
+        });
     }
 
     teamMember.team_barrier();
@@ -1034,17 +1035,18 @@ void GMLS::operator()(const AssembleManifoldPsqrtW&, const member_type& teamMemb
         // no copy from Psqrt to PsqrtW_LL since they point to the same memory (already existed)
         // they just stride differently (or viewed differently in layout)
         // copy and row-scale from PsqrtW_LL -> PTW_LL_Transpose
-        for (int i=0; i < this_num_cols; i++) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this_num_cols), [=] (const int i) {
             for (int j=0; j < max_num_rows; j++) {
                 // Transpose the matrix and multiply by sqrt(w) to have PTW
                 PW_Transpose_LL(i, j) = PsqrtW_LL(j, i)*std::sqrt(w(j));
             }
-        }
+        });
+        teamMember.team_barrier();
 
         // Now copy the flat 1D memory over
-        for (int i=0; i < this_num_cols*max_num_rows; i++) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this_num_cols*max_num_rows), [=] (const int i) {
             PsqrtW_LL_flat(i) = PW_Transpose_LL_flat(i);
-        }
+        });
     }
 
     // Quang will put LU here

--- a/toolkit/src/Compadre_GMLS.hpp
+++ b/toolkit/src/Compadre_GMLS.hpp
@@ -145,8 +145,8 @@ protected:
     //! problem type for GMLS problem, can also be set to STANDARD for normal or MANIFOLD for manifold problems
     ProblemType _problem_type;
 
-    //! boundary type for GMLS problem, can also be set to DIRICHLET or NEUMANN
-    BoundaryType _boundary_type;
+    //! boundary type for GMLS problem, can also be set to NO_CONSTRAINT or NEUMANN_GRAD_SCALAR
+    ConstraintType _constraint_type;
 
     //! polynomial sampling functional used to construct P matrix, set at GMLS class instantiation
     const SamplingFunctional _polynomial_sampling_functional;
@@ -659,15 +659,15 @@ protected:
     }
 
     //! Parses a string to determine boundary type
-    static BoundaryType parseBoundaryType(const std::string& boundary_type) {
-        std::string boundary_type_to_lower = boundary_type;
-        transform(boundary_type_to_lower.begin(), boundary_type_to_lower.end(), boundary_type_to_lower.begin(), ::tolower);
-        if (boundary_type_to_lower == "dirichlet") {
-            return BoundaryType::DIRICHLET;
-        } else if (boundary_type_to_lower == "neumann") {
-            return BoundaryType::NEUMANN;
+    static ConstraintType parseConstraintType(const std::string& constraint_type) {
+        std::string constraint_type_to_lower = constraint_type;
+        transform(constraint_type_to_lower.begin(), constraint_type_to_lower.end(), constraint_type_to_lower.begin(), ::tolower);
+        if (constraint_type_to_lower == "none") {
+            return ConstraintType::NO_CONSTRAINT;
+        } else if (constraint_type_to_lower == "neumann_grad_scalar") {
+            return ConstraintType::NEUMANN_GRAD_SCALAR;
         } else {
-            return BoundaryType::DIRICHLET;
+            return ConstraintType::NO_CONSTRAINT;
         }
     }
 
@@ -688,7 +688,7 @@ public:
         const int dimensions = 3,
         const std::string dense_solver_type = std::string("QR"),
         const std::string problem_type = std::string("STANDARD"),
-        const std::string boundary_type = std::string("DIRICHLET"),
+        const std::string constraint_type = std::string("NO_CONSTRAINT"),
         const int manifold_curvature_poly_order = 2) : 
             _poly_order(poly_order),
             _curvature_poly_order(manifold_curvature_poly_order),
@@ -696,7 +696,7 @@ public:
             _reconstruction_space(reconstruction_space),
             _dense_solver_type(parseSolverType(dense_solver_type)),
             _problem_type(parseProblemType(problem_type)),
-            _boundary_type(parseBoundaryType(boundary_type)),
+            _constraint_type(parseConstraintType(constraint_type)),
             _polynomial_sampling_functional(((_problem_type == ProblemType::MANIFOLD) 
                         && (polynomial_sampling_strategy == VectorPointSample)) ? ManifoldVectorPointSample : polynomial_sampling_strategy),
             _data_sampling_functional(((_problem_type == ProblemType::MANIFOLD) 
@@ -704,7 +704,7 @@ public:
             {
 
         // Asserting available problems and solvers
-        compadre_kernel_assert_release((_boundary_type != BoundaryType::NEUMANN) &&
+        compadre_kernel_assert_release((_constraint_type == ConstraintType::NO_CONSTRAINT) &&
                                        "Neumann boundary type hasn't been implemented yet.");
 
         // seed random number generator pool
@@ -779,9 +779,9 @@ public:
          const int dimensions = 3,
          const std::string dense_solver_type = std::string("QR"),
          const std::string problem_type = std::string("STANDARD"),
-         const std::string boundary_type = std::string("DIRICHLET"),
+         const std::string constraint_type = std::string("NO_CONSTRAINT"),
          const int manifold_curvature_poly_order = 2)
-      : GMLS(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, VectorPointSample, VectorPointSample, poly_order, dimensions, dense_solver_type, problem_type, boundary_type, manifold_curvature_poly_order) {}
+      : GMLS(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial, VectorPointSample, VectorPointSample, poly_order, dimensions, dense_solver_type, problem_type, constraint_type, manifold_curvature_poly_order) {}
 
     //! Constructor for the case when nonstandard sampling functionals or reconstruction spaces
     //! are to be used. Reconstruction space and sampling strategy can only be set at instantiation.
@@ -791,9 +791,9 @@ public:
          const int dimensions = 3,
          const std::string dense_solver_type = std::string("QR"),
          const std::string problem_type = std::string("STANDARD"),
-         const std::string boundary_type = std::string("DIRICHLET"),
+         const std::string constraint_type = std::string("NO_CONSTRAINT"),
          const int manifold_curvature_poly_order = 2)
-      : GMLS(reconstruction_space, dual_sampling_strategy, dual_sampling_strategy, poly_order, dimensions, dense_solver_type, problem_type, boundary_type, manifold_curvature_poly_order) {}
+      : GMLS(reconstruction_space, dual_sampling_strategy, dual_sampling_strategy, poly_order, dimensions, dense_solver_type, problem_type, constraint_type, manifold_curvature_poly_order) {}
 
     //! Destructor
     ~GMLS(){
@@ -963,7 +963,7 @@ public:
     ProblemType getProblemType() { return _problem_type; }
 
     //! Get boundary type
-    BoundaryType getBoundaryType() { return _boundary_type; }
+    ConstraintType getConstraintType() { return _constraint_type; }
 
     //! Type for weighting kernel for GMLS problem
     WeightingFunctionType getWeightingType() const { return _weighting_type; }

--- a/toolkit/src/Compadre_Operators.hpp
+++ b/toolkit/src/Compadre_Operators.hpp
@@ -184,11 +184,11 @@ namespace Compadre {
     };
 
     //! Boundary type, to determine whether it's Dirichlet or Neumann
-    enum BoundaryType {
-        //! Dirichlet BC Type
-        DIRICHLET,
-        //! Neumann BC Type
-        NEUMANN,
+    enum ConstraintType {
+        //! No constraint
+        NO_CONSTRAINT,
+        //! Neumann Gradient Scalar Type
+        NEUMANN_GRAD_SCALAR,
     };
 
     //! Available weighting kernel function types


### PR DESCRIPTION
If direct solve is requested on a system with > 1 block, then then row maps and column maps are amalgamated into a giant matrix that is then solved, with the solution exported back to the multiple solution vectors. 

This significantly reduces code complexity for blocked / unblocked.