### PR TITLE
Extracted parallel kernel sizing and calling from GMLS class into ParallelManager

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ bob_config_header("${CMAKE_CURRENT_BINARY_DIR}/Compadre_Config.h")
 
 set(COMPADRE_HEADERS
   "${CMAKE_CURRENT_BINARY_DIR}/Compadre_Config.h"
+  Compadre_Functors.hpp
   Compadre_GMLS.hpp
   Compadre_GMLS_ApplyTargetEvaluations.hpp
   Compadre_GMLS_Basis.hpp
@@ -12,6 +13,7 @@ set(COMPADRE_HEADERS
   Compadre_LinearAlgebra_Definitions.hpp
   Compadre_Misc.hpp
   Compadre_Operators.hpp
+  Compadre_ParallelManager.hpp
   Compadre_PointCloudSearch.hpp
   Compadre_Typedefs.hpp
   Compadre_Evaluator.hpp

--- a/src/Compadre_Functors.hpp
+++ b/src/Compadre_Functors.hpp
@@ -16,6 +16,14 @@ struct ConvertLayoutLeftToRight {
         
         // Quang's code goes here
         int i = teamMember.league_rank();
+        printf("CALLED2!\n");
+
+    }
+    
+    void operator() (const member_type& teamMember) const {
+        
+        // Quang's code goes here
+        int i = teamMember.league_rank();
         printf("CALLED!\n");
 
     }

--- a/src/Compadre_Functors.hpp
+++ b/src/Compadre_Functors.hpp
@@ -20,6 +20,7 @@ struct ConvertLayoutLeftToRight {
 
     }
     
+    KOKKOS_INLINE_FUNCTION
     void operator() (const member_type& teamMember) const {
         
         // Quang's code goes here

--- a/src/Compadre_Functors.hpp
+++ b/src/Compadre_Functors.hpp
@@ -1,0 +1,25 @@
+#ifndef _COMPADRE_MISC_HPP_
+#define _COMPADRE_MISC_HPP_
+
+namespace Compadre {
+
+struct DefaultTag{
+    // intentionally empty
+};
+
+struct ConvertLayoutLeftToRight {
+
+    //! Converts from layout left to right
+    KOKKOS_INLINE_FUNCTION
+    void operator() (const DefaultTag&, const member_type& teamMember) const {
+        
+        // Quang's code goes here
+        printf("CALLED!\n");
+
+    }
+
+}; 
+
+}; // Compadre
+
+#endif

--- a/src/Compadre_Functors.hpp
+++ b/src/Compadre_Functors.hpp
@@ -1,9 +1,10 @@
-#ifndef _COMPADRE_MISC_HPP_
-#define _COMPADRE_MISC_HPP_
+#ifndef _COMPADRE_FUNCTORS_HPP_
+#define _COMPADRE_FUNCTORS_HPP_
 
 namespace Compadre {
 
 struct DefaultTag{
+    DefaultTag() {};
     // intentionally empty
 };
 
@@ -14,6 +15,7 @@ struct ConvertLayoutLeftToRight {
     void operator() (const DefaultTag&, const member_type& teamMember) const {
         
         // Quang's code goes here
+        int i = teamMember.league_rank();
         printf("CALLED!\n");
 
     }

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -171,6 +171,9 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
         thread_scratch_size_b += scratch_vector_type::shmem_size(this_num_cols); // delta, used for each thread
     }
+#ifdef COMPADRE_USE_CUDA
+    if (_basis_multiplier*_NP > 96) _pm.setThreadsPerTeam(_pm.getThreadsPerTeam() + 128);
+#endif
     _pm.setTeamScratchSize(0, team_scratch_size_a);
     _pm.setTeamScratchSize(1, team_scratch_size_b);
     _pm.setThreadScratchSize(0, thread_scratch_size_a);

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -104,12 +104,12 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
      */
 
     // for tallying scratch space needed for device kernel calls
-    _team_scratch_size_a = 0;
+    int team_scratch_size_a = 0;
 
     // TEMPORARY, take to zero after conversion
-    _team_scratch_size_b = 0;
-    _thread_scratch_size_a = 0;
-    _thread_scratch_size_b = 0;
+    int team_scratch_size_b = 0;
+    int thread_scratch_size_a = 0;
+    int thread_scratch_size_b = 0;
 
     // dimensions that are relevant for each subproblem
     int max_num_rows = _sampling_multiplier*_max_num_neighbors;
@@ -128,21 +128,21 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
          *    Calculate Scratch Space Allocations
          */
 
-        _team_scratch_size_b += scratch_matrix_right_type::shmem_size(_dimensions-1, _dimensions-1); // G
-        _team_scratch_size_b += scratch_matrix_right_type::shmem_size(_dimensions, _dimensions); // PTP matrix
-        _team_scratch_size_b += scratch_vector_type::shmem_size( (_dimensions-1)*_max_num_neighbors ); // manifold_gradient
+        team_scratch_size_b += scratch_matrix_right_type::shmem_size(_dimensions-1, _dimensions-1); // G
+        team_scratch_size_b += scratch_matrix_right_type::shmem_size(_dimensions, _dimensions); // PTP matrix
+        team_scratch_size_b += scratch_vector_type::shmem_size( (_dimensions-1)*_max_num_neighbors ); // manifold_gradient
 
-        _team_scratch_size_b += scratch_vector_type::shmem_size(_max_num_neighbors*std::max(_sampling_multiplier,_basis_multiplier)); // t1 work vector for qr
-        _team_scratch_size_b += scratch_vector_type::shmem_size(_max_num_neighbors*std::max(_sampling_multiplier,_basis_multiplier)); // t2 work vector for qr
+        team_scratch_size_b += scratch_vector_type::shmem_size(_max_num_neighbors*std::max(_sampling_multiplier,_basis_multiplier)); // t1 work vector for qr
+        team_scratch_size_b += scratch_vector_type::shmem_size(_max_num_neighbors*std::max(_sampling_multiplier,_basis_multiplier)); // t2 work vector for qr
 
-        _team_scratch_size_b += scratch_vector_type::shmem_size(max_P_row_size); // row of P matrix, one for each operator
+        team_scratch_size_b += scratch_vector_type::shmem_size(max_P_row_size); // row of P matrix, one for each operator
         if (_dense_solver_type == DenseSolverType::LU) {
             // Allocated extra memories for LU - since we need to transpose PsqrtW
-            _team_scratch_size_b += scratch_matrix_right_type::shmem_size(this_num_cols, max_num_rows);
+            team_scratch_size_b += scratch_matrix_right_type::shmem_size(this_num_cols, max_num_rows);
         }
-        _thread_scratch_size_b += scratch_vector_type::shmem_size(max_manifold_NP*_basis_multiplier); // delta, used for each thread
+        thread_scratch_size_b += scratch_vector_type::shmem_size(max_manifold_NP*_basis_multiplier); // delta, used for each thread
         if (_data_sampling_functional == VaryingManifoldVectorPointSample) {
-            _thread_scratch_size_b += scratch_vector_type::shmem_size(_dimensions*_dimensions); // temporary tangent calculations, used for each thread
+            thread_scratch_size_b += scratch_vector_type::shmem_size(_dimensions*_dimensions); // temporary tangent calculations, used for each thread
         }
 
 
@@ -158,23 +158,23 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
          *    Calculate Scratch Space Allocations
          */
 
-        _team_scratch_size_a += scratch_vector_type::shmem_size(max_num_rows); // t1 work vector for qr
-        _team_scratch_size_a += scratch_vector_type::shmem_size(max_num_rows); // t2 work vector for qr
+        team_scratch_size_a += scratch_vector_type::shmem_size(max_num_rows); // t1 work vector for qr
+        team_scratch_size_a += scratch_vector_type::shmem_size(max_num_rows); // t2 work vector for qr
 
         // row of P matrix, one for each operator
         // +1 is for the original target site which always gets evaluated
-        _team_scratch_size_b += scratch_vector_type::shmem_size(this_num_cols*_total_alpha_values*max_evaluation_sites); 
+        team_scratch_size_b += scratch_vector_type::shmem_size(this_num_cols*_total_alpha_values*max_evaluation_sites); 
         if (_dense_solver_type == DenseSolverType::LU) {
             // Allocated extra memories for LU - since we need to transpose PsqrtW
-            _team_scratch_size_b += scratch_matrix_right_type::shmem_size(this_num_cols, max_num_rows);
+            team_scratch_size_b += scratch_matrix_right_type::shmem_size(this_num_cols, max_num_rows);
         }
 
-        _thread_scratch_size_b += scratch_vector_type::shmem_size(this_num_cols); // delta, used for each thread
+        thread_scratch_size_b += scratch_vector_type::shmem_size(this_num_cols); // delta, used for each thread
     }
-    _pm.setTeamScratchSize(0, _team_scratch_size_a);
-    _pm.setTeamScratchSize(1, _team_scratch_size_b);
-    _pm.setThreadScratchSize(0, _team_scratch_size_a);
-    _pm.setThreadScratchSize(1, _team_scratch_size_b);
+    _pm.setTeamScratchSize(0, team_scratch_size_a);
+    _pm.setTeamScratchSize(1, team_scratch_size_b);
+    _pm.setThreadScratchSize(0, thread_scratch_size_a);
+    _pm.setThreadScratchSize(1, thread_scratch_size_b);
 
     /*
      *    Allocate Global Device Storage of Data Needed Over Multiple Calls
@@ -194,15 +194,6 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
     /*
      *    Calculate Optimal Threads Based On Levels of Parallelism
      */
-
-
-#ifdef COMPADRE_USE_CUDA
-    _threads_per_team = 128;
-    if (_basis_multiplier*_NP > 96) _threads_per_team += 128;
-#else
-    _threads_per_team = 1;
-#endif
-
 
     _initial_index_for_batch = 0;
     for (int batch_num=0; batch_num<number_of_batches; ++batch_num) {
@@ -224,18 +215,18 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
             if (!_orthonormal_tangent_space_provided) { // user did not specify orthonormal tangent directions, so we approximate them first
                 // coarse tangent plane approximation construction of P^T*P
-                this->CallFunctorWithTeamThreads<ComputeCoarseTangentPlane>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+                _pm.CallFunctorWithTeamThreads<ComputeCoarseTangentPlane>(this_batch_size, *this);
 
                 // if the user provided the reference outward normal direction, then orient the computed or user provided
                 // outward normal directions in the tangent bundle
                 if (_reference_outward_normal_direction_provided && _use_reference_outward_normal_direction_provided_to_orient_surface) {
                     // use the reference outward normal direction provided by the user to orient
                     // the tangent bundle
-                    this->CallFunctorWithTeamThreads<FixTangentDirectionOrdering>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+                    _pm.CallFunctorWithTeamThreads<FixTangentDirectionOrdering>(this_batch_size, *this); 
                 }
 
                 // assembles the P*sqrt(weights) matrix and constructs sqrt(weights)*Identity for curvature
-                this->CallFunctorWithTeamThreads<AssembleCurvaturePsqrtW>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+                _pm.CallFunctorWithTeamThreads<AssembleCurvaturePsqrtW>(this_batch_size, *this);
 
                 // solves P*sqrt(weights) against sqrt(weights)*Identity, stored in RHS
                 Kokkos::Profiling::pushRegion("Curvature QR Factorization");
@@ -243,7 +234,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
                 Kokkos::Profiling::popRegion();
 
                 // evaluates targets, applies target evaluation to polynomial coefficients for curvature
-                this->CallFunctorWithTeamThreads<GetAccurateTangentDirections>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+                _pm.CallFunctorWithTeamThreads<GetAccurateTangentDirections>(this_batch_size, *this);
 
                 if (batch_num==number_of_batches-1) {
                     // copy tangent bundle from device back to host
@@ -254,7 +245,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
             // this time assembling curvature PsqrtW matrix is using a highly accurate approximation of the tangent, previously calculated
             // assembles the P*sqrt(weights) matrix and constructs sqrt(weights)*Identity for curvature
-            this->CallFunctorWithTeamThreads<AssembleCurvaturePsqrtW>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            _pm.CallFunctorWithTeamThreads<AssembleCurvaturePsqrtW>(this_batch_size, *this);
 
             // solves P*sqrt(weights) against sqrt(weights)*Identity, stored in RHS
             Kokkos::Profiling::pushRegion("Curvature QR Factorization");
@@ -262,23 +253,17 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
             Kokkos::Profiling::popRegion();
 
             // evaluates targets, applies target evaluation to polynomial coefficients for curvature
-            this->CallFunctorWithTeamThreads<ApplyCurvatureTargets>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            _pm.CallFunctorWithTeamThreads<ApplyCurvatureTargets>(this_batch_size, *this);
             Kokkos::fence();
 
             // prestencil weights calculated here. appropriate because:
             // precedes polynomial reconstruction from data (replaces contents of _RHS) 
             // follows reconstruction of geometry
             // calculate prestencil weights
-#ifdef COMPADRE_USE_CUDA
-            int nv=8;
-#else
-            int nv=1;
-#endif
-            int nt=_threads_per_team/nv;
-            this->CallFunctorWithTeamThreadsAndVectors<ComputePrestencilWeights>(this_batch_size, nt, nv, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            _pm.CallFunctorWithTeamThreadsAndVectors<ComputePrestencilWeights>(this_batch_size, _pm.getThreadsPerTeam(_pm.getVectorLanesPerThread()), _pm.getVectorLanesPerThread(), *this);
 
             // assembles the P*sqrt(weights) matrix and constructs sqrt(weights)*Identity
-            this->CallFunctorWithTeamThreads<AssembleManifoldPsqrtW>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            _pm.CallFunctorWithTeamThreads<AssembleManifoldPsqrtW>(this_batch_size, *this);
 
             // solves P*sqrt(weights) against sqrt(weights)*Identity, stored in RHS
             // uses SVD if necessary or if explicitly asked to do so (much slower than QR)
@@ -309,7 +294,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
             // assembles the P*sqrt(weights) matrix and constructs sqrt(weights)*Identity
             _pm.CallFunctorWithTeamThreads<AssembleStandardPsqrtW>(this_batch_size, *this);
-            //this->CallFunctorWithTeamThreads<AssembleStandardPsqrtW>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            //_pm.CallFunctorWithTeamThreads<AssembleStandardPsqrtW>(this_batch_size, *this);
             Kokkos::fence();
 
             // solves P*sqrt(weights) against sqrt(weights)*Identity, stored in RHS
@@ -328,13 +313,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
                 Kokkos::Profiling::popRegion();
             }
 
-#ifdef COMPADRE_USE_CUDA
-            int nv=8;
-#else
-            int nv=1;
-#endif
-            int nt=_threads_per_team/nv;
-            this->CallFunctorWithTeamThreadsAndVectors<ComputePrestencilWeights>(this_batch_size, nt, nv, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            _pm.CallFunctorWithTeamThreadsAndVectors<ComputePrestencilWeights>(this_batch_size, _pm.getThreadsPerTeam(_pm.getVectorLanesPerThread()), _pm.getVectorLanesPerThread(), *this);
             Kokkos::fence();
         }
 
@@ -350,7 +329,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
              */
 
             // evaluates targets, applies target evaluation to polynomial coefficients to store in _alphas
-            this->CallFunctorWithTeamThreads<ApplyManifoldTargets>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            _pm.CallFunctorWithTeamThreads<ApplyManifoldTargets>(this_batch_size, *this);
 
         } else {
 
@@ -359,13 +338,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
              */
 
             // evaluates targets, applies target evaluation to polynomial coefficients to store in _alphas
-#ifdef COMPADRE_USE_CUDA
-            int nv=8;
-#else
-            int nv=1;
-#endif
-            int nt=_threads_per_team/nv;
-            this->CallFunctorWithTeamThreadsAndVectors<ApplyStandardTargets>(this_batch_size, nt, nv, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            _pm.CallFunctorWithTeamThreadsAndVectors<ApplyStandardTargets>(this_batch_size, _pm.getThreadsPerTeam(_pm.getVectorLanesPerThread()), _pm.getVectorLanesPerThread(), *this);
 
         }
         _initial_index_for_batch += max_batch_size;
@@ -437,7 +410,7 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
             + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows), max_num_rows);
 
     // delta, used for each thread
-    scratch_vector_type delta(teamMember.thread_scratch(_scratch_thread_level_b), this_num_cols);
+    scratch_vector_type delta(teamMember.thread_scratch(_pm.getThreadScratchLevel(1)), this_num_cols);
 
     /*
      *    Assemble P*sqrt(W) and sqrt(w)*Identity
@@ -469,7 +442,7 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
         // create layout left matrix
         // using the allocated data of PsqrtW
         // this memory only lives on team scratch memory - will be deleted out of this scope
-        scratch_matrix_left_type PW_Transpose_LL(teamMember.team_scratch(_scratch_team_level_b),
+        scratch_matrix_left_type PW_Transpose_LL(teamMember.team_scratch(_pm.getTeamScratchLevel(1)),
                                                  this_num_cols, max_num_rows);
 
         // Indexed as 1D array style
@@ -531,9 +504,9 @@ void GMLS::operator()(const ApplyStandardTargets&, const member_type& teamMember
     scratch_vector_type w(_w.data() 
             + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows), max_num_rows);
 
-    scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_a), max_num_rows);
-    scratch_vector_type t2(teamMember.team_scratch(_scratch_team_level_a), max_num_rows);
-    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_scratch_team_level_b), _total_alpha_values*max_evaluation_sites, this_num_cols);
+    scratch_vector_type t1(teamMember.team_scratch(_pm.getTeamScratchLevel(0)), max_num_rows);
+    scratch_vector_type t2(teamMember.team_scratch(_pm.getTeamScratchLevel(0)), max_num_rows);
+    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _total_alpha_values*max_evaluation_sites, this_num_cols);
 
     /*
      *    Apply Standard Target Evaluations to Polynomial Coefficients
@@ -574,10 +547,10 @@ void GMLS::operator()(const ComputeCoarseTangentPlane&, const member_type& teamM
     scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
-    scratch_matrix_right_type PTP(teamMember.team_scratch(_scratch_team_level_b), _dimensions, _dimensions);
+    scratch_matrix_right_type PTP(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _dimensions, _dimensions);
 
     // delta, used for each thread
-    scratch_vector_type delta(teamMember.thread_scratch(_scratch_thread_level_b), max_manifold_NP*_basis_multiplier);
+    scratch_vector_type delta(teamMember.thread_scratch(_pm.getThreadScratchLevel(1)), max_manifold_NP*_basis_multiplier);
 
     /*
      *    Determine Coarse Approximation of Manifold Tangent Plane
@@ -627,7 +600,7 @@ void GMLS::operator()(const AssembleCurvaturePsqrtW&, const member_type& teamMem
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
     // delta, used for each thread
-    scratch_vector_type delta(teamMember.thread_scratch(_scratch_thread_level_b), max_manifold_NP*_basis_multiplier);
+    scratch_vector_type delta(teamMember.thread_scratch(_pm.getThreadScratchLevel(1)), max_manifold_NP*_basis_multiplier);
 
 
     //
@@ -676,10 +649,10 @@ void GMLS::operator()(const GetAccurateTangentDirections&, const member_type& te
     scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
-    scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
-    scratch_vector_type t2(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
-    scratch_vector_type manifold_gradient(teamMember.team_scratch(_scratch_team_level_b), (_dimensions-1)*_max_num_neighbors);
-    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_scratch_team_level_b), _total_alpha_values*max_evaluation_sites, max_manifold_NP*_basis_multiplier);
+    scratch_vector_type t1(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
+    scratch_vector_type t2(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
+    scratch_vector_type manifold_gradient(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), (_dimensions-1)*_max_num_neighbors);
+    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _total_alpha_values*max_evaluation_sites, max_manifold_NP*_basis_multiplier);
 
 
     /*
@@ -865,11 +838,11 @@ void GMLS::operator()(const ApplyCurvatureTargets&, const member_type& teamMembe
     scratch_vector_type manifold_coeffs(_manifold_curvature_coefficients.data() + target_index*manifold_NP, manifold_NP);
     scratch_vector_type manifold_gradient_coeffs(_manifold_curvature_gradient.data() + target_index*(_dimensions-1), (_dimensions-1));
 
-    scratch_matrix_right_type G(teamMember.team_scratch(_scratch_team_level_b), _dimensions-1, _dimensions-1);
-    scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
-    scratch_vector_type t2(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
-    scratch_vector_type manifold_gradient(teamMember.team_scratch(_scratch_team_level_b), (_dimensions-1)*_max_num_neighbors);
-    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_scratch_team_level_b), _total_alpha_values*max_evaluation_sites, max_manifold_NP*_basis_multiplier);
+    scratch_matrix_right_type G(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _dimensions-1, _dimensions-1);
+    scratch_vector_type t1(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
+    scratch_vector_type t2(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
+    scratch_vector_type manifold_gradient(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), (_dimensions-1)*_max_num_neighbors);
+    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _total_alpha_values*max_evaluation_sites, max_manifold_NP*_basis_multiplier);
 
     /*
      *    Manifold
@@ -994,7 +967,7 @@ void GMLS::operator()(const AssembleManifoldPsqrtW&, const member_type& teamMemb
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
     // delta, used for each thread
-    scratch_vector_type delta(teamMember.thread_scratch(_scratch_thread_level_b), max_manifold_NP*_basis_multiplier);
+    scratch_vector_type delta(teamMember.thread_scratch(_pm.getThreadScratchLevel(1)), max_manifold_NP*_basis_multiplier);
 
 
     /*
@@ -1027,7 +1000,7 @@ void GMLS::operator()(const AssembleManifoldPsqrtW&, const member_type& teamMemb
         // create layout left matrix
         // using the allocated data of PsqrtW
         // this memory only lives on team scratch memory - will be deleted out of this scope
-        scratch_matrix_left_type PW_Transpose_LL(teamMember.team_scratch(_scratch_team_level_b),
+        scratch_matrix_left_type PW_Transpose_LL(teamMember.team_scratch(_pm.getTeamScratchLevel(1)),
                                                  this_num_cols, max_num_rows);
 
         // Indexed as 1D array style
@@ -1099,9 +1072,9 @@ void GMLS::operator()(const ApplyManifoldTargets&, const member_type& teamMember
     scratch_vector_type manifold_coeffs(_manifold_curvature_coefficients.data() + target_index*manifold_NP, manifold_NP);
     scratch_vector_type manifold_gradient_coeffs(_manifold_curvature_gradient.data() + target_index*(_dimensions-1), (_dimensions-1));
 
-    scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
-    scratch_vector_type t2(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
-    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_scratch_team_level_b), _total_alpha_values*max_evaluation_sites, max_manifold_NP*_basis_multiplier);
+    scratch_vector_type t1(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
+    scratch_vector_type t2(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
+    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _total_alpha_values*max_evaluation_sites, max_manifold_NP*_basis_multiplier);
 
     /*
      *    Apply Standard Target Evaluations to Polynomial Coefficients
@@ -1137,8 +1110,8 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
      */
 
 
-    scratch_vector_type t1(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
-    scratch_vector_type t2(teamMember.team_scratch(_scratch_team_level_b), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
+    scratch_vector_type t1(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
+    scratch_vector_type t2(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _max_num_neighbors*((_sampling_multiplier>_basis_multiplier) ? _sampling_multiplier : _basis_multiplier));
 
 
     // holds polynomial coefficients for curvature reconstruction
@@ -1148,8 +1121,8 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
     scratch_matrix_right_type T(_T.data() 
             + TO_GLOBAL(target_index)*TO_GLOBAL(_dimensions)*TO_GLOBAL(_dimensions), _dimensions, _dimensions);
 
-    scratch_vector_type manifold_gradient(teamMember.team_scratch(_scratch_team_level_b), (_dimensions-1)*_max_num_neighbors);
-    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_scratch_team_level_b), _total_alpha_values*max_evaluation_sites, max_manifold_NP*_basis_multiplier);
+    scratch_vector_type manifold_gradient(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), (_dimensions-1)*_max_num_neighbors);
+    scratch_matrix_right_type P_target_row(teamMember.team_scratch(_pm.getTeamScratchLevel(1)), _total_alpha_values*max_evaluation_sites, max_manifold_NP*_basis_multiplier);
 
     /*
      *    Prestencil Weight Calculations
@@ -1196,7 +1169,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
         });
     } else if (_data_sampling_functional == VaryingManifoldVectorPointSample) {
 
-        scratch_vector_type delta(teamMember.thread_scratch(_scratch_thread_level_b), manifold_NP);
+        scratch_vector_type delta(teamMember.thread_scratch(_pm.getThreadScratchLevel(1)), manifold_NP);
 
         Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this->getNNeighbors(target_index)), [&] (const int m) {
             
@@ -1237,7 +1210,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
 
         teamMember.team_barrier();
 
-        scratch_matrix_right_type tangent(teamMember.thread_scratch(_scratch_thread_level_b), _dimensions-1, _dimensions);
+        scratch_matrix_right_type tangent(teamMember.thread_scratch(_pm.getThreadScratchLevel(1)), _dimensions-1, _dimensions);
 
         Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this->getNNeighbors(target_index)), [=] (const int m) {
             // constructs tangent vector at neighbor site

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -171,6 +171,10 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
         _thread_scratch_size_b += scratch_vector_type::shmem_size(this_num_cols); // delta, used for each thread
     }
+    _pm.setTeamScratchSize(0, _team_scratch_size_a);
+    _pm.setTeamScratchSize(1, _team_scratch_size_b);
+    _pm.setThreadScratchSize(0, _team_scratch_size_a);
+    _pm.setThreadScratchSize(1, _team_scratch_size_b);
 
     /*
      *    Allocate Global Device Storage of Data Needed Over Multiple Calls
@@ -304,7 +308,8 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
                 this->generate1DQuadrature();
 
             // assembles the P*sqrt(weights) matrix and constructs sqrt(weights)*Identity
-            this->CallFunctorWithTeamThreads<AssembleStandardPsqrtW>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
+            _pm.CallFunctorWithTeamThreads<AssembleStandardPsqrtW>(this_batch_size, *this);
+            //this->CallFunctorWithTeamThreads<AssembleStandardPsqrtW>(this_batch_size, _threads_per_team, _team_scratch_size_a, _team_scratch_size_b, _thread_scratch_size_a, _thread_scratch_size_b);
             Kokkos::fence();
 
             // solves P*sqrt(weights) against sqrt(weights)*Identity, stored in RHS

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -7,6 +7,7 @@
 #include "Compadre_Misc.hpp"
 #include "Compadre_Operators.hpp"
 #include "Compadre_LinearAlgebra_Definitions.hpp"
+#include "Compadre_ParallelManager.hpp"
 
 
 namespace Compadre {
@@ -284,8 +285,8 @@ protected:
     //! calculated number of threads per team
     int _threads_per_team;
 
-
-
+    //! determines scratch level spaces and is used to call kernels
+    ParallelManager _pm;
 
 
 /** @name Private Modifiers

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -265,26 +265,6 @@ protected:
     //! used for sizing P_target_row and the _alphas view
     int _total_alpha_values;
 
-
-    //! lowest level memory for Kokkos::parallel_for for team access memory
-    int _scratch_team_level_a;
-    int _team_scratch_size_a;
-
-    //! higher (slower) level memory for Kokkos::parallel_for for team access memory
-    int _scratch_thread_level_a;
-    int _thread_scratch_size_a;
-
-    //! lowest level memory for Kokkos::parallel_for for thread access memory
-    int _scratch_team_level_b;
-    int _team_scratch_size_b;
-
-    //! higher (slower) level memory for Kokkos::parallel_for for thread access memory
-    int _scratch_thread_level_b;
-    int _thread_scratch_size_b;
-
-    //! calculated number of threads per team
-    int _threads_per_team;
-
     //! determines scratch level spaces and is used to call kernels
     ParallelManager _pm;
 
@@ -293,53 +273,6 @@ protected:
  *  Private function because information lives on the device
  */
 ///@{
-
-    //! Calls a parallel_for using the tag given as the first argument.
-    //! parallel_for will break out over loops over teams with each vector lane executing code be default
-    template<class Tag>
-    void CallFunctorWithTeamThreadsAndVectors(const global_index_type batch_size, const int threads_per_team, const int vector_lanes_per_thread, const int team_scratch_size_a, const int team_scratch_size_b, const int thread_scratch_size_a, const int thread_scratch_size_b) {
-    if ( (_scratch_team_level_a != _scratch_team_level_b) && (_scratch_thread_level_a != _scratch_thread_level_b) ) {
-            // all levels of each type need specified separately
-            Kokkos::parallel_for(
-                Kokkos::TeamPolicy<Tag>(batch_size, threads_per_team, vector_lanes_per_thread)
-                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a))
-                .set_scratch_size(_scratch_team_level_b, Kokkos::PerTeam(team_scratch_size_b))
-                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a))
-                .set_scratch_size(_scratch_thread_level_b, Kokkos::PerThread(thread_scratch_size_b)),
-                *this, typeid(Tag).name());
-        } else if (_scratch_team_level_a != _scratch_team_level_b) {
-            // scratch thread levels are the same
-            Kokkos::parallel_for(
-                Kokkos::TeamPolicy<Tag>(batch_size, threads_per_team, vector_lanes_per_thread)
-                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a))
-                .set_scratch_size(_scratch_team_level_b, Kokkos::PerTeam(team_scratch_size_b))
-                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a + thread_scratch_size_b)),
-                *this, typeid(Tag).name());
-        } else if (_scratch_thread_level_a != _scratch_thread_level_b) {
-            // scratch team levels are the same
-            Kokkos::parallel_for(
-                Kokkos::TeamPolicy<Tag>(batch_size, threads_per_team, vector_lanes_per_thread)
-                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a + team_scratch_size_b))
-                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a))
-                .set_scratch_size(_scratch_thread_level_b, Kokkos::PerThread(thread_scratch_size_b)),
-                *this, typeid(Tag).name());
-        } else {
-            // scratch team levels and thread levels are the same
-            Kokkos::parallel_for(
-                Kokkos::TeamPolicy<Tag>(batch_size, threads_per_team, vector_lanes_per_thread)
-                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a + team_scratch_size_b))
-                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a + thread_scratch_size_b)),
-                *this, typeid(Tag).name());
-        }
-    }
-
-    //! Calls a parallel for using the tag given as the first argument. 
-    //! parallel_for will break out over loops over teams with each thread executing code be default
-    template<class Tag>
-    void CallFunctorWithTeamThreads(const global_index_type batch_size, const int threads_per_team, const int team_scratch_size_a, const int team_scratch_size_b, const int thread_scratch_size_a, const int thread_scratch_size_b) {
-        // calls breakout over vector lanes with vector lane size of 1
-        CallFunctorWithTeamThreadsAndVectors<Tag>(batch_size, threads_per_team, 1, team_scratch_size_a, team_scratch_size_b, thread_scratch_size_a, thread_scratch_size_b);
-    }
 
     /*! \brief Evaluates the polynomial basis under a particular sampling function. Generally used to fill a row of P.
         \param delta            [in/out] - scratch space that is allocated so that each thread has its own copy. Must be at least as large is the _basis_multipler*the dimension of the polynomial basis.
@@ -710,19 +643,6 @@ public:
 
         _NP = this->getNP(_poly_order, dimensions, _reconstruction_space);
         Kokkos::fence();
-
-#ifdef COMPADRE_USE_CUDA
-        _scratch_team_level_a = 0;
-        _scratch_thread_level_a = 1;
-        _scratch_team_level_b = 1;
-        _scratch_thread_level_b = 1;
-#else
-        _scratch_team_level_a = 0;
-        _scratch_thread_level_a = 0;
-        _scratch_team_level_b = 0;
-        _scratch_thread_level_b = 0;
-#endif
-        _threads_per_team = 0;
 
         // register curvature operations for manifold problems
         if (_problem_type == ProblemType::MANIFOLD) {

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -112,9 +112,6 @@ protected:
     Kokkos::View<int*, Kokkos::HostSpace> _number_of_additional_evaluation_indices; 
 
 
-    //! reconstruction type
-    int _type; 
-
     //! order of basis for polynomial reconstruction
     int _poly_order; 
 
@@ -741,7 +738,6 @@ public:
         _lro = std::vector<TargetOperation>();
 
         // various initializations
-        _type = 1;
         _total_alpha_values = 0;
 
         _weighting_type = WeightingFunctionType::Power;

--- a/src/Compadre_ParallelManager.hpp
+++ b/src/Compadre_ParallelManager.hpp
@@ -78,7 +78,6 @@ public:
         _scratch_team_level_b = 1;
         _scratch_thread_level_b = 1;
         _threads_per_team = 128;
-        if (_basis_multiplier*_NP > 96) _threads_per_team += 128;
         _vector_lanes_per_thread = 8;
 #else
         _scratch_team_level_a = 0;
@@ -203,7 +202,8 @@ public:
         CallFunctorWithTeamThreadsAndVectors<C>(batch_size, this->getThreadsPerTeam(), 1, functor, functor_name);
     }
 
-    int getTeamScratchLevel(int level) const {
+    KOKKOS_INLINE_FUNCTION
+    int getTeamScratchLevel(const int level) const {
         if (level == 0) {
             return _scratch_team_level_a;
         } else {
@@ -211,7 +211,8 @@ public:
         }
     }
 
-    int getThreadScratchLevel(int level) const {
+    KOKKOS_INLINE_FUNCTION
+    int getThreadScratchLevel(const int level) const {
         if (level == 0) {
             return _scratch_thread_level_a;
         } else {
@@ -219,7 +220,8 @@ public:
         }
     }
 
-    int getTeamScratchSize(int level) const {
+    KOKKOS_INLINE_FUNCTION
+    int getTeamScratchSize(const int level) const {
         if (level == 0) {
             return _team_scratch_size_a;
         } else {
@@ -227,7 +229,8 @@ public:
         }
     }
 
-    int getThreadScratchSize(int level) const {
+    KOKKOS_INLINE_FUNCTION
+    int getThreadScratchSize(const int level) const {
         if (level == 0) {
             return _thread_scratch_size_a;
         } else {
@@ -235,10 +238,12 @@ public:
         }
     }
     
+    KOKKOS_INLINE_FUNCTION
     int getThreadsPerTeam(const int vector_lanes_per_thread = 1) const {
         return _threads_per_team / vector_lanes_per_thread;
     }
 
+    KOKKOS_INLINE_FUNCTION
     int getVectorLanesPerThread() const {
         return _vector_lanes_per_thread;
     }
@@ -251,7 +256,7 @@ public:
  */
 ///@{
 
-    void setTeamScratchLevel(int level, int value) {
+    void setTeamScratchLevel(const int level, const int value) {
         if (level == 0) {
             _scratch_team_level_a = value;
         } else {
@@ -259,7 +264,7 @@ public:
         }
     }
 
-    void setThreadScratchLevel(int level, int value) {
+    void setThreadScratchLevel(const int level, const int value) {
         if (level == 0) {
             _scratch_thread_level_a = value;
         } else {
@@ -267,7 +272,7 @@ public:
         }
     }
 
-    void setTeamScratchSize(int level, int value) {
+    void setTeamScratchSize(const int level, const int value) {
         if (level == 0) {
             _team_scratch_size_a = value;
         } else {
@@ -275,12 +280,20 @@ public:
         }
     }
 
-    void setThreadScratchSize(int level, int value) {
+    void setThreadScratchSize(const int level, const int value) {
         if (level == 0) {
             _thread_scratch_size_a = value;
         } else {
             _thread_scratch_size_b = value;
         }
+    }
+
+    void setThreadsPerTeam(const int value) {
+        _threads_per_team = value;
+    }
+
+    void setVectorLanesPerThread(const int value) {
+        _vector_lanes_per_thread = value;
     }
 
 ///@}

--- a/src/Compadre_ParallelManager.hpp
+++ b/src/Compadre_ParallelManager.hpp
@@ -12,6 +12,10 @@ namespace Compadre {
 //!  Parallel Manager
 /*!
 *  This class sets and manages thread / teams levels, scratch memory sizes, and kernel executions.
+*  ex:
+*  Compadre::ConvertLayoutLeftToRight clr;
+*  Compadre::ParallelManager pm;
+*  pm.CallFunctorWithTeamThreads(clr, 100);
 */
 class ParallelManager {
 protected:
@@ -97,50 +101,61 @@ public:
 
     //! Calls a parallel_for using the tag given as the first argument.
     //! parallel_for will break out over loops over teams with each vector lane executing code be default
-    template<class Tag = DefaultTag>
-    void CallFunctorWithTeamThreadsAndVectors(void* functor, const global_index_type batch_size) const {
+    template<typename Tag, class C>
+    void CallFunctorWithTeamThreadsAndVectors(const global_index_type batch_size, const int threads_per_team, const int vector_lanes_per_thread, C functor) const {
 
     if ( (_scratch_team_level_a != _scratch_team_level_b) && (_scratch_thread_level_a != _scratch_thread_level_b) ) {
             // all levels of each type need specified separately
             Kokkos::parallel_for(
-                Kokkos::TeamPolicy<Tag>(batch_size, _threads_per_team, _vector_lanes_per_thread)
-                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a))
-                .set_scratch_size(_scratch_team_level_b, Kokkos::PerTeam(team_scratch_size_b))
-                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a))
-                .set_scratch_size(_scratch_thread_level_b, Kokkos::PerThread(thread_scratch_size_b)),
-                *functor, typeid(Tag).name());
+                Kokkos::TeamPolicy<Tag>(batch_size, threads_per_team, vector_lanes_per_thread)
+                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(_team_scratch_size_a))
+                .set_scratch_size(_scratch_team_level_b, Kokkos::PerTeam(_team_scratch_size_b))
+                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(_thread_scratch_size_a))
+                .set_scratch_size(_scratch_thread_level_b, Kokkos::PerThread(_thread_scratch_size_b)),
+                functor, typeid(Tag).name());
         } else if (_scratch_team_level_a != _scratch_team_level_b) {
             // scratch thread levels are the same
             Kokkos::parallel_for(
-                Kokkos::TeamPolicy<Tag>(batch_size, _threads_per_team, _vector_lanes_per_thread)
-                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a))
-                .set_scratch_size(_scratch_team_level_b, Kokkos::PerTeam(team_scratch_size_b))
-                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a + thread_scratch_size_b)),
-                *functor, typeid(Tag).name());
+                Kokkos::TeamPolicy<Tag>(batch_size, threads_per_team, vector_lanes_per_thread)
+                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(_team_scratch_size_a))
+                .set_scratch_size(_scratch_team_level_b, Kokkos::PerTeam(_team_scratch_size_b))
+                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(_thread_scratch_size_a + _thread_scratch_size_b)),
+                functor, typeid(Tag).name());
         } else if (_scratch_thread_level_a != _scratch_thread_level_b) {
             // scratch team levels are the same
             Kokkos::parallel_for(
-                Kokkos::TeamPolicy<Tag>(batch_size, _threads_per_team, _vector_lanes_per_thread)
-                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a + team_scratch_size_b))
-                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a))
-                .set_scratch_size(_scratch_thread_level_b, Kokkos::PerThread(thread_scratch_size_b)),
-                *functor, typeid(Tag).name());
+                Kokkos::TeamPolicy<Tag>(batch_size, threads_per_team, vector_lanes_per_thread)
+                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(_team_scratch_size_a + _team_scratch_size_b))
+                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(_thread_scratch_size_a))
+                .set_scratch_size(_scratch_thread_level_b, Kokkos::PerThread(_thread_scratch_size_b)),
+                functor, typeid(Tag).name());
         } else {
             // scratch team levels and thread levels are the same
             Kokkos::parallel_for(
-                Kokkos::TeamPolicy<Tag>(batch_size, _threads_per_team, _vector_lanes_per_thread)
-                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a + team_scratch_size_b))
-                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a + thread_scratch_size_b)),
-                *functor, typeid(Tag).name());
+                Kokkos::TeamPolicy<Tag>(batch_size, threads_per_team, vector_lanes_per_thread)
+                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(_team_scratch_size_a + _team_scratch_size_b))
+                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(_thread_scratch_size_a + _thread_scratch_size_b)),
+                functor, typeid(Tag).name());
         }
+    }
+    template<class C>
+    void CallFunctorWithTeamThreadsAndVectors(const global_index_type batch_size, const int threads_per_team, const int vector_lanes_per_thread, C functor) const {
+        CallFunctorWithTeamThreadsAndVectors<DefaultTag,C>(batch_size, _threads_per_team, _vector_lanes_per_thread, functor);
     }
 
     //! Calls a parallel for using the tag given as the first argument. 
     //! parallel_for will break out over loops over teams with each thread executing code be default
-    template<class Tag = DefaultTag>
-    void CallFunctorWithTeamThreads(void* functor, const global_index_type batch_size) const {
+    //template<class C, typename Tag = DefaultTag>
+    template<typename Tag, class C>
+    void CallFunctorWithTeamThreads(const global_index_type batch_size, C functor) const {
         // calls breakout over vector lanes with vector lane size of 1
-        CallFunctorWithTeamThreadsAndVectors<Tag>(functor, batch_size);
+        CallFunctorWithTeamThreadsAndVectors<Tag,C>(batch_size, _threads_per_team, _vector_lanes_per_thread, functor);
+    }
+
+    template<class C>
+    void CallFunctorWithTeamThreads(const global_index_type batch_size, C functor) const {
+        // calls breakout over vector lanes with vector lane size of 1
+        CallFunctorWithTeamThreadsAndVectors<DefaultTag,C>(batch_size, _threads_per_team, _vector_lanes_per_thread, functor);
     }
 
     int getTeamScratchSize(int level) {

--- a/src/Compadre_ParallelManager.hpp
+++ b/src/Compadre_ParallelManager.hpp
@@ -1,0 +1,195 @@
+#ifndef _COMPADRE_PARALLELMANAGER_HPP_
+#define _COMPADRE_PARALLELMANAGER_HPP_
+
+#include "Compadre_Config.h"
+#include "Compadre_Typedefs.hpp"
+
+#include "Compadre_Functors.hpp"
+
+
+namespace Compadre {
+
+//!  Parallel Manager
+/*!
+*  This class sets and manages thread / teams levels, scratch memory sizes, and kernel executions.
+*/
+class ParallelManager {
+protected:
+
+    //! lowest level memory for Kokkos::parallel_for for team access memory
+    int _scratch_team_level_a;
+    int _team_scratch_size_a;
+
+    //! higher (slower) level memory for Kokkos::parallel_for for team access memory
+    int _scratch_thread_level_a;
+    int _thread_scratch_size_a;
+
+    //! lowest level memory for Kokkos::parallel_for for thread access memory
+    int _scratch_team_level_b;
+    int _team_scratch_size_b;
+
+    //! higher (slower) level memory for Kokkos::parallel_for for thread access memory
+    int _scratch_thread_level_b;
+    int _thread_scratch_size_b;
+
+    //! calculated number of threads per team
+    int _threads_per_team;
+    int _vector_lanes_per_thread;
+
+
+/** @name Private Modifiers
+ *  Private function because information lives on the device
+ */
+///@{
+///@}
+
+/** @name Private Accessors
+ *  Private function because information lives on the device
+ */
+///@{
+///@}
+
+/** @name Private Utility
+ *  
+ */
+///@{
+///@}
+
+public:
+
+/** @name Instantiation / Destruction
+ *  
+ */
+///@{
+
+    ParallelManager() : _team_scratch_size_a(0), _thread_scratch_size_a(0), 
+            _team_scratch_size_b(0), _thread_scratch_size_b(0) {
+
+#ifdef COMPADRE_USE_CUDA
+        _scratch_team_level_a = 0;
+        _scratch_thread_level_a = 1;
+        _scratch_team_level_b = 1;
+        _scratch_thread_level_b = 1;
+        _threads_per_team = 128;
+        if (_basis_multiplier*_NP > 96) _threads_per_team += 128;
+#else
+        _scratch_team_level_a = 0;
+        _scratch_thread_level_a = 0;
+        _scratch_team_level_b = 0;
+        _scratch_thread_level_b = 0;
+        _threads_per_team = 1;
+#endif
+        _vector_lanes_per_thread= 1;
+    }
+
+///@}
+
+/** @name Public Utility
+ *  
+ */
+///@{
+///@}
+
+/** @name Accessors
+ *  Retrieve member variables through public member functions
+ */
+///@{
+
+    //! Calls a parallel_for using the tag given as the first argument.
+    //! parallel_for will break out over loops over teams with each vector lane executing code be default
+    template<class Tag = DefaultTag>
+    void CallFunctorWithTeamThreadsAndVectors(void* functor, const global_index_type batch_size) const {
+
+    if ( (_scratch_team_level_a != _scratch_team_level_b) && (_scratch_thread_level_a != _scratch_thread_level_b) ) {
+            // all levels of each type need specified separately
+            Kokkos::parallel_for(
+                Kokkos::TeamPolicy<Tag>(batch_size, _threads_per_team, _vector_lanes_per_thread)
+                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a))
+                .set_scratch_size(_scratch_team_level_b, Kokkos::PerTeam(team_scratch_size_b))
+                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a))
+                .set_scratch_size(_scratch_thread_level_b, Kokkos::PerThread(thread_scratch_size_b)),
+                *functor, typeid(Tag).name());
+        } else if (_scratch_team_level_a != _scratch_team_level_b) {
+            // scratch thread levels are the same
+            Kokkos::parallel_for(
+                Kokkos::TeamPolicy<Tag>(batch_size, _threads_per_team, _vector_lanes_per_thread)
+                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a))
+                .set_scratch_size(_scratch_team_level_b, Kokkos::PerTeam(team_scratch_size_b))
+                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a + thread_scratch_size_b)),
+                *functor, typeid(Tag).name());
+        } else if (_scratch_thread_level_a != _scratch_thread_level_b) {
+            // scratch team levels are the same
+            Kokkos::parallel_for(
+                Kokkos::TeamPolicy<Tag>(batch_size, _threads_per_team, _vector_lanes_per_thread)
+                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a + team_scratch_size_b))
+                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a))
+                .set_scratch_size(_scratch_thread_level_b, Kokkos::PerThread(thread_scratch_size_b)),
+                *functor, typeid(Tag).name());
+        } else {
+            // scratch team levels and thread levels are the same
+            Kokkos::parallel_for(
+                Kokkos::TeamPolicy<Tag>(batch_size, _threads_per_team, _vector_lanes_per_thread)
+                .set_scratch_size(_scratch_team_level_a, Kokkos::PerTeam(team_scratch_size_a + team_scratch_size_b))
+                .set_scratch_size(_scratch_thread_level_a, Kokkos::PerThread(thread_scratch_size_a + thread_scratch_size_b)),
+                *functor, typeid(Tag).name());
+        }
+    }
+
+    //! Calls a parallel for using the tag given as the first argument. 
+    //! parallel_for will break out over loops over teams with each thread executing code be default
+    template<class Tag = DefaultTag>
+    void CallFunctorWithTeamThreads(void* functor, const global_index_type batch_size) const {
+        // calls breakout over vector lanes with vector lane size of 1
+        CallFunctorWithTeamThreadsAndVectors<Tag>(functor, batch_size);
+    }
+
+    int getTeamScratchSize(int level) {
+        if (level == 0) {
+            return _team_scratch_size_a;
+        } else {
+            return _team_scratch_size_b;
+        }
+    }
+
+    int getThreadScratchSize(int level) {
+        if (level == 0) {
+            return _thread_scratch_size_a;
+        } else {
+            return _thread_scratch_size_b;
+        }
+    }
+
+///@}
+
+
+/** @name Modifiers
+ *  Changed member variables through public member functions
+ */
+///@{
+
+
+    void setTeamScratchSize(int level, int value) {
+        if (level == 0) {
+            _team_scratch_size_a = value;
+        } else {
+            _team_scratch_size_b = value;
+        }
+    }
+
+    void setThreadScratchSize(int level, int value) {
+        if (level == 0) {
+            _thread_scratch_size_a = value;
+        } else {
+            _thread_scratch_size_b = value;
+        }
+    }
+
+///@}
+
+
+}; // ParallelManager Class
+}; // Compadre
+
+#endif
+
+


### PR DESCRIPTION
There were many member variables and private member functions for calling Kokkos functors inside of the GMLS class. Much of this could be abstracted and called from in a way that allows it to be reused for launching other functors that are not in the GMLS class.