### PR TITLE
Enabled particle sets separate from cell midpoints for REBAR

### DIFF
--- a/src/Compadre_PhysicsT.hpp
+++ b/src/Compadre_PhysicsT.hpp
@@ -81,6 +81,10 @@ class PhysicsT {
         // default comes from particles class 
         virtual local_index_type getMaxNumNeighbors();
 
+        particle_type* getParticles() {
+            return _particles.getRawPtr();
+        }
+
 };
 
 }

--- a/test_data/parameter_lists/reactiondiffusion/parameters_template.xml
+++ b/test_data/parameter_lists/reactiondiffusion/parameters_template.xml
@@ -35,6 +35,7 @@
     <Parameter name="input dimensions" type="int" value="2"/>
     <Parameter name="input file prefix" type="string" value="../test_data/grids/"/>
     <Parameter name="input file" type="string" value="dg_0.nc"/>
+    <Parameter name="particles input file" type="string" value="dg_0.nc"/>
     <Parameter name="output file prefix" type="string" value="../test_data/"/>
     <Parameter name="output file" type="string" value="dg_out.nc"/>
     <Parameter name="preserve gids" type="bool" value="false"/>

--- a/test_data/utilities/variational_convergence.py
+++ b/test_data/utilities/variational_convergence.py
@@ -45,9 +45,31 @@ if args.pressure_order<0:
 
 
 if (args.dim==2):
-    file_names = ["dg_%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["dg_%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["shear_annulus_tf0_n%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["shear_annulus_tf1_n%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["shear_annulus_tf1.795_n%d.nc"%num for num in range(args.num_meshes)]
+    #particle_file_names = ["shear_annulus_tf1.795_n%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["shear_annulus_tf0_n%d.nc"%num for num in range(args.num_meshes)]
+    #particle_file_names = ["shear_annulus_tf0_n%d.nc"%num for num in range(args.num_meshes)]
+    #particle_file_names = ["shear_annulus_tf1.795_n%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["dg_%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["transformed_box_n%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["box_n%d.nc"%num for num in range(args.num_meshes)]
+    #particle_file_names = ["transformed_box_n%d.nc"%num for num in range(args.num_meshes)]
+    #particle_file_names = ["box_n%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["box_n%d.nc"%num for num in range(args.num_meshes)]
+
+    # for stokes
+    file_names = ["timoshenko_regular_mesh_scaled_%d.nc"%num for num in range(args.num_meshes)]
+    particle_file_names = ["timoshenko_regular_mesh_scaled_%d.nc"%num for num in range(args.num_meshes)]
 else:
     file_names = ["cube_%d.nc"%num for num in range(args.num_meshes)]
+
+# if particle set not something different from mesh, then just use mesh for centroids as particle set
+if 'particle_file_names' not in locals():
+    particle_file_names = file_names
+
 error_types=['vel. l2','vel. h1','vel. jp','vel. sum','pr. l2']
 all_errors = [list(), list(), list(), list(), list(), list(), list()]#list() * len(error_types)
 
@@ -71,7 +93,9 @@ for key2, fname in enumerate(file_names):
     
     for item in list(f):
         if (item.attrib['name']=="input file"):
-            item.attrib['value']=fname
+            item.attrib['value']=file_names[key2]
+        if (item.attrib['name']=="particles input file"):
+            item.attrib['value']=particle_file_names[key2]
         if (item.attrib['name']=="input dimensions"):
             item.attrib['value']=str(args.dim)
 

--- a/test_data/utilities/variational_convergence.py
+++ b/test_data/utilities/variational_convergence.py
@@ -45,7 +45,7 @@ if args.pressure_order<0:
 
 
 if (args.dim==2):
-    #file_names = ["dg_%d.nc"%num for num in range(args.num_meshes)]
+    file_names = ["dg_%d.nc"%num for num in range(args.num_meshes)]
     #file_names = ["shear_annulus_tf0_n%d.nc"%num for num in range(args.num_meshes)]
     #file_names = ["shear_annulus_tf1_n%d.nc"%num for num in range(args.num_meshes)]
     #file_names = ["shear_annulus_tf1.795_n%d.nc"%num for num in range(args.num_meshes)]
@@ -61,8 +61,8 @@ if (args.dim==2):
     #file_names = ["box_n%d.nc"%num for num in range(args.num_meshes)]
 
     # for stokes
-    file_names = ["timoshenko_regular_mesh_scaled_%d.nc"%num for num in range(args.num_meshes)]
-    particle_file_names = ["timoshenko_regular_mesh_scaled_%d.nc"%num for num in range(args.num_meshes)]
+    #file_names = ["timoshenko_regular_mesh_scaled_%d.nc"%num for num in range(args.num_meshes)]
+    #particle_file_names = ["timoshenko_regular_mesh_scaled_%d.nc"%num for num in range(args.num_meshes)]
 else:
     file_names = ["cube_%d.nc"%num for num in range(args.num_meshes)]
 


### PR DESCRIPTION
This SHA used to generate results for REBAR SAND report for reaction-diffusion and Stokes flow.
Linear elasticity was done in May of 2020.

Corrected Cell->Particle and Particle->Cell neighborhoods ordering.
Previously, they were backwards but it didn't matter at that point
becauses Cells==Particles previously.