### PR TITLE
Added keep_coefficients argument to generateAlphas()

### DIFF
--- a/examples/GMLS_Device.cpp
+++ b/examples/GMLS_Device.cpp
@@ -365,7 +365,7 @@ bool all_passed = true;
     my_GMLS.setWeightingPower(2);
     
     // generate the alphas that to be combined with data for each target operation requested in lro
-    my_GMLS.generateAlphas(number_of_batches);
+    my_GMLS.generateAlphas(number_of_batches, true /* keep polynomial coefficients, only needed for a test later in this program */);
     
     
     //! [Setting Up The GMLS Object]

--- a/examples/GMLS_SmallBatchReuse_Device.cpp
+++ b/examples/GMLS_SmallBatchReuse_Device.cpp
@@ -374,7 +374,7 @@ bool all_passed = true;
         
         
         // generate the alphas that to be combined with data for each target operation requested in lro
-        my_GMLS.generateAlphas();
+        my_GMLS.generateAlphas(1, true /* keep polynomial coefficients, only needed for a test later in this program */);
         
         
         //! [Setting Up The GMLS Object]

--- a/examples/GMLS_Vector.cpp
+++ b/examples/GMLS_Vector.cpp
@@ -364,7 +364,7 @@ bool all_passed = true;
     my_GMLS.setWeightingPower(2);
     
     // generate the alphas that to be combined with data for each target operation requested in lro
-    my_GMLS.generateAlphas();
+    my_GMLS.generateAlphas(1, true /* keep polynomial coefficients, only needed for a test later in this program */);
     
     
     //! [Setting Up The GMLS Object]

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -8,7 +8,10 @@
 
 namespace Compadre {
 
-void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
+void GMLS::generatePolynomialCoefficients(const int number_of_batches, const bool keep_coefficients) {
+
+    compadre_assert_release( (keep_coefficients==false || number_of_batches==1)
+                && "keep_coefficients is set to true, but number of batches exceeds 1.");
 
     /*
      *    Generate Quadrature
@@ -396,16 +399,21 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
     if (number_of_batches > 1) { // no reason to keep coefficients if they aren't all in memory
         _RHS = Kokkos::View<double*>("RHS",0);
         _P = Kokkos::View<double*>("P",0);
+        _entire_batch_computed_at_once = false;
     } else {
         if (_constraint_type != ConstraintType::NO_CONSTRAINT) {
             _RHS = Kokkos::View<double*>("RHS", 0);
+            if (!keep_coefficients) _P = Kokkos::View<double*>("P", 0);
         } else {
             if (_dense_solver_type != DenseSolverType::LU) {
                 _P = Kokkos::View<double*>("P", 0);
+                if (!keep_coefficients) _RHS = Kokkos::View<double*>("RHS", 0);
             } else {
                 _RHS = Kokkos::View<double*>("RHS", 0);
+                if (!keep_coefficients) _P = Kokkos::View<double*>("P", 0);
             }
         }
+        if (keep_coefficients) _store_PTWP_inv_PTW = true;
     }
 
     /*
@@ -424,9 +432,9 @@ void GMLS::generatePolynomialCoefficients(const int number_of_batches) {
 
 }
 
-void GMLS::generateAlphas(const int number_of_batches) {
+void GMLS::generateAlphas(const int number_of_batches, const bool keep_coefficients) {
 
-    this->generatePolynomialCoefficients(number_of_batches);
+    this->generatePolynomialCoefficients(number_of_batches, keep_coefficients);
 
 }
 

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -213,6 +213,9 @@ protected:
     //! this is false, and so the _RHS matrix can not be stored or requested
     bool _entire_batch_computed_at_once;
 
+    //! whether polynomial coefficients were requested to be stored (in a state not yet applied to data)
+    bool _store_PTWP_inv_PTW;
+
     //! initial index for current batch
     int _initial_index_for_batch;
 
@@ -670,6 +673,7 @@ public:
         _reference_outward_normal_direction_provided = false;
         _use_reference_outward_normal_direction_provided_to_orient_surface = false;
         _entire_batch_computed_at_once = true;
+        _store_PTWP_inv_PTW = false;
 
         _initial_index_for_batch = 0;
 
@@ -916,6 +920,8 @@ public:
         auto M_by_N = this->getPolynomialCoefficientsDomainRangeSize();
         compadre_assert_release(_entire_batch_computed_at_once 
                 && "Entire batch not computed at once, so getFullPolynomialCoefficientsBasis() can not be called.");
+        compadre_assert_release(_store_PTWP_inv_PTW
+                && "generateAlphas() called with keep_coefficients set to false.");
         host_managed_local_index_type sizes("sizes", 2);
         if ((_constraint_type == ConstraintType::NO_CONSTRAINT) && (_dense_solver_type != DenseSolverType::LU)) {
             int rhsdim = getRHSSquareDim(_dense_solver_type, _constraint_type, _reconstruction_space, _dimensions, M_by_N[1], M_by_N[0]);
@@ -1054,6 +1060,8 @@ public:
     decltype(_RHS) getFullPolynomialCoefficientsBasis() const { 
         compadre_assert_release(_entire_batch_computed_at_once 
                 && "Entire batch not computed at once, so getFullPolynomialCoefficientsBasis() can not be called.");
+        compadre_assert_release(_store_PTWP_inv_PTW
+                && "generateAlphas() called with keep_coefficients set to false.");
         if ((_constraint_type == ConstraintType::NO_CONSTRAINT) && (_dense_solver_type != DenseSolverType::LU)) {
             return _RHS; 
         } else {
@@ -1797,15 +1805,17 @@ public:
     //! that can later be contracted against data or degrees of freedom to form a
     //! global linear system.
     //! \param number_of_batches    [in] - how many batches to break up the total workload into (for storage)
+    //! \param keep_coefficients    [in] - whether to store (P^T W P)^-1 * P^T * W
     */
-    void generatePolynomialCoefficients(const int number_of_batches = 1);
+    void generatePolynomialCoefficients(const int number_of_batches = 1, const bool keep_coefficients = false);
 
     /*! \brief Meant to calculate target operations and apply the evaluations to the previously 
     //! constructed polynomial coefficients. But now that is inside of generatePolynomialCoefficients because
     //! it must be to handle number_of_batches>1. Effectively, this just calls generatePolynomialCoefficients.
     //! \param number_of_batches    [in] - how many batches to break up the total workload into (for storage)
+    //! \param keep_coefficients    [in] - whether to store (P^T W P)^-1 * P^T * W
     */
-    void generateAlphas(const int number_of_batches = 1);
+    void generateAlphas(const int number_of_batches = 1, const bool keep_coefficients = false);
 
 ///@}
 


### PR DESCRIPTION
Added keep_coefficients argument to generateAlphas() and generatePolynomialCoefficients() which is set to false by default. If false, then solution to (PTWP^-1 * PTW deallocated after its use in generating the alpha coefficients.

Descriptive error is given when trying to access coefficients that arechosen not to be stored. Check added that if storing coefficients, number of batches must be equal to 1 (otherwise all coefficients weren't stored, anyways).

Tests that access polynomial coefficients have been modified to use the true flag for keep_coefficients when calling generateAlphas().