### PR TITLE
Version 1.0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10.0 FATAL_ERROR)
 
 ##########
 #
@@ -6,7 +6,8 @@ cmake_minimum_required(VERSION 3.0.0)
 #
 ########## 
 
-PROJECT(Compadre VERSION 1.0.2 LANGUAGES CXX)
+PROJECT(Compadre VERSION 1.0.3 LANGUAGES CXX)
+
 
 # cmake helper functions
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/bob.cmake)
@@ -24,7 +25,7 @@ SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
 SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-SET(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib ${CMAKE_INSTALL_RPATH})
+SET(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_LIBDIR} ${CMAKE_INSTALL_RPATH})
 
 # RPATH should always include the folder it is called from
 bob_option(PYTHON_CALLING_BUILD "Python setuptools calling build" OFF)
@@ -365,7 +366,7 @@ if (Compadre_USE_PYTHON)
   ENDIF()
 
   set(SWIG_PREFIX "../python") # relative to examples folder
-  bob_input(GMLS_Module_DEST "lib/python/dist-packages" PATH "Path to install python module")
+  bob_input(GMLS_Module_DEST "${CMAKE_INSTALL_LIBDIR}/python/dist-packages" PATH "Path to install python module")
 
   IF(NOT EXISTS ${PYTHON_INCLUDE_DIRS})
     EXECUTE_PROCESS(

--- a/cmake/bob.cmake
+++ b/cmake/bob.cmake
@@ -30,9 +30,9 @@ function(bob_always_full_rpath)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH False PARENT_SCOPE)
   # the RPATH to be used when installing, but only if it's not a system directory
   list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
-       "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+       "${CMAKE_INSTALL_LIBDIR}" isSystemDir)
   if("${isSystemDir}" STREQUAL "-1")
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" PARENT_SCOPE)
+    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}" PARENT_SCOPE)
   endif()
   # add the automatically determined parts of the RPATH
   # which point to directories outside the build tree to the install RPATH
@@ -341,10 +341,10 @@ macro(bob_add_dependency)
       install(TARGETS ${tgt} EXPORT
           ${tgt}-target
           RUNTIME DESTINATION bin
-          ARCHIVE DESTINATION lib
-          RUNTIME DESTINATION lib)
+          ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+          RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
       install(EXPORT ${tgt}-target
-              DESTINATION lib/cmake/${PROJECT_NAME})
+              DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
       set(${PROJECT_NAME}_EXPORTED_TARGETS
           ${${PROJECT_NAME}_EXPORTED_TARGETS}
           ${tgt})
@@ -390,11 +390,11 @@ function(bob_export_target tgt_name)
     install(TARGETS ${tgt_name} DESTINATION bin)
   else()
     if (USE_XSDK_DEFAULTS)
-      install(TARGETS ${tgt_name} DESTINATION lib)
+      install(TARGETS ${tgt_name} DESTINATION ${CMAKE_INSTALL_LIBDIR})
     else()
-      install(TARGETS ${tgt_name} EXPORT ${tgt_name}-target DESTINATION lib)
+      install(TARGETS ${tgt_name} EXPORT ${tgt_name}-target DESTINATION ${CMAKE_INSTALL_LIBDIR})
       install(EXPORT ${tgt_name}-target NAMESPACE ${PROJECT_NAME}::
-              DESTINATION lib/cmake/${PROJECT_NAME})
+              DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
       set(${PROJECT_NAME}_EXPORTED_TARGETS
           ${${PROJECT_NAME}_EXPORTED_TARGETS} ${tgt_name} PARENT_SCOPE)
     endif()
@@ -516,7 +516,7 @@ function(bob_install_provenance)
        "${${PROJECT_NAME}_CMAKE_ARGS}")
   install(FILES
       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_cmake_args.txt
-      DESTINATION lib/cmake/${PROJECT_NAME})
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
   string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type_upper)
   foreach(lang IN LISTS languages)
@@ -524,7 +524,7 @@ function(bob_install_provenance)
          "${CMAKE_${lang}_COMPILER} ${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${build_type_upper}}")
     install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${lang}_compile_line.txt
-        DESTINATION lib/cmake/${PROJECT_NAME})
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   endforeach()
   foreach(tgt IN LISTS ${PROJECT_NAME}_EXPORTED_TARGETS)
     get_target_property(tgt_type "${tgt}" TYPE)
@@ -534,7 +534,7 @@ function(bob_install_provenance)
            "${link_libs}")
       install(FILES
           ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${tgt}_libs.txt
-          DESTINATION lib/cmake/${PROJECT_NAME})
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
     endif()
   endforeach()
 
@@ -545,7 +545,7 @@ function(bob_install_provenance_no_recurse no_recurse_components_list)
        "${${PROJECT_NAME}_CMAKE_ARGS}")
   install(FILES
       ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_cmake_args.txt
-      DESTINATION lib/cmake/${PROJECT_NAME})
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
   string(TOUPPER "${CMAKE_BUILD_TYPE}" build_type_upper)
   foreach(lang IN LISTS languages)
@@ -553,7 +553,7 @@ function(bob_install_provenance_no_recurse no_recurse_components_list)
          "${CMAKE_${lang}_COMPILER} ${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${build_type_upper}}")
     install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${lang}_compile_line.txt
-        DESTINATION lib/cmake/${PROJECT_NAME})
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   endforeach()
   foreach(tgt IN LISTS ${PROJECT_NAME}_EXPORTED_TARGETS)
     get_target_property(tgt_type "${tgt}" TYPE)
@@ -563,7 +563,7 @@ function(bob_install_provenance_no_recurse no_recurse_components_list)
            "${link_libs}")
       install(FILES
           ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}_${tgt}_libs.txt
-          DESTINATION lib/cmake/${PROJECT_NAME})
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
     endif()
   endforeach()
 
@@ -572,7 +572,7 @@ endfunction(bob_install_provenance_no_recurse)
 function(bob_end_package)
   include(CMakePackageConfigHelpers)
   set(INCLUDE_INSTALL_DIR include)
-  set(LIB_INSTALL_DIR lib)
+  set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
   set(LATEST_FIND_DEPENDENCY
 "#The definition of this macro is really inconvenient prior to CMake
 #commit ab358d6a859d8b7e257ed1e06ca000e097a32ef6
@@ -654,7 +654,7 @@ set(${KEY_${TYPE}} \"${val}\")")
 ")
   install(FILES
     "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-    DESTINATION lib/cmake/${PROJECT_NAME})
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   if(PROJECT_VERSION)
     file(WRITE
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
@@ -665,7 +665,7 @@ set(${KEY_${TYPE}} \"${val}\")")
         COMPATIBILITY SameMajorVersion)
     install(FILES
       "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-      DESTINATION lib/cmake/${PROJECT_NAME})
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   endif()
   bob_install_provenance()
 endfunction(bob_end_package)
@@ -673,7 +673,7 @@ endfunction(bob_end_package)
 function(bob_end_package_no_recurse no_recurse_components_list)
   include(CMakePackageConfigHelpers)
   set(INCLUDE_INSTALL_DIR include)
-  set(LIB_INSTALL_DIR lib)
+  set(LIB_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
   set(LATEST_FIND_DEPENDENCY
 "#The definition of this macro is really inconvenient prior to CMake
 #commit ab358d6a859d8b7e257ed1e06ca000e097a32ef6
@@ -749,7 +749,7 @@ set(${KEY_${TYPE}} \"${val}\")")
 ")
   install(FILES
     "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-    DESTINATION lib/cmake/${PROJECT_NAME})
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   if(PROJECT_VERSION)
     file(WRITE
         ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
@@ -760,7 +760,7 @@ set(${KEY_${TYPE}} \"${val}\")")
         COMPATIBILITY SameMajorVersion)
     install(FILES
       "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-      DESTINATION lib/cmake/${PROJECT_NAME})
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
   endif()
   bob_install_provenance_no_recurse("${no_recurse_components_list}")
 endfunction(bob_end_package_no_recurse)

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -5,17 +5,23 @@ import distutils
 import subprocess 
 import shutil
 
+#try:
+#    import cmake
+#except:
+#    print("import cmake failed")
+#    import cmake
+
 import pkg_resources
 # rather than deal with --no-build-isolation flags and other various flags to get a decent CMake build,
 # we do not use build and install requirements in pyproject.toml
 
 min_wheel_version = ['0','33','1']
 min_numpy_version = ['1','16','0']
-min_cmake_version = ['3','0','0']
+#min_cmake_version = ['3','0','0']
 
 min_wheel_version_str = '.'.join(min_wheel_version)
 min_numpy_version_str = '.'.join(min_numpy_version)
-min_cmake_version_str = '.'.join(min_cmake_version)
+#min_cmake_version_str = '.'.join(min_cmake_version)
 
 is_error = False
 error_msg = ""
@@ -59,21 +65,21 @@ except AssertionError:
     error_msg = error_msg + """Python 'numpy' package is too old. [%s < %s]!
         Upgrade it by running 'pip install numpy --upgrade'"""%(numpy_version_str,min_numpy_version_str,) + "\n"
 
-try:
-    import cmake
-    cmake_version = pkg_resources.get_distribution("cmake").version.split('.')
-    assert cmake_version >= min_cmake_version
-except ImportError:
-    is_error = True
-    error_msg = error_msg + """You need the Python 'cmake' package >= %s!
-        install it by running 'pip install cmake'"""%(min_cmake_version_str,) + "\n"
-except AssertionError:
-    is_error = True
-    import cmake
-    cmake_version = pkg_resources.get_distribution("cmake").version.split('.')
-    cmake_version_str = '.'.join(cmake_version)
-    error_msg = error_msg + """Python 'cmake' package is too old. [%s < %s]!
-        Upgrade it by running 'pip install cmake --upgrade'"""%(cmake_version_str,min_cmake_version_str,) + "\n"
+#try:
+#    import cmake
+#    cmake_version = pkg_resources.get_distribution("cmake").version.split('.')
+#    assert cmake_version >= min_cmake_version
+#except ImportError:
+#    is_error = True
+#    error_msg = error_msg + """You need the Python 'cmake' package >= %s!
+#        install it by running 'pip install cmake'"""%(min_cmake_version_str,) + "\n"
+#except AssertionError:
+#    is_error = True
+#    import cmake
+#    cmake_version = pkg_resources.get_distribution("cmake").version.split('.')
+#    cmake_version_str = '.'.join(cmake_version)
+#    error_msg = error_msg + """Python 'cmake' package is too old. [%s < %s]!
+#        Upgrade it by running 'pip install cmake --upgrade'"""%(cmake_version_str,min_cmake_version_str,) + "\n"
 
 if is_error:
     sys.exit(error_msg)
@@ -108,77 +114,22 @@ class CMakeExtension(Extension):
 
 class InstallCommand(install):
     user_options = install.user_options + [
-        ('use-gpu', None, None),
-        ('use-openmp', None, None),
-        ('disable-openmp', None, None),
-        ('use-pthread', None, None),
-        ('disable-pthread', None, None),
-        ('kokkos-arch=', None, None),
-        ('trilinos-prefix=', None, None),
-        ('kokkos-prefix=', None, None),
-        ('cuda-prefix=', None, None),
-        ('cuda-cublas-prefix=', None, None),
-        ('blas-prefix=', None, None),
-        ('lapack-prefix=', None, None),
+        ('cmake-file=', None, 'File declaring CMake variables, separated by new lines.'),
     ]
 
     def initialize_options(self):
         install.initialize_options(self)
-        self.use_gpu = None
-        self.use_openmp = None
-        self.disable_openmp = None
-        self.use_pthread = None
-        self.disable_pthread = None
-        self.kokkos_arch = None
-        self.trilinos_prefix = None
-        self.kokkos_prefix = None
-        self.cuda_prefix = None
-        self.cuda_cublas_prefix = None
-        self.blas_prefix = None
-        self.lapack_prefix = None
+        self.cmake_file = None
 
     def finalize_options(self):
-        print("--use-gpu:", self.use_gpu)
-        print("--use-openmp:", self.use_openmp)
-        print("--disable-openmp:", self.disable_openmp)
-        print("--use-pthread:", self.use_pthread)
-        print("--disable-pthread:", self.disable_pthread)
-        print("--kokkos-arch:", self.kokkos_arch)
-        print("--trilinos-prefix:", self.trilinos_prefix)
-        print("--kokkos-prefix:", self.kokkos_prefix)
-        print("--cuda-prefix:", self.cuda_prefix)
-        print("--cuda-cublas-prefix:", self.cuda_cublas_prefix)
-        print("--blas-prefix:", self.blas_prefix)
-        print("--lapack-prefix:", self.lapack_prefix)
+        print("--cmake-file:", self.cmake_file)
         install.finalize_options(self)
 
     def run(self):
 
-        global use_gpu
-        global use_openmp
-        global disable_openmp
-        global use_pthread
-        global disable_pthread
-        global kokkos_arch
-        global trilinos_prefix
-        global kokkos_prefix
-        global cuda_prefix
-        global cuda_cublas_prefix
-        global blas_prefix
-        global lapack_prefix
+        global cmake_file
 
-        use_gpu = self.use_gpu
-        use_openmp = self.use_openmp
-        disable_openmp = self.disable_openmp
-        use_pthread = self.use_pthread
-        disable_pthread = self.disable_pthread
-        kokkos_arch = self.kokkos_arch
-        trilinos_prefix = self.trilinos_prefix
-        kokkos_prefix = self.kokkos_prefix
-        cuda_prefix = self.cuda_prefix
-        cuda_cublas_prefix = self.cuda_cublas_prefix
-        blas_prefix = self.blas_prefix
-        lapack_prefix = self.lapack_prefix
+        cmake_file = self.cmake_file
 
         install.run(self)
 
@@ -216,136 +167,16 @@ class build_ext(build_ext_orig):
         except:
             pass # already exists
 
-
-        # Parse bool for using GPU
-        use_gpu_string = "OFF"
-        try:
-            if use_gpu != None:
-                use_gpu_string = "ON"
-                print("Compadre_USE_CUDA set to ON")
-            else:
-                print("Compadre_USE_CUDA set to OFF")
-        except:
-            print("Compadre_USE_CUDA set to OFF")
-
-        # Parse bool for using OpenMP
-        use_openmp_string = ""
-        # check if turned on
-        try:
-            if use_openmp != None:
-                use_openmp_string = "ON"
-                print("Compadre_USE_OPENMP set to ON")
-            else:
-                print("Compadre_USE_OPENMP not set by Python")
-        except:
-            print("Compadre_USE_OPENMP not set by Python")
-        # check if turned off
-        try:
-            if disable_openmp != None:
-                use_openmp_string = "OFF"
-                print("Compadre_USE_OPENMP set to OFF")
-            else:
-                print("Compadre_USE_OPENMP not set by Python")
-        except:
-            print("Compadre_USE_OPENMP not set by Python")
-
-        # Parse bool for using Pthread
-        use_pthread_string = ""
-        # check if turned on
-        try:
-            if use_pthread != None:
-                use_pthread_string = "ON"
-                print("Compadre_USE_PTHREAD set to ON")
-            else:
-                print("Compadre_USE_PTHREAD not set by Python")
-        except:
-            print("Compadre_USE_PTHREAD not set by Python")
-        # check if turned off
-        try:
-            if disable_pthread != None:
-                use_pthread_string = "OFF"
-                print("Compadre_USE_PTHREAD set to OFF")
-            else:
-                print("Compadre_USE_PTHREAD not set by Python")
-        except:
-            print("Compadre_USE_PTHREAD not set by Python")
-
         # Parse string for kokkos architecture
-        kokkos_arch_string = ""
+        cmake_file_string = ""
         try:
-            if kokkos_arch != None:
-                kokkos_arch_string = str(kokkos_arch)
-                print("KokkosCore_ARCH set to: %s"%(kokkos_arch_string,))
+            if cmake_file != None:
+                cmake_file_string = str(cmake_file)
+                print("Custom cmake args file set to: %s"%(cmake_file_string,))
             else:
-                print("KokkosCore_ARCH not set.")
+                print("Custom cmake args file not set.")
         except:
-            print("KokkosCore_ARCH not set.")
-
-        # Parse string for trilinos prefix (containing a kokkos install, optional)
-        trilinos_prefix_string = ""
-        try:
-            if trilinos_prefix != None:
-                trilinos_prefix_string = str(trilinos_prefix)
-                print("Trilinos_PREFIX set to: %s"%(trilinos_prefix_string,))
-            else:
-                print("Trilinos_PREFIX not set in Python.")
-        except:
-            print("Trilinos_PREFIX not set in Python.")
-
-        # Parse string for kokkos prefix (user installed previous to python package install, optional)
-        kokkos_prefix_string = ""
-        try:
-            if kokkos_prefix != None:
-                kokkos_prefix_string = str(kokkos_prefix)
-                print("KokkosCore_PREFIX set to: %s"%(kokkos_prefix_string,))
-            else:
-                print("KokkosCore_PREFIX not set in Python.")
-        except:
-            print("KokkosCore_PREFIX not set in Python.")
-
-        # Parse string for CUDA prefix
-        cuda_prefix_string = ""
-        try:
-            if cuda_prefix != None:
-                cuda_prefix_string = str(cuda_prefix)
-                print("CUDA_PREFIX set to: %s"%(cuda_prefix_string,))
-            else:
-                print("CUDA_PREFIX not set in Python.")
-        except:
-            print("CUDA_PREFIX not set in Python.")
-
-        # Parse string for CUDA CUBLAS prefix
-        cuda_cublas_prefix_string = ""
-        try:
-            if cuda_cublas_prefix != None:
-                cuda_cublas_prefix_string = str(cuda_cublas_prefix)
-                print("CUDA_CUBLAS_PREFIX set to: %s"%(cuda_cublas_prefix_string,))
-            else:
-                print("CUDA_CUBLAS_PREFIX not set in Python.")
-        except:
-            print("CUDA_CUBLAS_PREFIX not set in Python.")
-
-        # Parse string for BLAS prefix
-        blas_prefix_string = ""
-        try:
-            if blas_prefix != None:
-                blas_prefix_string = str(blas_prefix)
-                print("BLAS_PREFIX set to: %s"%(blas_prefix_string,))
-            else:
-                print("BLAS_PREFIX not set in Python.")
-        except:
-            print("BLAS_PREFIX not set in Python.")
-
-        # Parse string for LAPACK prefix
-        lapack_prefix_string = ""
-        try:
-            if lapack_prefix != None:
-                lapack_prefix_string = str(lapack_prefix)
-                print("LAPACK_PREFIX set to: %s"%(lapack_prefix_string,))
-            else:
-                print("LAPACK_PREFIX not set in Python.")
-        except:
-            print("LAPACK_PREFIX not set in Python.")
+            print("Custom cmake args file not set.")
 
         # Configure CMake
         config = 'Debug' if self.debug else 'Release'
@@ -362,31 +193,14 @@ class build_ext(build_ext_orig):
             '-DCompadre_EXAMPLES:BOOL=OFF',
             '-DPYTHON_CALLING_BUILD:BOOL=ON',
         ]
-        if (len(kokkos_arch_string)>0):
-            for kokkos_arch in kokkos_arch_string.split(";").lstrip().rstrip():
-                if (len(kokkos_arch)>0):
-                    cmake_args.append('-DKokkos_ARCH_%s:BOOL=ON'%(kokkos_arch,))
 
-        if use_gpu_string != "":
-            cmake_args.append('-DCompadre_USE_CUDA:BOOL=%s'%(use_gpu_string,),)
-        if use_openmp_string != "":
-            cmake_args.append('-DCompadre_USE_OPENMP:BOOL=%s'%(use_openmp_string,),)
-        if use_pthread_string != "":
-            cmake_args.append('-DCompadre_USE_PTHREAD:BOOL=%s'%(use_pthread_string,),)
-        if kokkos_prefix_string != "":
-            cmake_args.append('-DKokkosCore_PREFIX:STRING=%s'%(kokkos_prefix_string,))
-        if cuda_prefix_string != "":
-            cmake_args.append('-DKokkos_CUDA_DIR:STRING=%s'%(cuda_prefix_string,))
-        if cuda_cublas_prefix_string != "":
-            cmake_args.append('-DKokkosKernels_CUBLAS_ROOT:STRING=%s'%(cuda_cublas_prefix_string,))
-        if blas_prefix_string != "":
-            cmake_args.append('-DKokkosKernels_BLAS_ROOT:STRING=%s'%(blas_prefix_string,))
-        if lapack_prefix_string != "":
-            cmake_args.append('-DKokkosKernels_LAPACK_ROOT:STRING=%s'%(lapack_prefix_string,))
-        if trilinos_prefix_string != "":
-            cmake_args.append('-DTrilinos_PREFIX:STRING=%s'%(trilinos_prefix_string,))
-        else:
-            cmake_args.append('-DCMAKE_BUILD_TYPE=' + config)
+        cmake_file_list = list()
+        if (cmake_file_string != ""):
+            cmake_arg_list = [line.rstrip('\n') for line in open(cmake_file_string)]
+            for arg in cmake_arg_list:
+                cmake_args.append('-D'+arg)
+            print('Custom CMake Args: ', cmake_arg_list)
+
         build_args = [
             '--config', config,
             '--', '-j4'
@@ -444,7 +258,7 @@ setup(
           "pathlib2",
           "wheel>=%s"%(min_wheel_version_str,),
           "numpy>=%s"%(min_numpy_version_str,),
-          "cmake>=%s"%(min_cmake_version_str,),
+          #"cmake>=%s"%(min_cmake_version_str,),
     ],
     install_requires=[
           "numpy>=%s"%(min_numpy_version_str,),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,6 +34,14 @@ set(COMPADRE_SOURCES
 add_library(compadre ${COMPADRE_SOURCES})
 bob_library_includes(compadre)
 
+# openmp if needed
+if (Compadre_USE_OPENMP)
+  find_package(OpenMP QUIET)
+  if(OpenMP_CXX_FOUND)
+      target_link_libraries(compadre PUBLIC OpenMP::OpenMP_CXX)
+  endif()
+endif()
+
 # link to Kokkos
 if (KOKKOS_EXISTING_ELSEWHERE) # user points to Kokkos installation
   target_link_libraries(compadre PUBLIC Kokkos::kokkoscore)


### PR DESCRIPTION
Looked for optional OpenMP and link target if found.

Bump CMake version to 3.10.0 requires (Same as Kokkos and Trilinos)

Changed to
>> pip install compadre --install-option="--cmake-file=/some/absolute/path/to/file/with/cmake/variables.txt"

Removed all cmake module importing in setup.py created by toolkit.
Now, if cmake can be called (such as from sudo apt-get install cmake),
that will also work, and it won't necessarily require the cmake python
module which can be problematic to install.