### PR TITLE
Fix Snapshot Unit Test

### DIFF
--- a/scripts/snapshot_into_trilinos.py
+++ b/scripts/snapshot_into_trilinos.py
@@ -221,7 +221,7 @@ def test_create_snapshot_dir_args():
     dest = "to_there"
     args = create_snapshot_dir_args(orig, dest)
     expected = (f"--orig-dir {orig}/ --dest-dir {dest}/ --exclude kokkos "
-                "kokkos-kernels python scripts cmake/bob.cmake "
+                "kokkos-kernels python scripts "
                 "cmake/detect_trilinos_opts.cmake "
                 "examples/Python_3D_Convergence.py.in "
                 "--clean-ignored-files-orig-dir")


### PR DESCRIPTION
Before #173 was merged, the files excluded by the snapshotting script were adjusted, but the corresponding unit test wasn't.  This adjusts the unit test such that pytest is passing again.  Running `pytest snapshot_into_trilinos.py` now yields
```
================================================ test session starts ================================================
platform linux -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /workspace/compadre/scripts
plugins: arraydiff-0.3, astropy-header-0.1.1, doctestplus-0.5.0, openfiles-0.4.0, remotedata-0.3.2
collected 4 items                                                                                                   

snapshot_into_trilinos.py ....                                                                                [100%]

================================================= 4 passed in 0.16s =================================================
```