### PR TITLE
Added residual() function that can be called after solve() on ProblemT

### DIFF
--- a/src/Compadre_ProblemT.hpp
+++ b/src/Compadre_ProblemT.hpp
@@ -101,6 +101,7 @@ class ProblemT {
 
 		void initialize(scalar_type initial_simulation_time = 0);
 		void solve();
+		void residual();
 
 	private:
 

--- a/src/Compadre_SolverT.hpp
+++ b/src/Compadre_SolverT.hpp
@@ -60,7 +60,11 @@ class SolverT {
 
 		Teuchos::RCP<mvec_type> getSolution(local_index_type idx = -1) const;
 
+		void setSolution(local_index_type idx, Teuchos::RCP<mvec_type> vec);
+
 		void solve();
+
+		void residual();
 
     protected:
 


### PR DESCRIPTION
to get the residual stored on particles.

This assists with visual debugging.

Exact solution can be put on particles in between solver() and residual() call
which will test the forward action of the operator on the exact solution.

Address issue #178 