### PR TITLE
Changing size of matrix P based on solver type and constraints

### DIFF
--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -1219,7 +1219,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
             Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(teamMember,this->getNNeighbors(target_index)), [=] (const int i, double &t_grad_xi1) {
                 double alpha_ij = 0;
                 for (int l=0; l<manifold_NP; ++l) {
-                    alpha_ij += delta(l)*Q(i,l);
+                    alpha_ij += delta(l)*Q(l,i);
                 }
                 XYZ rel_coord = getRelativeCoord(target_index, i, _dimensions, &T);
                 double normal_coordinate = rel_coord[_dimensions-1];
@@ -1235,7 +1235,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
             Kokkos::parallel_reduce(Kokkos::ThreadVectorRange(teamMember,this->getNNeighbors(target_index)), [=] (const int i, double &t_grad_xi2) {
                 double alpha_ij = 0;
                 for (int l=0; l<manifold_NP; ++l) {
-                    alpha_ij += delta(l)*Q(i,l);
+                    alpha_ij += delta(l)*Q(l,i);
                 }
                 XYZ rel_coord = getRelativeCoord(target_index, i, _dimensions, &T);
                 double normal_coordinate = rel_coord[_dimensions-1];

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -1153,7 +1153,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
     } else {
         // Solution from LU comes from P
         Q = scratch_matrix_right_type(_P.data()
-            + TO_GLOBAL(local_index)*TO_GLOBAL(P_dim_0)*TO_GLOBAL(P_dim_1), P_dim_0, P_dim_1);
+            + TO_GLOBAL(local_index)*TO_GLOBAL(P_dim_1)*TO_GLOBAL(P_dim_0), P_dim_1, P_dim_0);
     }
 
     scratch_matrix_right_type T(_T.data() 

--- a/src/Compadre_Misc.hpp
+++ b/src/Compadre_Misc.hpp
@@ -40,7 +40,7 @@ struct XYZ {
 }; // XYZ
 
 KOKKOS_INLINE_FUNCTION
-int getRHSDims(DenseSolverType dense_solver_type, ConstraintType constraint_type, const int M, const int N) {
+int getRHSSquareDim(DenseSolverType dense_solver_type, ConstraintType constraint_type, const int M, const int N) {
     // Return the appropriate size for _RHS. Since in LU, the system solves P^T*P against P^T*W.
     // We store P^T*P in the RHS space, which means RHS can be much smaller compared to the
     // case for QR/SVD where the system solves PsqrtW against sqrtW*Identity
@@ -48,6 +48,25 @@ int getRHSDims(DenseSolverType dense_solver_type, ConstraintType constraint_type
         return M;
     } else {
         return N;
+    }
+}
+
+KOKKOS_INLINE_FUNCTION
+void getPDims(DenseSolverType dense_solver_type, ConstraintType constraint_type, const int M, const int N, int &out_row, int &out_col) {
+    // Return the appropriate size for _P.
+    // In the case of solving with LU and additional constraint is used, _P needs
+    // to be resized to include additional row(s) based on the type of constraint.
+    if (dense_solver_type == LU) {
+        if (constraint_type == NEUMANN_GRAD_SCALAR) {
+            out_row = N + 1;
+            out_col = M + 1;
+        } else {
+            out_row = N;
+            out_col = M;
+        }
+    } else {
+        out_row = M;
+        out_col = N;
     }
 }
 

--- a/src/Compadre_Misc.hpp
+++ b/src/Compadre_Misc.hpp
@@ -58,11 +58,11 @@ void getPDims(DenseSolverType dense_solver_type, ConstraintType constraint_type,
     // to be resized to include additional row(s) based on the type of constraint.
     if (dense_solver_type == LU) {
         if (constraint_type == NEUMANN_GRAD_SCALAR) {
-            out_row = N + 1;
-            out_col = M + 1;
+            out_row = M + 1;
+            out_col = N + 1;
         } else {
-            out_row = N;
-            out_col = M;
+            out_row = M;
+            out_col = N;
         }
     } else {
         out_row = M;


### PR DESCRIPTION
Use a function to return the size of matrix `_P` based on the solver type and the constraint type. This is necessary to move toward solving the saddle-point problem in Neumann BC.