### PR TITLE
Fixed populating CMAKE_INSTALL_LIBDIR and including header for subdirectories.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,10 @@ else() # Raw CMake Project
 
   get_directory_property(Compadre_HAS_PARENT PARENT_DIRECTORY)
 
+  if (NOT Compadre_HAS_PARENT)
+    include(GNUInstallDirs)
+  endif()
+
   bob_begin_package()
 
   # Set to OFF for significantly faster performance and ON for error tracking

--- a/src/CMakeLists.tribits.cmake
+++ b/src/CMakeLists.tribits.cmake
@@ -37,3 +37,8 @@ tribits_add_library(
   HEADERS ${HEADERS}
   SOURCES ${SOURCES}
   )
+
+# allows us to use flat directory includes when building, since that will be the file structure once installed
+target_include_directories(compadre PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/basis>)
+target_include_directories(compadre PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/constraints>)
+target_include_directories(compadre PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tpl>)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,11 @@ compadre_append_glob(COMPADRE_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 add_library(compadre ${COMPADRE_SOURCES})
 bob_library_includes(compadre)
 
+# allows us to use flat directory includes when building, since that will be the file structure once installed
+target_include_directories(compadre PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/basis>)
+target_include_directories(compadre PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/constraints>)
+target_include_directories(compadre PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/tpl>)
+
 # openmp if needed
 if (Compadre_USE_OPENMP)
   find_package(OpenMP QUIET)

--- a/src/Compadre_GMLS.cpp
+++ b/src/Compadre_GMLS.cpp
@@ -4,7 +4,7 @@
 #include "Compadre_Quadrature.hpp"
 #include "Compadre_GMLS_Targets.hpp"
 #include "Compadre_Functors.hpp"
-#include "constraints/Compadre_CreateConstraints.hpp"
+#include "Compadre_CreateConstraints.hpp"
 
 namespace Compadre {
 

--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -9,8 +9,8 @@
 #include "Compadre_LinearAlgebra_Definitions.hpp"
 #include "Compadre_ParallelManager.hpp"
 #include "Compadre_Quadrature.hpp"
-#include "basis/Compadre_ScalarTaylorPolynomial.hpp"
-#include "basis/Compadre_DivergenceFreePolynomial.hpp"
+#include "Compadre_ScalarTaylorPolynomial.hpp"
+#include "Compadre_DivergenceFreePolynomial.hpp"
 
 namespace Compadre {
 

--- a/src/Compadre_PointCloudSearch.hpp
+++ b/src/Compadre_PointCloudSearch.hpp
@@ -2,7 +2,7 @@
 #define _COMPADRE_POINTCLOUDSEARCH_HPP_
 
 #include "Compadre_Typedefs.hpp"
-#include <tpl/nanoflann.hpp>
+#include "nanoflann.hpp"
 #include <Kokkos_Core.hpp>
 #include <memory>
 


### PR DESCRIPTION
Toolkit now includes GNUInstallDirs to populate CMAKE_INSTALL_LIBDIR.

If being built as child outside of Trilinos (like in the harness), it
will rely on the outer package defining CMAKE_INSTALL_LIBDIR.

Added build interface target_include_directories for compadre target,
which allow for flat header including, e.g.
\#include "some_basis.hpp"
will now work, even if some_basis.hpp is in "basis/some_basis.hpp"

Because all header files are installed into a flat /include structure,
this is important so that users can build against an installed Compadre
toolkit and use it's headers.