### PR TITLE
Allowing SVD to solve GMLS problem with Staggered Scheme and Neumann BC

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -78,6 +78,10 @@ if (Compadre_EXAMPLES)
     ADD_TEST(NAME GMLS_NeumannGradScalar_Dim3_LU COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_NeumannGradScalar_Test "3" "200" "3" "2" "0" "1" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_NeumannGradScalar_Dim3_LU PROPERTIES LABELS "UnitTest;unit;kokkos" TIMEOUT 10)
 
+    # Device views tests with Neumann BC for STAGGERED GMLS - SVD solver
+    ADD_TEST(NAME GMLS_StaggeredNeumannGradScalar_Dim3_SVD COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Staggered "3" "200" "3" "0" "0" "1" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(GMLS_StaggeredNeumannGradScalar_Dim3_SVD PROPERTIES LABELS "UnitTest;unit;kokkos;staggered" TIMEOUT 10)
+
     # Device views tests for GMLS (vector basis)
     ADD_TEST(NAME GMLS_Vector_Dim3_QR COMMAND ${CMAKE_CURRENT_BINARY_DIR}/GMLS_Vector_Test "3" "20" "3" "1" "0" "0" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(GMLS_Vector_Dim3_QR PROPERTIES LABELS "UnitTest;unit;kokkos;vector" TIMEOUT 10)

--- a/examples/UnitTest_ThreadedLapack.cpp
+++ b/examples/UnitTest_ThreadedLapack.cpp
@@ -82,7 +82,7 @@ Kokkos::initialize(argc, args);
 
     // call SVD on all num_matrices
     ParallelManager pm;
-    GMLS_LinearAlgebra::batchSVDFactorize(pm, all_P.data(), P_rows, P_cols, all_RHS.data(), RHS_rows, RHS_rows, P_rows, P_cols, P_rows, num_matrices);
+    GMLS_LinearAlgebra::batchSVDFactorize(pm, true, all_P.data(), P_rows, P_cols, true, all_RHS.data(), RHS_rows, RHS_rows, P_rows, P_cols, P_rows, num_matrices);
 
 
     const double tol = 1e-10;

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -10,6 +10,8 @@ namespace Compadre {
 
 void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
+    // throw an assertion for QR solver failer
+    compadre_assert_release( (!(_dense_solver_type==DenseSolverType::QR && _constraint_type==ConstraintType::NEUMANN_GRAD_SCALAR))  && "Cannot solve GMLS problems with the NEUMANN_GRAD_SCALAR constraint using QR Factorization.");
     /*
      *    Generate Quadrature
      */
@@ -36,14 +38,15 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
      */
 
     // calculate the additional size for different constraint problems
-    const int added_size = getAdditionalSizeFromConstraint(_dense_solver_type, _constraint_type);
+    const int added_alpha_size = getAdditionalAlphaSizeFromConstraint(_dense_solver_type, _constraint_type);
+    const int added_coeff_size = getAdditionalCoeffSizeFromConstraintAndSpace(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions);
 
     // initialize all alpha values to be used for taking the dot product with data to get a reconstruction 
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
     // would have to store for the max case (potentially number
     try {
-        _alphas = decltype(_alphas)("coefficients", _neighbor_lists.extent(0), _total_alpha_values*max_evaluation_sites, _max_num_neighbors + added_size);
+        _alphas = decltype(_alphas)("coefficients", _neighbor_lists.extent(0), _total_alpha_values*max_evaluation_sites, _max_num_neighbors + added_alpha_size);
     } catch(std::exception &e) {
        printf("Insufficient memory to store alphas: \n\n%s", e.what()); 
        throw e;
@@ -185,9 +188,9 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
      *    Calculate the size for matrix P and RHS
      */
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Allocate Global Device Storage of Data Needed Over Multiple Calls
@@ -304,7 +307,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
             // uses SVD if necessary or if explicitly asked to do so (much slower than QR)
             if (_nontrivial_nullspace || _dense_solver_type == DenseSolverType::SVD) {
                 Kokkos::Profiling::pushRegion("Manifold SVD Factorization");
-                GMLS_LinearAlgebra::batchSVDFactorize(_pm, _P.data(), P_dim_0, P_dim_1, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                GMLS_LinearAlgebra::batchSVDFactorize(_pm, true, _P.data(), P_dim_0, P_dim_1, true, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
                 Kokkos::Profiling::popRegion();
             } else if (_dense_solver_type == DenseSolverType::LU) {
                 Kokkos::Profiling::pushRegion("Manifold LU Factorization");
@@ -330,18 +333,31 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
             // solves P*sqrt(weights) against sqrt(weights)*Identity, stored in RHS
             // uses SVD if necessary or if explicitly asked to do so (much slower than QR)
-            if (_nontrivial_nullspace || _dense_solver_type == DenseSolverType::SVD) {
-                Kokkos::Profiling::pushRegion("SVD Factorization");
-                GMLS_LinearAlgebra::batchSVDFactorize(_pm, _P.data(), P_dim_0, P_dim_1, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
-                Kokkos::Profiling::popRegion();
-            } else if (_dense_solver_type == DenseSolverType::LU) {
-                Kokkos::Profiling::pushRegion("LU Factorization");
-                GMLS_LinearAlgebra::batchLUFactorize(_pm, _RHS.data(), RHS_square_dim, RHS_square_dim, _P.data(), P_dim_1, P_dim_0, this_num_cols + added_size, this_num_cols + added_size, max_num_rows + added_size, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
-                Kokkos::Profiling::popRegion();
+            if (_constraint_type == ConstraintType::NEUMANN_GRAD_SCALAR) {
+                if (_nontrivial_nullspace || _dense_solver_type == DenseSolverType::SVD) {
+                     Kokkos::Profiling::pushRegion("SVD Factorization");
+                     GMLS_LinearAlgebra::batchSVDFactorize(_pm, false, _RHS.data(), RHS_square_dim, RHS_square_dim, true, _P.data(), P_dim_1, P_dim_0, this_num_cols + added_coeff_size, this_num_cols + added_coeff_size, max_num_rows + added_alpha_size, this_batch_size, 0, _initial_index_for_batch, NULL);
+                     Kokkos::Profiling::popRegion();
+                } else {
+                     Kokkos::Profiling::pushRegion("LU Factorization");
+                     GMLS_LinearAlgebra::batchLUFactorize(_pm, _RHS.data(), RHS_square_dim, RHS_square_dim, _P.data(), P_dim_1, P_dim_0, this_num_cols + added_coeff_size, this_num_cols + added_coeff_size, max_num_rows + added_alpha_size, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                     Kokkos::Profiling::popRegion();
+                }
             } else {
-                Kokkos::Profiling::pushRegion("QR Factorization");
-                GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), P_dim_0, P_dim_1, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
-                Kokkos::Profiling::popRegion();
+                // Solve normally for no-constraint cases
+                if (_nontrivial_nullspace || _dense_solver_type == DenseSolverType::SVD) {
+                    Kokkos::Profiling::pushRegion("SVD Factorization");
+                    GMLS_LinearAlgebra::batchSVDFactorize(_pm, true, _P.data(), P_dim_0, P_dim_1, true, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                    Kokkos::Profiling::popRegion();
+                } else if (_dense_solver_type == DenseSolverType::LU) {
+                    Kokkos::Profiling::pushRegion("LU Factorization");
+                    GMLS_LinearAlgebra::batchLUFactorize(_pm, _RHS.data(), RHS_square_dim, RHS_square_dim, _P.data(), P_dim_1, P_dim_0, this_num_cols + added_coeff_size, this_num_cols + added_coeff_size, max_num_rows + added_alpha_size, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                    Kokkos::Profiling::popRegion();
+                } else {
+                    Kokkos::Profiling::pushRegion("QR Factorization");
+                    GMLS_LinearAlgebra::batchQRFactorize(_pm, _P.data(), P_dim_0, P_dim_1, _RHS.data(), RHS_square_dim, RHS_square_dim, max_num_rows, this_num_cols, max_num_rows, this_batch_size, _max_num_neighbors, _initial_index_for_batch, _number_of_neighbors_list.data());
+                    Kokkos::Profiling::popRegion();
+                }
             }
 
             _pm.CallFunctorWithTeamThreadsAndVectors<ComputePrestencilWeights>(this_batch_size, _pm.getThreadsPerTeam(_pm.getVectorLanesPerThread()), _pm.getVectorLanesPerThread(), *this);
@@ -382,10 +398,14 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
         _RHS = Kokkos::View<double*>("RHS",0);
         _P = Kokkos::View<double*>("P",0);
     } else {
-        if (_dense_solver_type != DenseSolverType::LU) {
-            _P = Kokkos::View<double*>("P",0);
+        if (_constraint_type == ConstraintType::NEUMANN_GRAD_SCALAR) {
+            _RHS = Kokkos::View<double*>("RHS", 0);
         } else {
-            _RHS = Kokkos::View<double*>("RHS",0);
+            if (_dense_solver_type != DenseSolverType::LU) {
+                _P = Kokkos::View<double*>("P", 0);
+            } else {
+                _RHS = Kokkos::View<double*>("RHS", 0);
+            }
         }
     }
 
@@ -426,9 +446,9 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
     const int this_num_rows = _sampling_multiplier*this->getNNeighbors(target_index);
     const int this_num_cols = _basis_multiplier*_NP;
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -451,7 +471,8 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
     // creates the matrix sqrt(W)*P
     this->createWeightsAndP(teamMember, delta, PsqrtW, w, _dimensions, _poly_order, true /*weight_p*/, NULL /*&V*/, _reconstruction_space, _polynomial_sampling_functional);
 
-    if (_dense_solver_type != DenseSolverType::LU) {
+    if ((_constraint_type == ConstraintType::NO_CONSTRAINT) && (_dense_solver_type != DenseSolverType::LU)) {
+    // if (_dense_solver_type != DenseSolverType::LU) {
         // fill in RHS with Identity * sqrt(weights)
         Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,this_num_rows), [=] (const int i) {
             for(int j = 0; j < this_num_rows; ++j) {
@@ -483,7 +504,7 @@ void GMLS::operator()(const AssembleStandardPsqrtW&, const member_type& teamMemb
             int num_neigh_target = this->getNNeighbors(target_index);
             double cutoff_p = _epsilons(target_index);
 
-            evaluateConstraints(M, PsqrtW, _constraint_type, cutoff_p, _dimensions, num_neigh_target, &T);
+            evaluateConstraints(M, PsqrtW, _constraint_type, _reconstruction_space, _NP, cutoff_p, _dimensions, num_neigh_target, &T);
         }
     }
 }
@@ -504,9 +525,9 @@ void GMLS::operator()(const ApplyStandardTargets&, const member_type& teamMember
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -514,7 +535,8 @@ void GMLS::operator()(const ApplyStandardTargets&, const member_type& teamMember
 
     // Coefficients for polynomial basis have overwritten _RHS
     scratch_matrix_right_type Coeffs;
-    if (_dense_solver_type != DenseSolverType::LU) {
+    // if (_dense_solver_type != DenseSolverType::LU) {
+    if ((_constraint_type == ConstraintType::NO_CONSTRAINT) && (_dense_solver_type != DenseSolverType::LU)) {
         Coeffs = scratch_matrix_right_type(_RHS.data() 
             + TO_GLOBAL(local_index)*TO_GLOBAL(RHS_square_dim)*TO_GLOBAL(RHS_square_dim), RHS_square_dim, RHS_square_dim);
     } else {
@@ -557,7 +579,7 @@ void GMLS::operator()(const ComputeCoarseTangentPlane&, const member_type& teamM
     const int this_num_cols = _basis_multiplier*max_manifold_NP;
 
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -609,9 +631,9 @@ void GMLS::operator()(const AssembleCurvaturePsqrtW&, const member_type& teamMem
     const int this_num_neighbors = this->getNNeighbors(target_index);
     const int this_num_cols = _basis_multiplier*max_manifold_NP;
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -683,9 +705,9 @@ void GMLS::operator()(const GetAccurateTangentDirections&, const member_type& te
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -881,9 +903,9 @@ void GMLS::operator()(const ApplyCurvatureTargets&, const member_type& teamMembe
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -1023,9 +1045,9 @@ void GMLS::operator()(const AssembleManifoldPsqrtW&, const member_type& teamMemb
     const int this_num_rows = _sampling_multiplier*this->getNNeighbors(target_index);
     const int this_num_cols = _basis_multiplier*max_manifold_NP;
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -1093,9 +1115,9 @@ void GMLS::operator()(const ApplyManifoldTargets&, const member_type& teamMember
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -1153,9 +1175,9 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
     const int max_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
                 ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
-    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols);
+    int RHS_square_dim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols);
     int P_dim_0, P_dim_1;
-    getPDims(_dense_solver_type, _constraint_type, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
+    getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, max_num_rows, this_num_cols, P_dim_0, P_dim_1);
 
     /*
      *    Data
@@ -1167,7 +1189,7 @@ void GMLS::operator()(const ComputePrestencilWeights&, const member_type& teamMe
 
     // holds polynomial coefficients for curvature reconstruction
     scratch_matrix_right_type Q;
-    if (_dense_solver_type != DenseSolverType::LU) {
+    if ((_constraint_type == ConstraintType::NO_CONSTRAINT) && (_dense_solver_type != DenseSolverType::LU)) {
         // Solution from QR comes from RHS
         Q = scratch_matrix_right_type(_RHS.data()
             + TO_GLOBAL(local_index)*TO_GLOBAL(RHS_square_dim)*TO_GLOBAL(RHS_square_dim), RHS_square_dim, RHS_square_dim);

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -35,6 +35,13 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
      *    Initialize Alphas and Prestencil Weights
      */
 
+    // throw an assertion for QR solver incompatibility
+    // TODO: this is a temporary location for this check, in the future the
+    // constraint type could be an object that can check when given a dense_solver_type
+    compadre_assert_release( (!(_dense_solver_type==DenseSolverType::QR
+                && _constraint_type==ConstraintType::NEUMANN_GRAD_SCALAR))
+            && "Cannot solve GMLS problems with the NEUMANN_GRAD_SCALAR constraint using QR Factorization.");
+
     // calculate the additional size for different constraint problems
     const int added_alpha_size = getAdditionalAlphaSizeFromConstraint(_dense_solver_type, _constraint_type);
     const int added_coeff_size = getAdditionalCoeffSizeFromConstraintAndSpace(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions);

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -10,8 +10,6 @@ namespace Compadre {
 
 void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
-    // throw an assertion for QR solver failer
-    compadre_assert_release( (!(_dense_solver_type==DenseSolverType::QR && _constraint_type==ConstraintType::NEUMANN_GRAD_SCALAR))  && "Cannot solve GMLS problems with the NEUMANN_GRAD_SCALAR constraint using QR Factorization.");
     /*
      *    Generate Quadrature
      */

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -331,7 +331,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
             // solves P*sqrt(weights) against sqrt(weights)*Identity, stored in RHS
             // uses SVD if necessary or if explicitly asked to do so (much slower than QR)
-            if (_constraint_type == ConstraintType::NEUMANN_GRAD_SCALAR) {
+            if (_constraint_type != ConstraintType::NO_CONSTRAINT) {
                 if (_nontrivial_nullspace || _dense_solver_type == DenseSolverType::SVD) {
                      Kokkos::Profiling::pushRegion("SVD Factorization");
                      GMLS_LinearAlgebra::batchSVDFactorize(_pm, false, _RHS.data(), RHS_square_dim, RHS_square_dim, true, _P.data(), P_dim_1, P_dim_0, this_num_cols + added_coeff_size, this_num_cols + added_coeff_size, max_num_rows + added_alpha_size, this_batch_size, 0, _initial_index_for_batch, NULL);
@@ -396,7 +396,7 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
         _RHS = Kokkos::View<double*>("RHS",0);
         _P = Kokkos::View<double*>("P",0);
     } else {
-        if (_constraint_type == ConstraintType::NEUMANN_GRAD_SCALAR) {
+        if (_constraint_type != ConstraintType::NO_CONSTRAINT) {
             _RHS = Kokkos::View<double*>("RHS", 0);
         } else {
             if (_dense_solver_type != DenseSolverType::LU) {

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -886,12 +886,12 @@ public:
         compadre_assert_release(_entire_batch_computed_at_once 
                 && "Entire batch not computed at once, so getFullPolynomialCoefficientsBasis() can not be called.");
         host_managed_local_index_type sizes("sizes", 2);
-        if (_dense_solver_type != DenseSolverType::LU) {
-            int rhsdim = getRHSSquareDim(_dense_solver_type, _constraint_type, M_by_N[1], M_by_N[0]);
+        if ((_constraint_type == ConstraintType::NO_CONSTRAINT) && (_dense_solver_type != DenseSolverType::LU)) {
+            int rhsdim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, M_by_N[1], M_by_N[0]);
             sizes(0) = rhsdim;
             sizes(1) = rhsdim;
         } else {
-            getPDims(_dense_solver_type, _constraint_type, M_by_N[1], M_by_N[0], sizes(1), sizes(0));
+            getPDims(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, M_by_N[1], M_by_N[0], sizes(1), sizes(0));
         }
         return sizes;
     }
@@ -1023,7 +1023,7 @@ public:
     decltype(_RHS) getFullPolynomialCoefficientsBasis() const { 
         compadre_assert_release(_entire_batch_computed_at_once 
                 && "Entire batch not computed at once, so getFullPolynomialCoefficientsBasis() can not be called.");
-        if (_dense_solver_type != DenseSolverType::LU) {
+        if ((_constraint_type == ConstraintType::NO_CONSTRAINT) && (_dense_solver_type != DenseSolverType::LU)) {
             return _RHS; 
         } else {
             return _P; 

--- a/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
+++ b/src/Compadre_GMLS_ApplyTargetEvaluations.hpp
@@ -12,14 +12,14 @@ void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vec
     const int num_evaluation_sites = (static_cast<int>(_additional_evaluation_indices.extent(1)) > 1) 
             ? static_cast<int>(_additional_evaluation_indices.extent(1)) : 1;
 
-    const int added_size = getAdditionalSizeFromConstraint(_dense_solver_type, _constraint_type);
+    const int added_alpha_size = getAdditionalAlphaSizeFromConstraint(_dense_solver_type, _constraint_type);
 
 #ifdef COMPADRE_USE_LAPACK
 
     // CPU
     for (int e=0; e<num_evaluation_sites; ++e) {
         // evaluating alpha_ij
-        for (int i=0; i<this->getNNeighbors(target_index) + added_size; ++i) {
+        for (int i=0; i<this->getNNeighbors(target_index) + added_alpha_size; ++i) {
             for (size_t j=0; j<_operations.size(); ++j) {
                 for (int k=0; k<_lro_output_tile_size[j]; ++k) {
                     for (int m=0; m<_lro_input_tile_size[j]; ++m) {
@@ -105,7 +105,7 @@ void GMLS::applyTargetsToCoefficients(const member_type& teamMember, scratch_vec
                 for (int m=0; m<_lro_input_tile_size[j]; ++m) {
                     int offset_index_jmke = getTargetOffsetIndexDevice(j,m,k,e);
                     Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,
-                            this->getNNeighbors(target_index) + added_size), [&] (const int i) {
+                            this->getNNeighbors(target_index) + added_alpha_size), [&] (const int i) {
                         double alpha_ij = 0;
                         if (_sampling_multiplier>1 && m<_sampling_multiplier) {
                             const int m_neighbor_offset = i+m*this->getNNeighbors(target_index);

--- a/src/Compadre_LinearAlgebra.cpp
+++ b/src/Compadre_LinearAlgebra.cpp
@@ -102,12 +102,13 @@ void batchQRFactorize(ParallelManager pm, double *P, int lda, int nda, double *R
             // use a custom # of neighbors for each problem, if possible
             const int multiplier = (max_neighbors > 0) ? M/max_neighbors : 1; // assumes M is some positive integer scalaing of max_neighbors
             int my_num_rows = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i + initial_index_of_batch))*multiplier : M;
+            int my_num_rhs = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i + initial_index_of_batch))*multiplier : NRHS;
 
             Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
             dgels_( const_cast<char *>(transpose_or_no.c_str()), 
-                    const_cast<int*>(&my_num_rows), const_cast<int*>(&N), const_cast<int*>(&my_num_rows), 
-                    p_offset, const_cast<int*>(&lda), 
-                    rhs_offset, const_cast<int*>(&ldb), 
+                    const_cast<int*>(&my_num_rows), const_cast<int*>(&N), const_cast<int*>(&my_num_rhs),
+                    p_offset, const_cast<int*>(&lda),
+                    rhs_offset, const_cast<int*>(&ldb),
                     scratch_work.data(), const_cast<int*>(&lwork), &i_info);
             });
 
@@ -128,11 +129,12 @@ void batchQRFactorize(ParallelManager pm, double *P, int lda, int nda, double *R
             // use a custom # of neighbors for each problem, if possible
             const int multiplier = (max_neighbors > 0) ? M/max_neighbors : 1; // assumes M is some positive integer scalaing of max_neighbors
             int my_num_rows = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i + initial_index_of_batch))*multiplier : M;
+            int my_num_rhs = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i + initial_index_of_batch))*multiplier : NRHS;
 
             dgels_( const_cast<char *>(transpose_or_no.c_str()), 
-                    const_cast<int*>(&my_num_rows), const_cast<int*>(&N), const_cast<int*>(&my_num_rows), 
-                    p_offset, const_cast<int*>(&lda), 
-                    rhs_offset, const_cast<int*>(&ldb), 
+                    const_cast<int*>(&my_num_rows), const_cast<int*>(&N), const_cast<int*>(&my_num_rhs),
+                    p_offset, const_cast<int*>(&lda),
+                    rhs_offset, const_cast<int*>(&ldb),
                     scratch_work.data(), const_cast<int*>(&lwork), &i_info);
 
             compadre_assert_release(i_info==0 && "dgels failed");
@@ -152,17 +154,19 @@ void batchQRFactorize(ParallelManager pm, double *P, int lda, int nda, double *R
 
 }
 
-void batchSVDFactorize(ParallelManager pm, double *P, int lda, int nda, double *RHS, int ldb, int ndb, int M, int N, int NRHS, const int num_matrices, const size_t max_neighbors, const int initial_index_of_batch, int * neighbor_list_sizes) {
+void batchSVDFactorize(ParallelManager pm, bool swap_layout_P, double *P, int lda, int nda, bool swap_layout_RHS, double *RHS, int ldb, int ndb, int M, int N, int NRHS, const int num_matrices, const size_t max_neighbors, const int initial_index_of_batch, int * neighbor_list_sizes) {
 
-    // P was constructed layout right, while LAPACK and CUDA expect layout left
-    // P is not squared and not symmetric, so we must convert it to layout left
-    // RHS is symmetric and square, so no conversion is necessary
-    ConvertLayoutRightToLeft crl(pm, lda, nda, P);
-    int scratch_size = scratch_matrix_left_type::shmem_size(lda, nda);
-    pm.clearScratchSizes();
-    pm.setTeamScratchSize(1, scratch_size);
-    pm.CallFunctorWithTeamThreads(num_matrices, crl);
-    Kokkos::fence();
+    if (swap_layout_P) {
+        // P was constructed layout right, while LAPACK and CUDA expect layout left
+        // P is not squared and not symmetric, so we must convert it to layout left
+        // RHS is symmetric and square, so no conversion is necessary
+        ConvertLayoutRightToLeft crl(pm, lda, nda, P);
+        int scratch_size = scratch_matrix_left_type::shmem_size(lda, nda);
+        pm.clearScratchSizes();
+        pm.setTeamScratchSize(1, scratch_size);
+        pm.CallFunctorWithTeamThreads(num_matrices, crl);
+        Kokkos::fence();
+    }
 
 #ifdef COMPADRE_USE_CUDA
 
@@ -339,28 +343,38 @@ void batchSVDFactorize(ParallelManager pm, double *P, int lda, int nda, double *
 
 
     Kokkos::Profiling::pushRegion("SVD::S Copy");
-      // deep copy neighbor list sizes over to gpu
-      Kokkos::View<int*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_neighbor_list_sizes(neighbor_list_sizes + initial_index_of_batch, num_matrices);
-      Kokkos::View<int*> d_neighbor_list_sizes("neighbor list sizes on device", num_matrices);
-      Kokkos::deep_copy(d_neighbor_list_sizes, h_neighbor_list_sizes);
+    // deep copy neighbor list sizes over to gpu
+    Kokkos::View<int*, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged> > h_neighbor_list_sizes(neighbor_list_sizes + initial_index_of_batch, num_matrices);
+    Kokkos::View<int*> d_neighbor_list_sizes("neighbor list sizes on device", num_matrices);
+    Kokkos::deep_copy(d_neighbor_list_sizes, h_neighbor_list_sizes);
 
-      int scratch_space_size = 0;
-      scratch_space_size += scratch_vector_type::shmem_size( min_mn );  // s
+    int scratch_space_level;
+    int scratch_space_size = 0;
+    scratch_space_size += scratch_vector_type::shmem_size( min_mn );  // s
+    if (swap_layout_P) {
+        // Less memory is required if the right hand side matrix is diagonal
+        scratch_space_level = 0;
+    } else {
+        // More memory is required to perform full matrix multiplication
+        scratch_space_size += scratch_matrix_left_type::shmem_size(N, M);
+        scratch_space_size += scratch_matrix_left_type::shmem_size(N, NRHS);
+        scratch_space_level = 1;
+    }
     Kokkos::Profiling::popRegion();
     
     Kokkos::parallel_for(
         team_policy(num_matrices, Kokkos::AUTO)
-        .set_scratch_size(0, Kokkos::PerTeam(scratch_space_size)), // shared memory
+        .set_scratch_size(scratch_space_level, Kokkos::PerTeam(scratch_space_size)), // shared memory
         KOKKOS_LAMBDA (const member_type& teamMember) {
 
         const int target_index = teamMember.league_rank();
 
         // use a custom # of neighbors for each problem, if possible
         const int multiplier = (max_neighbors > 0) ? M/max_neighbors : 1; // assumes M is some positive integer scalaing of max_neighbors
-        int my_num_rows = d_neighbor_list_sizes(target_index)*multiplier;
+        int my_num_rows = d_neighbor_list_sizes(target_index)*multiplier + initial_index_of_batch;
         //int my_num_rows = d_neighbor_list_sizes(target_index)*multiplier : M;
 
-        scratch_vector_type s(teamMember.team_scratch(0), min_mn ); // shared memory
+        scratch_vector_type s(teamMember.team_scratch(scratch_space_level), min_mn ); // shared memory
 
         // data is actually layout left
         scratch_matrix_left_type
@@ -383,20 +397,61 @@ void batchSVDFactorize(ParallelManager pm, double *P, int lda, int nda, double *
         });
         teamMember.team_barrier();
 
-        for (int i=0; i<my_num_rows; ++i) {
-            double sqrt_w_i_m = RHS_(i,i);
-            Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,N), 
-                  [=] (const int j) {
+        if (swap_layout_P) {
+            // When solving PsqrtW against sqrtW, since there are two
+            // diagonal matrices (s and the right hand side), the matrix
+            // multiplication can be written more efficiently
+            for (int i=0; i<my_num_rows; ++i) {
+                double sqrt_w_i_m = RHS_(i,i);
+                Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember,N),
+                      [=] (const int j) {
 
-                double  bdataj = 0;
-                for (int k=0; k<min_mn; ++k) {
-                    bdataj += V_(j,k)*s(k)*U_(i,k);
+                    double  bdataj = 0;
+                    for (int k=0; k<min_mn; ++k) {
+                        bdataj += V_(j,k)*s(k)*U_(i,k);
+                    }
+                // RHS_ is where we can find std::sqrt(w)
+                    bdataj *= sqrt_w_i_m;
+                    RHS_(j,i) = bdataj;
+                });
+                teamMember.team_barrier();
+            }
+        } else {
+            // Otherwise, you need to perform a full matrix multiplication
+            scratch_matrix_left_type temp_VSU_left_matrix(teamMember.team_scratch(scratch_space_level), N, M);
+            scratch_matrix_left_type temp_x_left_matrix(teamMember.team_scratch(scratch_space_level), N, NRHS);
+            // Multiply V s U^T and sotre into temp_VSU_left_matrix
+            Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, N),
+                [=] (const int i) {
+                for (int j=0; j<M; j++) {
+                    double temp = 0.0;
+                    for (int k=0; k<min_mn; k++) {
+                        temp += V_(i,k)*s(k)*U_(j,k);
+                    }
+                    temp_VSU_left_matrix(i, j) = temp;
                 }
-            // RHS_ is where we can find std::sqrt(w)
-                bdataj *= sqrt_w_i_m;
-                RHS_(j,i) = bdataj;
             });
             teamMember.team_barrier();
+
+            // Multiply temp_VSU_left_matrix with RHS_ and store in temp_x_left_matrix
+            Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, N),
+                [=] (const int i) {
+                for (int j=0; j<NRHS; j++) {
+                    double temp = 0.0;
+                    for (int k=0; k<M; k++) {
+                        temp += temp_VSU_left_matrix(i, k)*RHS_(k, j);
+                    }
+                    temp_x_left_matrix(i, j) = temp;
+                }
+            });
+            teamMember.team_barrier();
+            // Copy the matrix back to RHS
+            Kokkos::parallel_for(Kokkos::TeamThreadRange(teamMember, N),
+                [=] (const int i) {
+                for (int j=0; j<NRHS; j++) {
+                    RHS_(i, j) = temp_x_left_matrix(i, j);
+                }
+            });
         }
     }, "SVD: USV*RHS Multiply");
 
@@ -460,12 +515,13 @@ void batchSVDFactorize(ParallelManager pm, double *P, int lda, int nda, double *
 
                 // use a custom # of neighbors for each problem, if possible
                 const int multiplier = (max_neighbors > 0) ? M/max_neighbors : 1; // assumes M is some positive integer scalaing of max_neighbors
-                int my_num_rows = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i))*multiplier : M;
+                int my_num_rows = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i + initial_index_of_batch))*multiplier : M;
+                int my_num_rhs = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i + initial_index_of_batch))*multiplier : NRHS;
 
                 Kokkos::single(Kokkos::PerTeam(teamMember), [&] () {
-                dgelsd_( const_cast<int*>(&my_num_rows), const_cast<int*>(&N), const_cast<int*>(&my_num_rows), 
-                         p_offset, const_cast<int*>(&lda), 
-                         rhs_offset, const_cast<int*>(&ldb), 
+                dgelsd_( const_cast<int*>(&my_num_rows), const_cast<int*>(&N), const_cast<int*>(&my_num_rhs),
+                         p_offset, const_cast<int*>(&lda),
+                         rhs_offset, const_cast<int*>(&ldb),
                          scratch_s.data(), const_cast<double*>(&rcond), &i_rank,
                          scratch_work.data(), const_cast<int*>(&lwork), scratch_iwork.data(), &i_info);
                 });
@@ -491,10 +547,11 @@ void batchSVDFactorize(ParallelManager pm, double *P, int lda, int nda, double *
                 // use a custom # of neighbors for each problem, if possible
                 const int multiplier = (max_neighbors > 0) ? M/max_neighbors : 1; // assumes M is some positive integer scalaing of max_neighbors
                 int my_num_rows = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i + initial_index_of_batch))*multiplier : M;
+                int my_num_rhs = (neighbor_list_sizes) ? (*(neighbor_list_sizes + i + initial_index_of_batch))*multiplier : NRHS;
 
-                dgelsd_( const_cast<int*>(&my_num_rows), const_cast<int*>(&N), const_cast<int*>(&my_num_rows), 
-                         p_offset, const_cast<int*>(&lda), 
-                         rhs_offset, const_cast<int*>(&ldb), 
+                dgelsd_( const_cast<int*>(&my_num_rows), const_cast<int*>(&N), const_cast<int*>(&my_num_rhs),
+                         p_offset, const_cast<int*>(&lda),
+                         rhs_offset, const_cast<int*>(&ldb),
                          scratch_s, const_cast<double*>(&rcond), &i_rank,
                          scratch_work, const_cast<int*>(&lwork), scratch_iwork, &i_info);
 
@@ -512,7 +569,7 @@ void batchSVDFactorize(ParallelManager pm, double *P, int lda, int nda, double *
 
     // Results are written layout left, so they need converted to layout right
     ConvertLayoutLeftToRight clr(pm, ldb, ndb, RHS);
-    scratch_size = scratch_matrix_left_type::shmem_size(ldb, ndb);
+    int scratch_size = scratch_matrix_left_type::shmem_size(ldb, ndb);
     pm.clearScratchSizes();
     pm.setTeamScratchSize(1, scratch_size);
     pm.CallFunctorWithTeamThreads(num_matrices, clr);

--- a/src/Compadre_LinearAlgebra.cpp
+++ b/src/Compadre_LinearAlgebra.cpp
@@ -574,8 +574,8 @@ void batchSVDFactorize(ParallelManager pm, bool swap_layout_P, double *P, int ld
         pm.clearScratchSizes();
         pm.setTeamScratchSize(1, scratch_size);
         pm.CallFunctorWithTeamThreads(num_matrices, clr);
-        Kokkos::fence();
     }
+    Kokkos::fence();
 
 }
 

--- a/src/Compadre_LinearAlgebra_Declarations.hpp
+++ b/src/Compadre_LinearAlgebra_Declarations.hpp
@@ -82,9 +82,11 @@ namespace GMLS_LinearAlgebra {
          RHS contains num_matrices * ldn * ndb data which is num_matrices different matrix right hand sides.
 
         \param pm                   [in] - manager class for team and thread parallelism
+        \param swap_layout_P        [in] - boolean to check if layout of P will need to be swapped or not
         \param P                [in/out] - evaluation of sampling functional on polynomial basis (in), meaningless workspace output (out)
         \param lda                  [in] - row dimension of each matrix in P
         \param nda                  [in] - columns dimension of each matrix in P
+        \param swap_layout_RHS      [in] - boolean to check if layout of RHS will need to be swapped or not
         \param RHS              [in/out] - basis to invert P against (in), polynomial coefficients (out)
         \param ldb                  [in] - row dimension of each matrix in RHS
         \param ndb                  [in] - column dimension of each matrix in RHS
@@ -94,7 +96,7 @@ namespace GMLS_LinearAlgebra {
         \param max_neighbors        [in] - integer for maximum neighbor over all targets
         \param neighbor_list_sizes  [in] - pointer to all neighbor list sizes for each target
     */
-    void batchSVDFactorize(ParallelManager pm, double *P, int lda, int nda, double *RHS, int ldb, int ndb, int M, int N, int NRHS, const int num_matrices, const size_t max_neighbors = 0, const int initial_index_of_batch = 0, int * neighbor_list_sizes = NULL);
+    void batchSVDFactorize(ParallelManager pm, bool swap_layout_P, double *P, int lda, int nda, bool swap_layout_RHS, double *RHS, int ldb, int ndb, int M, int N, int NRHS, const int num_matrices, const size_t max_neighbors = 0, const int initial_index_of_batch = 0, int * neighbor_list_sizes = NULL);
 
     /*! \brief Calls LAPACK or CUBLAS to solve a batch of LU problems
 

--- a/src/Compadre_Misc.hpp
+++ b/src/Compadre_Misc.hpp
@@ -40,48 +40,65 @@ struct XYZ {
 }; // XYZ
 
 KOKKOS_INLINE_FUNCTION
-int getAdditionalSizeFromConstraint(DenseSolverType dense_solver_type, ConstraintType constraint_type) {
+int getAdditionalAlphaSizeFromConstraint(DenseSolverType dense_solver_type, ConstraintType constraint_type) {
     // Return the additional constraint size
-    if (dense_solver_type == LU) {
-        if (constraint_type == NEUMANN_GRAD_SCALAR) {
-            return 1;
-        } else {
-            return 0;
-        }
+    if (constraint_type == NEUMANN_GRAD_SCALAR) {
+        return 1;
     } else {
         return 0;
     }
 }
 
 KOKKOS_INLINE_FUNCTION
-int getRHSSquareDim(DenseSolverType dense_solver_type, ConstraintType constraint_type, const int M, const int N) {
-    // Return the appropriate size for _RHS. Since in LU, the system solves P^T*P against P^T*W.
-    // We store P^T*P in the RHS space, which means RHS can be much smaller compared to the
-    // case for QR/SVD where the system solves PsqrtW against sqrtW*Identity
-
-    int added_size = getAdditionalSizeFromConstraint(dense_solver_type, constraint_type);
-
-    if (dense_solver_type != LU) {
-        return M;
+int getAdditionalCoeffSizeFromConstraintAndSpace(DenseSolverType dense_solver_type, ConstraintType constraint_type, ReconstructionSpace reconstruction_space, const int dimension) {
+    // Return the additional constraint size
+    int added_alpha_size = getAdditionalAlphaSizeFromConstraint(dense_solver_type, constraint_type);
+    if (reconstruction_space == VectorTaylorPolynomial) {
+        return dimension*added_alpha_size;
     } else {
-        return N + added_size;
+        return added_alpha_size;
     }
 }
 
 KOKKOS_INLINE_FUNCTION
-void getPDims(DenseSolverType dense_solver_type, ConstraintType constraint_type, const int M, const int N, int &out_row, int &out_col) {
+int getRHSSquareDim(DenseSolverType dense_solver_type, ConstraintType constraint_type, ReconstructionSpace reconstruction_space, const int dimension, const int M, const int N) {
+    // Return the appropriate size for _RHS. Since in LU, the system solves P^T*P against P^T*W.
+    // We store P^T*P in the RHS space, which means RHS can be much smaller compared to the
+    // case for QR/SVD where the system solves PsqrtW against sqrtW*Identity
+
+    int added_coeff_size = getAdditionalCoeffSizeFromConstraintAndSpace(dense_solver_type, constraint_type, reconstruction_space, dimension);
+
+    if (constraint_type == NEUMANN_GRAD_SCALAR) {
+        return N + added_coeff_size;
+    } else {
+        if (dense_solver_type != LU) {
+            return M;
+        } else {
+            return N + added_coeff_size;
+        }
+    }
+}
+
+KOKKOS_INLINE_FUNCTION
+void getPDims(DenseSolverType dense_solver_type, ConstraintType constraint_type, ReconstructionSpace reconstruction_space, const int dimension, const int M, const int N, int &out_row, int &out_col) {
     // Return the appropriate size for _P.
     // In the case of solving with LU and additional constraint is used, _P needs
     // to be resized to include additional row(s) based on the type of constraint.
 
-    int added_size = getAdditionalSizeFromConstraint(dense_solver_type, constraint_type);
+    int added_coeff_size = getAdditionalCoeffSizeFromConstraintAndSpace(dense_solver_type, constraint_type, reconstruction_space, dimension);
+    int added_alpha_size = getAdditionalAlphaSizeFromConstraint(dense_solver_type, constraint_type);
 
-    if (dense_solver_type == LU) {
-        out_row = M + added_size;
-        out_col = N + added_size;
+    if (constraint_type == NEUMANN_GRAD_SCALAR) {
+        out_row = M + added_alpha_size;
+        out_col = N + added_coeff_size;
     } else {
-        out_row = M;
-        out_col = N;
+        if (dense_solver_type == LU) {
+            out_row = M + added_alpha_size;
+            out_col = N + added_coeff_size;
+        } else {
+            out_row = M;
+            out_col = N;
+        }
     }
 }
 

--- a/src/Compadre_Misc.hpp
+++ b/src/Compadre_Misc.hpp
@@ -41,13 +41,6 @@ struct XYZ {
 
 KOKKOS_INLINE_FUNCTION
 int getAdditionalAlphaSizeFromConstraint(DenseSolverType dense_solver_type, ConstraintType constraint_type) {
-    // throw an assertion for QR solver incompatibility
-    // TODO: this is a temporary location for this check, in the future the 
-    // constraint type could be an object that can check when given a dense_solver_type 
-    compadre_assert_release( (!(dense_solver_type==DenseSolverType::QR 
-                && constraint_type==ConstraintType::NEUMANN_GRAD_SCALAR))  
-            && "Cannot solve GMLS problems with the NEUMANN_GRAD_SCALAR constraint using QR Factorization.");
-
     // Return the additional constraint size
     if (constraint_type == NEUMANN_GRAD_SCALAR) {
         return 1;

--- a/src/Compadre_Misc.hpp
+++ b/src/Compadre_Misc.hpp
@@ -41,6 +41,13 @@ struct XYZ {
 
 KOKKOS_INLINE_FUNCTION
 int getAdditionalAlphaSizeFromConstraint(DenseSolverType dense_solver_type, ConstraintType constraint_type) {
+    // throw an assertion for QR solver incompatibility
+    // TODO: this is a temporary location for this check, in the future the 
+    // constraint type could be an object that can check when given a dense_solver_type 
+    compadre_assert_release( (!(dense_solver_type==DenseSolverType::QR 
+                && constraint_type==ConstraintType::NEUMANN_GRAD_SCALAR))  
+            && "Cannot solve GMLS problems with the NEUMANN_GRAD_SCALAR constraint using QR Factorization.");
+
     // Return the additional constraint size
     if (constraint_type == NEUMANN_GRAD_SCALAR) {
         return 1;

--- a/src/basis/CreateConstraints.hpp
+++ b/src/basis/CreateConstraints.hpp
@@ -6,15 +6,44 @@
 namespace Compadre {
 
 KOKKOS_INLINE_FUNCTION
-void evaluateConstraints(scratch_matrix_right_type M, scratch_matrix_right_type PsqrtW, const ConstraintType constraint_type, const double cutoff_p, const int dimension, const int num_neighbors = 0, scratch_matrix_right_type* T = NULL) {
+void evaluateConstraints(scratch_matrix_right_type M, scratch_matrix_right_type PsqrtW, const ConstraintType constraint_type, const ReconstructionSpace reconstruction_space, const int NP, const double cutoff_p, const int dimension, const int num_neighbors = 0, scratch_matrix_right_type* T = NULL) {
     if (constraint_type == ConstraintType::NEUMANN_GRAD_SCALAR) {
-        // Fill in the bottom right entry for PsqrtW
-        PsqrtW(num_neighbors, PsqrtW.extent(1)-1) = 1.0;
+        if (reconstruction_space == ReconstructionSpace::ScalarTaylorPolynomial) {
+            // Fill in the bottom right entry for PsqrtW
+            PsqrtW(num_neighbors, PsqrtW.extent(1)-1) = 1.0;
 
-        // Fill in the last column and row of M
-        for (int i=0; i<dimension; ++i) {
-            M(M.extent(0)-1, i+1) = (1.0/cutoff_p)*(*T)(dimension-1,i);
-            M(i+1, M.extent(0)-1) = (1.0/cutoff_p)*(*T)(dimension-1,i);
+            // Fill in the last column and row of M
+            for (int i=0; i<dimension; ++i) {
+                M(M.extent(0)-1, i+1) = (1.0/cutoff_p)*(*T)(dimension-1,i);
+                M(i+1, M.extent(0)-1) = (1.0/cutoff_p)*(*T)(dimension-1,i);
+            }
+        } else if (reconstruction_space == ReconstructionSpace::VectorTaylorPolynomial) {
+            // Fill in the bottom right of PsqrtW
+            PsqrtW(num_neighbors, PsqrtW.extent(1) - 1) = 1.0;
+            PsqrtW(num_neighbors, PsqrtW.extent(1) - 2) = 1.0;
+            PsqrtW(num_neighbors, PsqrtW.extent(1) - 3) = 1.0;
+
+            // Fill in the last column and row of M
+            M(0, M.extent(0)-3) = (*T)(2, 0);
+            M(0, M.extent(0)-2) = (*T)(2, 0);
+            M(0, M.extent(0)-1) = (*T)(2, 0);
+            M(M.extent(0)-3, 0) = (*T)(2, 0);
+            M(M.extent(0)-2, 0) = (*T)(2, 0);
+            M(M.extent(0)-1, 0) = (*T)(2, 0);
+
+            M(NP, M.extent(0) - 3) = (*T)(2, 1);
+            M(NP, M.extent(0) - 2) = (*T)(2, 1);
+            M(NP, M.extent(0) - 1) = (*T)(2, 1);
+            M(M.extent(0) - 3, NP) = (*T)(2, 1);
+            M(M.extent(0) - 2, NP) = (*T)(2, 1);
+            M(M.extent(0) - 1, NP) = (*T)(2, 1);
+
+            M(2*NP, M.extent(0) - 3) = (*T)(2, 2);
+            M(2*NP, M.extent(0) - 2) = (*T)(2, 2);
+            M(2*NP, M.extent(0) - 1) = (*T)(2, 2);
+            M(M.extent(0) - 3, 2*NP) = (*T)(2, 2);
+            M(M.extent(0) - 2, 2*NP) = (*T)(2, 2);
+            M(M.extent(0) - 1, 2*NP) = (*T)(2, 2);
         }
     }
 }


### PR DESCRIPTION
Basically Re PR #148 but without the unnecessary file. 

Since this PR spans two separate decades, a lot of things are bounded to happen.

* When solving the Neumann constraint with GMLS, the staggered scheme introduce a row of 0 in th P^TWP matrix. This PR allows SVD to solve the square system P^T W P against P^T W
* The original code of SVD post-multiply the factorization with a diagonal matrix (solving P^T sqrt(W) against sqrt(W) ) hence allowing a trick to be used. This PR check the switch and perform full matrix multiplication if necessary.
* Consider solving the constraint Neumann with Vector reconstruction space. When the target operator is `DivergenceOfVector`, the added rows and columns to the M = P^T W P matrix is equal to the dimension of the space, but the additional alpha is only one extra. Due to the mismatch between then, two additional variables have been created. `added_constraint_size` stores the additional rows and columns added to the constraint KKT system, while `added_alpha_size` reflects the additional number of alpha for that constraints.
* When applying the targets, it need to loop through `added_alpha_size` rather than the `added_constraint_size`. 
* Added a unit test case for staggered scheme with Neumann Grad Scalar using SVD. 
* Latest commit address the issue #150 