### PR TITLE
Allow RHS to be adjustable 

### DIFF
--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -234,7 +234,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
                 } else {
                     // solves P*sqrt(weights) against sqrt(weights)*Identity with QR, stored in RHS
                     Kokkos::Profiling::pushRegion("Curvature QR Factorization");
-                    GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), max_num_rows, max_num_rows, _max_num_neighbors, manifold_NP, _max_num_neighbors, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                    GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), RHS_square_dim, RHS_square_dim, _max_num_neighbors, manifold_NP, _max_num_neighbors, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
                     Kokkos::Profiling::popRegion();
                 }
 
@@ -263,7 +263,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
             } else {
                  // solves P*sqrt(weights) against sqrt(weights)*Identity, stored in RHS
                 Kokkos::Profiling::pushRegion("Curvature QR Factorization");
-                GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), max_num_rows, max_num_rows, _max_num_neighbors, manifold_NP, _max_num_neighbors, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), RHS_square_dim, RHS_square_dim, _max_num_neighbors, manifold_NP, _max_num_neighbors, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
                 Kokkos::Profiling::popRegion();
            }
 
@@ -287,7 +287,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
             // uses SVD if necessary or if explicitly asked to do so (much slower than QR)
             if (_nontrivial_nullspace || _dense_solver_type == DenseSolverType::SVD) {
                 Kokkos::Profiling::pushRegion("Manifold SVD Factorization");
-                GMLS_LinearAlgebra::batchSVDFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), max_num_rows, max_num_rows, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                GMLS_LinearAlgebra::batchSVDFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
                 Kokkos::Profiling::popRegion();
             } else if (_dense_solver_type == DenseSolverType::LU) {
                 Kokkos::Profiling::pushRegion("Manifold LU Factorization");
@@ -295,7 +295,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
                 Kokkos::Profiling::popRegion();
             } else {
                 Kokkos::Profiling::pushRegion("Manifold QR Factorization");
-                GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), max_num_rows, max_num_rows, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
                 Kokkos::Profiling::popRegion();
             }
             Kokkos::fence();
@@ -319,7 +319,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
             // uses SVD if necessary or if explicitly asked to do so (much slower than QR)
             if (_nontrivial_nullspace || _dense_solver_type == DenseSolverType::SVD) {
                 Kokkos::Profiling::pushRegion("SVD Factorization");
-                GMLS_LinearAlgebra::batchSVDFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), max_num_rows, max_num_rows, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                GMLS_LinearAlgebra::batchSVDFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
                 Kokkos::Profiling::popRegion();
             } else if (_dense_solver_type == DenseSolverType::LU) {
                 Kokkos::Profiling::pushRegion("LU Factorization");
@@ -327,7 +327,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
                 Kokkos::Profiling::popRegion();
             } else {
                 Kokkos::Profiling::pushRegion("QR Factorization");
-                GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), max_num_rows, max_num_rows, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), max_num_rows, this_num_cols, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
                 Kokkos::Profiling::popRegion();
             }
 
@@ -479,6 +479,8 @@ void GMLS::operator()(const ApplyStandardTargets&, const member_type& teamMember
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
+    int RHS_square_dim = getRHSDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+
     /*
      *    Data
      */
@@ -487,7 +489,7 @@ void GMLS::operator()(const ApplyStandardTargets&, const member_type& teamMember
     scratch_matrix_right_type Coeffs;
     if (_dense_solver_type != DenseSolverType::LU) {
         Coeffs = scratch_matrix_right_type(_RHS.data() 
-            + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
+            + TO_GLOBAL(local_index)*TO_GLOBAL(RHS_square_dim)*TO_GLOBAL(RHS_square_dim), RHS_square_dim, RHS_square_dim);
     } else {
         Coeffs = scratch_matrix_right_type(_P.data() 
             + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_cols), this_num_cols, max_num_rows);
@@ -649,6 +651,8 @@ void GMLS::operator()(const GetAccurateTangentDirections&, const member_type& te
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
+    int RHS_square_dim = getRHSDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+
     /*
      *    Data
      */
@@ -656,7 +660,7 @@ void GMLS::operator()(const GetAccurateTangentDirections&, const member_type& te
     if (_dense_solver_type != DenseSolverType::LU) {
         // Solution from QR comes from RHS
         Q = scratch_matrix_right_type(_RHS.data()
-            + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
+            + TO_GLOBAL(local_index)*TO_GLOBAL(RHS_square_dim)*TO_GLOBAL(RHS_square_dim), RHS_square_dim, RHS_square_dim);
     } else {
         // Solution from LU comes from P
         Q = scratch_matrix_right_type(_P.data()
@@ -843,6 +847,8 @@ void GMLS::operator()(const ApplyCurvatureTargets&, const member_type& teamMembe
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
+    int RHS_square_dim = getRHSDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+
     /*
      *    Data
      */
@@ -850,7 +856,7 @@ void GMLS::operator()(const ApplyCurvatureTargets&, const member_type& teamMembe
     if (_dense_solver_type != DenseSolverType::LU) {
         // Solution from QR comes from RHS
         Q = scratch_matrix_right_type(_RHS.data()
-            + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
+            + TO_GLOBAL(local_index)*TO_GLOBAL(RHS_square_dim)*TO_GLOBAL(RHS_square_dim), RHS_square_dim, RHS_square_dim);
     } else {
         // Solution from LU comes from P
         Q = scratch_matrix_right_type(_P.data()
@@ -1049,6 +1055,8 @@ void GMLS::operator()(const ApplyManifoldTargets&, const member_type& teamMember
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
+    int RHS_square_dim = getRHSDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+
     /*
      *    Data
      */
@@ -1056,7 +1064,7 @@ void GMLS::operator()(const ApplyManifoldTargets&, const member_type& teamMember
     scratch_matrix_right_type Coeffs;
     if (_dense_solver_type != DenseSolverType::LU) {
         Coeffs = scratch_matrix_right_type(_RHS.data() 
-            + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
+            + TO_GLOBAL(local_index)*TO_GLOBAL(RHS_square_dim)*TO_GLOBAL(RHS_square_dim), RHS_square_dim, RHS_square_dim);
     } else {
         Coeffs = scratch_matrix_right_type(_P.data() 
             + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(this_num_cols), this_num_cols, max_num_rows);
@@ -1105,6 +1113,8 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
+    int RHS_square_dim = getRHSDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+
     /*
      *    Data
      */
@@ -1118,7 +1128,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
     if (_dense_solver_type != DenseSolverType::LU) {
         // Solution from QR comes from RHS
         Q = scratch_matrix_right_type(_RHS.data()
-            + TO_GLOBAL(local_index)*TO_GLOBAL(max_num_rows)*TO_GLOBAL(max_num_rows), max_num_rows, max_num_rows);
+            + TO_GLOBAL(local_index)*TO_GLOBAL(RHS_square_dim)*TO_GLOBAL(RHS_square_dim), RHS_square_dim, RHS_square_dim);
     } else {
         // Solution from LU comes from P
         Q = scratch_matrix_right_type(_P.data()

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -440,8 +440,8 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
 
     if (_dense_solver_type != DenseSolverType::LU) {
         // fill in RHS with Identity * sqrt(weights)
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,RHS_square_dim), [=] (const int i) {
-            for(int j = 0; j < RHS_square_dim; ++j) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this_num_rows), [=] (const int i) {
+            for(int j = 0; j < this_num_rows; ++j) {
                 RHS(j,i) = (i==j) ? std::sqrt(w(i)) : 0;
             }
         });
@@ -1014,8 +1014,8 @@ void GMLS::operator()(const AssembleManifoldPsqrtW&, const member_type& teamMemb
 
     if (_dense_solver_type != DenseSolverType::LU) {
         // fill in RHS with Identity * sqrt(weights)
-        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,RHS_square_dim), [=] (const int i) {
-            for(int j = 0; j < RHS_square_dim; ++j) {
+        Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this_num_rows), [=] (const int i) {
+            for(int j = 0; j < this_num_rows; ++j) {
                 Q(i, j) = (i==j) ? std::sqrt(w(i)) : 0;
             }
         });

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -176,7 +176,6 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
      *    Allocate Global Device Storage of Data Needed Over Multiple Calls
      */
     int RHS_square_dim = getRHSDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
-    std::cout << "RHS square dim " << RHS_square_dim << " this num cols " << this_num_cols << std::endl;
 
     global_index_type max_batch_size = (_target_coordinates.extent(0) + TO_GLOBAL(number_of_batches) - 1) / TO_GLOBAL(number_of_batches);
     try {

--- a/src/Compadre_Misc.hpp
+++ b/src/Compadre_Misc.hpp
@@ -1,6 +1,8 @@
 #ifndef _COMPADRE_MISC_HPP_
 #define _COMPADRE_MISC_HPP_
 
+#include "Compadre_Operators.hpp"
+
 namespace Compadre {
 
 struct XYZ {
@@ -36,6 +38,18 @@ struct XYZ {
         return result;
     }
 }; // XYZ
+
+KOKKOS_INLINE_FUNCTION
+int getRHSDims(DenseSolverType dense_solver_type, ConstraintType constraint_type, const int M, const int N) {
+    // Return the appropriate size for _RHS. Since in LU, the system solves P^T*P against P^T*W.
+    // We store P^T*P in the RHS space, which means RHS can be much smaller compared to the
+    // case for QR/SVD where the system solves PsqrtW against sqrtW*Identity
+    if (dense_solver_type != LU) {
+        return M;
+    } else {
+        return N;
+    }
+}
 
 }; // Compadre
 


### PR DESCRIPTION
Add a function to calculate the dimension for the square `RHS` matrix. This will allow the RHS to be much smaller in solving with LU. The interface to change the matrix dimension can also be useful when adding extra constraints to the minimisation least-square problem. 