### PR TITLE
Moved InteractingFields out of CompadreHarness_Typedefs.h, fixed field registration

### DIFF
--- a/physics/Compadre_GMLS_Stokes_Operator.cpp
+++ b/physics/Compadre_GMLS_Stokes_Operator.cpp
@@ -268,10 +268,7 @@ Teuchos::RCP<crs_graph_type> GMLS_StokesPhysics::computeGraph(local_index_type f
         auto existing_row_map = _row_map;
         auto existing_col_map = _col_map;
 
-        size_t max_entries_per_row;
-        Teuchos::ArrayRCP<const size_t> empty_array;
-        bool bound_same_for_all_local_rows = true;
-        this->_A_graph->getNumEntriesPerLocalRowUpperBound(empty_array, max_entries_per_row, bound_same_for_all_local_rows);
+        size_t max_entries_per_row = this->_A_graph->getNodeMaxNumRowEntries();
 
         auto row_map_index_base = existing_row_map->getIndexBase();
         auto row_map_entries = existing_row_map->getMyGlobalIndices();
@@ -321,10 +318,7 @@ Teuchos::RCP<crs_graph_type> GMLS_StokesPhysics::computeGraph(local_index_type f
         auto existing_row_map = _row_map;
         auto existing_col_map = _col_map;
 
-        size_t max_entries_per_row;
-        Teuchos::ArrayRCP<const size_t> empty_array;
-        bool bound_same_for_all_local_rows = true;
-        this->_A_graph->getNumEntriesPerLocalRowUpperBound(empty_array, max_entries_per_row, bound_same_for_all_local_rows);
+        size_t max_entries_per_row = this->_A_graph->getNodeMaxNumRowEntries();
 
         auto col_map_index_base = existing_col_map->getIndexBase();
         auto col_map_entries = existing_col_map->getMyGlobalIndices();

--- a/physics/Compadre_LagrangianShallowWater_Operator.cpp
+++ b/physics/Compadre_LagrangianShallowWater_Operator.cpp
@@ -36,835 +36,835 @@ void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, lo
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 
-//	/*
-//	 * Example for velocity = cos(t), and height = -sin(t)
-//	 */
-//
-//	host_view_type b_data = _b->getLocalView<host_view_type>();
-//	// get field_one and check which one it is
-//	int my_field = field_one;
-//	host_view_type other_data = _particles->getFieldManager()->getFieldByID(field_two)->getMultiVectorPtr()->getLocalView<host_view_type>();
-//
-//	if (field_two != field_one) {
-//		if (_particles->getFieldManager()->getIDOfFieldFromName("velocity") == my_field) {
-//			// if velocity, set to height
-//			for (int i=0; i<b_data.dimension_0(); ++i) {
-//				b_data(i,0) = other_data(i,0);
-//			}
-//		} else {
-//			// if height, set to -velocity
-//			for (int i=0; i<b_data.dimension_0(); ++i) {
-//				b_data(i,0) = -other_data(i,0);
-//			}
-//		}
-//	}
-
-//	/*
-//	 *  Rigid body rotation test
-//	 */
-//
-//	double Omega = 2*PI;
-//
-//	host_view_type b_data = _b->getLocalView<host_view_type>();
-//	// get field_one and check which one it is
-//	int my_field = field_one;
-//	host_view_type other_data = _particles->getFieldManager()->getFieldByID(field_two)->getMultiVectorPtr()->getLocalView<host_view_type>();
-//
-//	if (field_two == field_one) {
-//		if (_particles->getFieldManager()->getIDOfFieldFromName("displacement") == my_field) {
-//
-//			const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-//					this->_particles->getDOFManagerConst()->getDOFMap();
-//
-//			// if velocity, set to height
-//			for (int i=0; i<other_data.dimension_0(); ++i) {
-//				local_index_type dof_x = local_to_dof_map[i][field_one][0];
-//				b_data(dof_x,0) =  other_data(i,1) * Omega;
-//				local_index_type dof_y = local_to_dof_map[i][field_one][1];
-//				b_data(dof_y,0) = -other_data(i,0) * Omega;
-//				local_index_type dof_z = local_to_dof_map[i][field_one][2];
-//				b_data(dof_z,0) = 0;
-//			}
-//		}
-//	}
-
-	bool EULERIAN = true;
-	if (_particles->getCoordsConst()->isLagrangian()) {
-		EULERIAN = false;
-	}
-
-
-	bool include_halo = true;
-
-	bool use_physical_coords = true; // can be set on the operator in the future
-
-	TEUCHOS_TEST_FOR_EXCEPT_MSG(_b==NULL, "Tpetra multivector for Physics not yet specified.");
-
-	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
-    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
-	const host_view_local_index_type bc_id = this->_particles->getFlags()->getLocalView<host_view_local_index_type>();
-	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
-	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-
-	//****************
-	//
-	//  Copying data from particles (std::vector's, multivectors, etc....) to views used by local reconstruction class
-	//
-	//****************
-
-	// generate the interpolation operator and call the coefficients needed (storing them)
-	const coords_type* target_coords = this->_coords;
-	const coords_type* source_coords = this->_coords;
-
-	size_t max_num_neighbors = neighborhood->computeMaxNumNeighbors(false /* use local processor max*/);
-
-	Kokkos::View<int**> kokkos_neighbor_lists("neighbor lists", target_coords->nLocal(), max_num_neighbors+1);
-	Kokkos::View<int**>::HostMirror kokkos_neighbor_lists_host = Kokkos::create_mirror_view(kokkos_neighbor_lists);
-
-	// fill in the neighbor lists into a kokkos view. First entry is # of neighbors for that target
-	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,target_coords->nLocal()), KOKKOS_LAMBDA(const int i) {
-		const int num_i_neighbors = neighborhood->getNumNeighbors(i);
-		for (int j=1; j<num_i_neighbors+1; ++j) {
-			kokkos_neighbor_lists_host(i,j) = neighborhood->getNeighbor(i,j-1);
-		}
-		kokkos_neighbor_lists_host(i,0) = num_i_neighbors;
-	});
-
-	Kokkos::View<double**> kokkos_augmented_source_coordinates("source_coordinates", source_coords->nLocal(true /* include halo in count */), source_coords->nDim());
-	Kokkos::View<double**>::HostMirror kokkos_augmented_source_coordinates_host = Kokkos::create_mirror_view(kokkos_augmented_source_coordinates);
-
-	// fill in the source coords, adding regular with halo coordinates into a kokkos view
-	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,source_coords->nLocal(true /* include halo in count*/)), KOKKOS_LAMBDA(const int i) {
-		xyz_type coordinate = source_coords->getLocalCoords(i, true /*include halo*/, use_physical_coords);
-		kokkos_augmented_source_coordinates_host(i,0) = coordinate.x;
-		kokkos_augmented_source_coordinates_host(i,1) = coordinate.y;
-		kokkos_augmented_source_coordinates_host(i,2) = coordinate.z;
-	});
-
-	Kokkos::View<double**> kokkos_target_coordinates("target_coordinates", target_coords->nLocal(), target_coords->nDim());
-	Kokkos::View<double**>::HostMirror kokkos_target_coordinates_host = Kokkos::create_mirror_view(kokkos_target_coordinates);
-	// fill in the target, adding regular coordinates only into a kokkos view
-	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,target_coords->nLocal()), KOKKOS_LAMBDA(const int i) {
-		xyz_type coordinate = target_coords->getLocalCoords(i, false /*include halo*/, use_physical_coords);
-		kokkos_target_coordinates_host(i,0) = coordinate.x;
-		kokkos_target_coordinates_host(i,1) = coordinate.y;
-		kokkos_target_coordinates_host(i,2) = coordinate.z;
-	});
-
-	auto epsilons = neighborhood->getHSupportSizes()->getLocalView<const host_view_type>();
-	Kokkos::View<double*> kokkos_epsilons("epsilons", target_coords->nLocal());
-	Kokkos::View<double*>::HostMirror kokkos_epsilons_host = Kokkos::create_mirror_view(kokkos_epsilons);
-	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,target_coords->nLocal()), KOKKOS_LAMBDA(const int i) {
-		kokkos_epsilons_host(i) = epsilons(i,0);
-	});
-
-	//****************
-	//
-	// End of data copying
-	//
-	//****************
-
-	// GMLS operator
-
-        GMLS my_scalar_GMLS(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
-                            target_coords->nDim(),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
-	my_scalar_GMLS.setProblemData(
-			kokkos_neighbor_lists_host,
-			kokkos_augmented_source_coordinates_host,
-			kokkos_target_coordinates,
-			kokkos_epsilons_host);
-	my_scalar_GMLS.setWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("weighting type"));
-	my_scalar_GMLS.setWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("weighting power"));
-	my_scalar_GMLS.setCurvatureWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("curvature weighting type"));
-	my_scalar_GMLS.setCurvatureWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature weighting power"));
-
-        GMLS my_vector_GMLS(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial,
-                            ManifoldVectorPointSample,
-                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
-                            target_coords->nDim(),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
-
-	my_vector_GMLS.setProblemData(
-			kokkos_neighbor_lists_host,
-			kokkos_augmented_source_coordinates_host,
-			kokkos_target_coordinates,
-			kokkos_epsilons_host);
-	my_vector_GMLS.setWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("weighting type"));
-	my_vector_GMLS.setWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("weighting power"));
-	my_vector_GMLS.setCurvatureWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("curvature weighting type"));
-	my_vector_GMLS.setCurvatureWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature weighting power"));
-
-
-	bool use_velocity_interpolation = true;//true;
-	bool use_staggered_gradient_fix = false;
-	int mountain_source_data = 0; // 0-GMLS, 1-GMLS-Staggered
-	bool use_staggered_divergence_fix = false;
-
-
-	if (_particles->getFieldManager()->getIDOfFieldFromName("velocity") == field_one) {
-
-		GMLS my_GMLS_staggered_grad (ReconstructionSpace::ScalarTaylorPolynomial,
-                            StaggeredEdgeAnalyticGradientIntegralSample,
-                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
-                            target_coords->nDim(),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
-                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
-
-		my_GMLS_staggered_grad.setProblemData(
-			kokkos_neighbor_lists_host,
-			kokkos_augmented_source_coordinates_host,
-			kokkos_target_coordinates,
-			kokkos_epsilons_host);
-		my_GMLS_staggered_grad.setWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("weighting type"));
-		my_GMLS_staggered_grad.setWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("weighting power"));
-		my_GMLS_staggered_grad.setCurvatureWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("curvature weighting type"));
-		my_GMLS_staggered_grad.setCurvatureWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature weighting power"));
-
-		// add scalar sample targets
-		my_scalar_GMLS.addTargets(TargetOperation::GradientOfScalarPointEvaluation);
-//		my_scalar_GMLS.addTargets(TargetOperation::LaplacianOfScalarPointEvaluation);
-
-		// add vector sample targets
-		my_vector_GMLS.addTargets(TargetOperation::VectorPointEvaluation);
-		my_vector_GMLS.addTargets(TargetOperation::VectorLaplacianPointEvaluation);
-
-		if (use_staggered_gradient_fix) {
-			my_GMLS_staggered_grad.addTargets(TargetOperation::GradientOfScalarPointEvaluation);
-			my_GMLS_staggered_grad.generateAlphas();
-		}
-		my_scalar_GMLS.generateAlphas();
-		my_vector_GMLS.generateAlphas();
-
-        auto tangent_directions = my_scalar_GMLS.getTangentDirections();
-
-
-		host_view_type b_data = _b->getLocalView<host_view_type>();
-		host_view_type h_data = _particles->getFieldManager()->getFieldByName("height")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
-		host_view_type h_halo_data = _particles->getFieldManager()->getFieldByName("height")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
-		host_view_type v_data = _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
-		host_view_type v_halo_data = _particles->getFieldManager()->getFieldByName("velocity")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
-
-		Teuchos::RCP<Compadre::ShallowWaterTestCases> swtc = Teuchos::rcp(new Compadre::ShallowWaterTestCases(_parameters->get<int>("shallow water test case"), 0 /*alpha*/));
-		swtc->setMountain();
-
-		Teuchos::RCP<Compadre::CoriolisForce> cf = Teuchos::rcp(new Compadre::CoriolisForce(swtc->getOmega()));
-
-        auto global_min_h = _particles->getNeighborhood()->computeMinHSupportSize(true /*global min*/);
-		const double artificial_viscosity_coeff = _parameters->get<Teuchos::ParameterList>("physics").get<double>("artificial viscosity") * global_min_h * global_min_h;
-
-		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,nlocal), KOKKOS_LAMBDA(const int i) {
-			const local_index_type num_neighbors = neighborhood->getNumNeighbors(i);
-
-			xyz_type xyz = _particles->getCoordsConst()->getLocalCoords(i, include_halo, use_physical_coords);
-			xyz_type normal_direction = xyz / xyz.magnitude();
-//			xyz_type normal_direction = xyz / swtc->getRadius();
-
-			double coriolis_force = cf->evalScalar(xyz);
-
-//						std::vector<std::vector<double> > P(3, std::vector<double>(3,0));
-//						{
-//							xyz_type xyz = _particles->getCoordsConst()->getLocalCoords(i, include_halo, use_physical_coords);
-//							double r = 1;
-//							double scaling = 1. / (r*r);
-//
-//							P[0][0] = r*r - xyz.x*xyz.x;
-//							P[1][1] = r*r - xyz.y*xyz.y;
-//							P[2][2] = r*r - xyz.z*xyz.z;
-//
-//							P[0][1] = -xyz.x*xyz.y;
-//							P[0][2] = -xyz.x*xyz.z;
-//							P[1][0] = -xyz.x*xyz.y;
-//							P[2][0] = -xyz.x*xyz.z;
-//
-//							P[1][2] = -xyz.y*xyz.z;
-//							P[2][1] = -xyz.y*xyz.z;
-//
-//							for (int j=0; j<3; ++j) {
-//								for (int k=0; k<3; ++k) {
-//									P[j][k] = P[j][k]*scaling;
-//								}
-//							}
-//						}
-
-
-            // local view of tangent directions
-            scratch_matrix_right_type td
-                    (tangent_directions.data() + i*3*3, 3, 3);
-
-
-			if (bc_id(i, 0) == 0) {
-
-				double reconstructed_h_grad_0_local = 0;
-				double reconstructed_h_grad_1_local = 0;
-				double reconstructed_h_grad_0_ambient = 0;
-				double reconstructed_h_grad_1_ambient = 0;
-				double reconstructed_h_grad_2_ambient = 0;
-				double reconstructed_v0_local = 0;
-				double reconstructed_v1_local = 0;
-				double reconstructed_v0_ambient = 0;
-				double reconstructed_v1_ambient = 0;
-				double reconstructed_v2_ambient = 0;
-
-				const local_index_type my_index = neighborhood->getNeighbor(i,0);
-				double h_data_mine_0 = (my_index < nlocal) ? h_data(my_index, 0) : h_halo_data(my_index-nlocal, 0);
-				double h_value_mine = swtc->evalScalar(xyz);
-				double v_data_mine_0 = (my_index < nlocal) ? v_data(my_index, 0) : v_halo_data(my_index-nlocal, 0);
-				double v_data_mine_1 = (my_index < nlocal) ? v_data(my_index, 1) : v_halo_data(my_index-nlocal, 1);
-				double v_data_mine_2 = (my_index < nlocal) ? v_data(my_index, 2) : v_halo_data(my_index-nlocal, 2);
-
-				for (local_index_type l = 0; l < num_neighbors; l++) {
-					const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
-
-					double h_data_0 = (neighbor_index < nlocal) ? h_data(neighbor_index, 0) : h_halo_data(neighbor_index-nlocal, 0);
-					double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
-					double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
-					double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
-
-					if (use_staggered_gradient_fix) {
-						reconstructed_h_grad_0_local += h_data_0 * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-						reconstructed_h_grad_1_local += h_data_0 * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-
-						reconstructed_h_grad_0_local -= h_data_mine_0 * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-						reconstructed_h_grad_1_local -= h_data_mine_0 * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-					} else {
-						reconstructed_h_grad_0_local += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-						reconstructed_h_grad_1_local += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-					}
-
-					if (use_velocity_interpolation) {
-						double contracted_data[2] = {0,0};
-						for (local_index_type dim=0; dim<2; ++dim) {
-							contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
-							contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
-							contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
-						}
-						for (local_index_type dim=0; dim<2; ++dim) {
-							reconstructed_v0_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 0, l, dim);
-							reconstructed_v1_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 1, l, dim);
-						}
-					}
-
-
-					if (_parameters->get<int>("shallow water test case") != 2) {
-						xyz_type neighbor_xyz = _particles->getCoordsConst()->getLocalCoords(neighbor_index, include_halo, use_physical_coords);
-						double h_value = swtc->evalScalar(neighbor_xyz);
-						if (mountain_source_data==1 && use_staggered_gradient_fix) {
-							reconstructed_h_grad_0_local += h_value * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-							reconstructed_h_grad_1_local += h_value * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-
-							reconstructed_h_grad_0_local -= h_value_mine * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-							reconstructed_h_grad_1_local -= h_value_mine * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-						} else if (mountain_source_data==0) {
-							reconstructed_h_grad_0_local += h_value * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-							reconstructed_h_grad_1_local += h_value * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-						}
-					}
-				}
-                
-
-                // convert to ambient from local
-                reconstructed_h_grad_0_ambient = td(0,0)*reconstructed_h_grad_0_local + td(1,0)*reconstructed_h_grad_1_local;
-                reconstructed_h_grad_1_ambient = td(0,1)*reconstructed_h_grad_0_local + td(1,1)*reconstructed_h_grad_1_local;
-                reconstructed_h_grad_2_ambient = td(0,2)*reconstructed_h_grad_0_local + td(1,2)*reconstructed_h_grad_1_local;
-
-				if (use_velocity_interpolation) {
-                    reconstructed_v0_ambient = td(0,0)*reconstructed_v0_local + td(1,0)*reconstructed_v1_local;
-                    reconstructed_v1_ambient = td(0,1)*reconstructed_v0_local + td(1,1)*reconstructed_v1_local;
-                    reconstructed_v2_ambient = td(0,2)*reconstructed_v0_local + td(1,2)*reconstructed_v1_local;
-                } else {
-					reconstructed_v0_ambient = v_data_mine_0;
-					reconstructed_v1_ambient = v_data_mine_1;
-					reconstructed_v2_ambient = v_data_mine_2;
-                }
-
-
-				double coriolis_1=0;
-				double coriolis_2=0;
-				double coriolis_3=0;
-
-				// Eulerian
-				double reconstructed_v0_grad0 = 0;
-				double reconstructed_v0_grad1 = 0;
-				double reconstructed_v0_grad2 = 0;
-				double reconstructed_v1_grad0 = 0;
-				double reconstructed_v1_grad1 = 0;
-				double reconstructed_v1_grad2 = 0;
-				double reconstructed_v2_grad0 = 0;
-				double reconstructed_v2_grad1 = 0;
-				double reconstructed_v2_grad2 = 0;
-
-				if (EULERIAN) {
-					for (local_index_type l = 0; l < num_neighbors; l++) {
-						const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
-
-						double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
-						double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
-						double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
-
-						{
-							reconstructed_v0_grad0 += v_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-							reconstructed_v0_grad1 += v_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-							reconstructed_v0_grad2 += v_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 2, l);
-						}
-						{
-							reconstructed_v1_grad0 += v_data_1 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-							reconstructed_v1_grad1 += v_data_1 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-							reconstructed_v1_grad2 += v_data_1 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 2, l);
-						}
-						{
-							reconstructed_v2_grad0 += v_data_2 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-							reconstructed_v2_grad1 += v_data_2 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-							reconstructed_v2_grad2 += v_data_2 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 2, l);
-						}
-					}
-				}
-
-				// remove normal contribution of forces
-				double force[3] = {-coriolis_force * (normal_direction.y*reconstructed_v2_ambient - reconstructed_v1_ambient*normal_direction.z) - _gravity*reconstructed_h_grad_0_ambient,
-						coriolis_force * (normal_direction.x*reconstructed_v2_ambient - reconstructed_v0_ambient*normal_direction.z) - _gravity*reconstructed_h_grad_1_ambient,
-						-coriolis_force * (normal_direction.x*reconstructed_v1_ambient - reconstructed_v0_ambient*normal_direction.y) - _gravity*reconstructed_h_grad_2_ambient};
-
-//				double dot_product = force[0]*normal_direction.x + force[1]*normal_direction.y + force[2]*normal_direction.z;
-//				force[0] -= dot_product * normal_direction.x;
-//				force[1] -= dot_product * normal_direction.y;
-//				force[2] -= dot_product * normal_direction.z;
-
-
-				// remove normal contribution of forces
-				double advective_force[3] = {-(reconstructed_v0_ambient*reconstructed_v0_grad0 + reconstructed_v1_ambient*reconstructed_v0_grad1 + reconstructed_v2_ambient*reconstructed_v0_grad2),
-						-(reconstructed_v0_ambient*reconstructed_v1_grad0 + reconstructed_v1_ambient*reconstructed_v1_grad1 + reconstructed_v2_ambient*reconstructed_v1_grad2),
-						-(reconstructed_v0_ambient*reconstructed_v2_grad0 + reconstructed_v1_ambient*reconstructed_v2_grad1 + reconstructed_v2_ambient*reconstructed_v2_grad2)};
-
-//				double advective_dot_product = advective_force[0]*normal_direction.x + advective_force[1]*normal_direction.y + advective_force[2]*normal_direction.z;
-//				advective_force[0] -= advective_dot_product * normal_direction.x;
-//				advective_force[1] -= advective_dot_product * normal_direction.y;
-//				advective_force[2] -= advective_dot_product * normal_direction.z;
-
-
-				double artificial_diffusion_force[3] = {0, 0, 0};
-
-				if (artificial_viscosity_coeff > 0) {
-
-					double reconstructed_laplace_u_0_local = 0;
-					double reconstructed_laplace_u_1_local = 0;
-
-					for (local_index_type l = 0; l < num_neighbors; l++) {
-						const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
-
-						double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
-						double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
-						double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
-
-						double contracted_data[2] = {0,0};
-						for (local_index_type dim=0; dim<2; ++dim) {
-							contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
-							contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
-							contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
-						}
-						for (local_index_type dim=0; dim<2; ++dim) {
-							reconstructed_laplace_u_0_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorLaplacianPointEvaluation, i, 0, l, dim);
-							reconstructed_laplace_u_1_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorLaplacianPointEvaluation, i, 1, l, dim);
-						}
-					}
-                    double reconstructed_laplace_u_0_ambient = td(0,0)*reconstructed_v0_local + td(1,0)*reconstructed_v1_local;
-                    double reconstructed_laplace_u_1_ambient = td(0,1)*reconstructed_v0_local + td(1,1)*reconstructed_v1_local;
-                    double reconstructed_laplace_u_2_ambient = td(0,2)*reconstructed_v0_local + td(1,2)*reconstructed_v1_local;
-
-					artificial_diffusion_force[0] = artificial_viscosity_coeff * reconstructed_laplace_u_0_ambient;
-					artificial_diffusion_force[1] = artificial_viscosity_coeff * reconstructed_laplace_u_1_ambient;
-					artificial_diffusion_force[2] = artificial_viscosity_coeff * reconstructed_laplace_u_2_ambient;
-
-//					double artificial_diffusion_dot_product = artificial_diffusion_force[0]*normal_direction.x + artificial_diffusion_force[1]*normal_direction.y + artificial_diffusion_force[2]*normal_direction.z;
-//					artificial_diffusion_force[0] -= artificial_diffusion_dot_product * normal_direction.x;
-//					artificial_diffusion_force[1] -= artificial_diffusion_dot_product * normal_direction.y;
-//					artificial_diffusion_force[2] -= artificial_diffusion_dot_product * normal_direction.z;
-				}
-
-
-				for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-					local_index_type row = local_to_dof_map(i, field_one, k);
-
-					b_data(row,0) = 0;
-
-//					double coriolis_constant = 2*swtc->getOmega()*xyz.z / (swtc->getRadius()*swtc->getRadius());
-//					if (k==0) {
-//						b_data(row, 0) = coriolis_constant*(xyz.z*reconstructed_v1 - xyz.y*reconstructed_v2) - _gravity*reconstructed_h_grad_0;
-//					} else if (k==1) {
-//						b_data(row, 0) = -coriolis_constant*(xyz.z*reconstructed_v0 - xyz.x*reconstructed_v2) - _gravity*reconstructed_h_grad_1;
-//					} else if (k==2) {
-//						b_data(row, 0) = coriolis_constant*(xyz.y*reconstructed_v0 - xyz.x*reconstructed_v1) - _gravity*reconstructed_h_grad_2;
-//					}
-
-					if (k==0) {
-						b_data(row, 0) -= 1./ (swtc->getRadius()*swtc->getRadius()) * xyz.x * (reconstructed_v0_ambient*reconstructed_v0_ambient + reconstructed_v1_ambient*reconstructed_v1_ambient + reconstructed_v2_ambient*reconstructed_v2_ambient);
-					} else if (k==1) {
-						b_data(row, 0) -= 1./ (swtc->getRadius()*swtc->getRadius()) * xyz.y * (reconstructed_v0_ambient*reconstructed_v0_ambient + reconstructed_v1_ambient*reconstructed_v1_ambient + reconstructed_v2_ambient*reconstructed_v2_ambient);
-					} else if (k==2) {
-						b_data(row, 0) -= 1./ (swtc->getRadius()*swtc->getRadius()) * xyz.z * (reconstructed_v0_ambient*reconstructed_v0_ambient + reconstructed_v1_ambient*reconstructed_v1_ambient + reconstructed_v2_ambient*reconstructed_v2_ambient);
-					}
-
-					if (k==0) {
-						b_data(row, 0) += force[0];//-coriolis_force * (normal_direction.y*reconstructed_v2 - reconstructed_v1*normal_direction.z) - _gravity*reconstructed_h_grad_0;
-						coriolis_1 += -coriolis_force * (normal_direction.y*reconstructed_v2_ambient - reconstructed_v1_ambient*normal_direction.z);
-					} else if (k==1) {
-						b_data(row, 0) += force[1];//coriolis_force * (normal_direction.x*reconstructed_v2 - reconstructed_v0*normal_direction.z) - _gravity*reconstructed_h_grad_1;
-						coriolis_2 += coriolis_force * (normal_direction.x*reconstructed_v2_ambient - reconstructed_v0_ambient*normal_direction.z);
-
-					} else if (k==2) {
-						b_data(row, 0) += force[2];//-coriolis_force * (normal_direction.x*reconstructed_v1 - reconstructed_v0*normal_direction.y) - _gravity*reconstructed_h_grad_2;
-						coriolis_3 += -coriolis_force * (normal_direction.x*reconstructed_v1_ambient - reconstructed_v0_ambient*normal_direction.y);
-					}
-
-
-					if (EULERIAN) {
-						if (k==0) {
-							b_data(row, 0) += advective_force[0];
-//							b_data(row, 0) += -(reconstructed_v0*reconstructed_v0_grad0 + reconstructed_v1*reconstructed_v1_grad0 + reconstructed_v2*reconstructed_v2_grad0);
-						} else if (k==1) {
-							b_data(row, 0) += advective_force[1];
-//							b_data(row, 0) += -(reconstructed_v0*reconstructed_v0_grad1 + reconstructed_v1*reconstructed_v1_grad1 + reconstructed_v2*reconstructed_v2_grad1);
-						} else if (k==2) {
-							b_data(row, 0) += advective_force[2];
-//							b_data(row, 0) += -(reconstructed_v0*reconstructed_v0_grad2 + reconstructed_v1*reconstructed_v1_grad2 + reconstructed_v2*reconstructed_v2_grad2);
-						}
-					}
-
-					if (artificial_viscosity_coeff > 0) {
-						// artificial viscosity
-						if (k==0) {
-							b_data(row,0) -= artificial_diffusion_force[0];
-						} else if (k==1) {
-							b_data(row,0) -= artificial_diffusion_force[1];
-						} else if (k==2) {
-							b_data(row,0) -= artificial_diffusion_force[2];
-						}
-					}
-				}
+	/*
+	 * Example for velocity = cos(t), and height = -sin(t)
+	 */
+
+	host_view_type b_data = _b->getLocalView<host_view_type>();
+	// get field_one and check which one it is
+	int my_field = field_one;
+	host_view_type other_data = _particles->getFieldManager()->getFieldByID(field_two)->getMultiVectorPtr()->getLocalView<host_view_type>();
+
+	if (field_two != field_one) {
+		if (_particles->getFieldManager()->getIDOfFieldFromName("velocity") == my_field) {
+			// if velocity, set to height
+			for (int i=0; i<b_data.extent(0); ++i) {
+				b_data(i,0) = other_data(i,0);
 			}
-		});
-
-	} else if (_particles->getFieldManager()->getIDOfFieldFromName("height") == field_one) {
-
-		GMLS my_GMLS_staggered_div (ReconstructionSpace::VectorTaylorPolynomial,
-				StaggeredEdgeIntegralSample,
-                                _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
-                                target_coords->nDim(),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
-                                _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
-		my_GMLS_staggered_div.setProblemData(
-			kokkos_neighbor_lists_host,
-			kokkos_augmented_source_coordinates_host,
-			kokkos_target_coordinates,
-			kokkos_epsilons_host);
-		my_GMLS_staggered_div.setWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("weighting type"));
-		my_GMLS_staggered_div.setWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("weighting power"));
-		my_GMLS_staggered_div.setCurvatureWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("curvature weighting type"));
-		my_GMLS_staggered_div.setCurvatureWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature weighting power"));
-		my_GMLS_staggered_div.setOrderOfQuadraturePoints(_parameters->get<Teuchos::ParameterList>("remap").get<int>("quadrature order"));
-		my_GMLS_staggered_div.setDimensionOfQuadraturePoints(_parameters->get<Teuchos::ParameterList>("remap").get<int>("quadrature dimension"));
-		my_GMLS_staggered_div.setQuadratureType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("quadrature type"));
-
-		my_scalar_GMLS.addTargets(TargetOperation::ScalarPointEvaluation);
-		// for Eulerian
-		my_scalar_GMLS.addTargets(TargetOperation::GradientOfScalarPointEvaluation);
-		if (use_staggered_divergence_fix) {
-			my_GMLS_staggered_div.addTargets(TargetOperation::DivergenceOfVectorPointEvaluation);
-			my_GMLS_staggered_div.generateAlphas();
 		} else {
-			my_vector_GMLS.addTargets(TargetOperation::DivergenceOfVectorPointEvaluation);
-			my_vector_GMLS.generateAlphas();
-		}
-		my_scalar_GMLS.generateAlphas();
-
-        auto tangent_directions = my_scalar_GMLS.getTangentDirections();
-
-
-		host_view_type b_data = _b->getLocalView<host_view_type>();
-		host_view_type h_data = _particles->getFieldManager()->getFieldByName("height")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
-		host_view_type h_halo_data = _particles->getFieldManager()->getFieldByName("height")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
-		host_view_type v_data = _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
-		host_view_type v_halo_data = _particles->getFieldManager()->getFieldByName("velocity")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
-
-
-		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,nlocal), KOKKOS_LAMBDA(const int i) {
-
-			const local_index_type num_neighbors = neighborhood->getNumNeighbors(i);
-
-//			std::vector<std::vector<double> > P(3, std::vector<double>(3,0));
-//			{
-//				xyz_type xyz = _particles->getCoordsConst()->getLocalCoords(i, include_halo, use_physical_coords);
-//				double r = 1;
-//				double scaling = 1. / (r*r);
-//
-//				P[0][0] = r*r - xyz.x*xyz.x;
-//				P[1][1] = r*r - xyz.y*xyz.y;
-//				P[2][2] = r*r - xyz.z*xyz.z;
-//
-//				P[0][1] = -xyz.x*xyz.y;
-//				P[0][2] = -xyz.x*xyz.z;
-//				P[1][0] = -xyz.x*xyz.y;
-//				P[2][0] = -xyz.x*xyz.z;
-//
-//				P[1][2] = -xyz.y*xyz.z;
-//				P[2][1] = -xyz.y*xyz.z;
-//
-//				for (int j=0; j<3; ++j) {
-//					for (int k=0; k<3; ++k) {
-//						P[j][k] = P[j][k]*scaling;
-//					}
-//				}
-//			}
-
-//			if (bc_id(i, 0) == 0) {
-
-                // local view of tangent directions
-                scratch_matrix_right_type td
-                        (tangent_directions.data() + i*3*3, 3, 3);
-
-				local_index_type row = local_to_dof_map(i, field_one, 0);
-
-				double reconstructed_h = 0;
-				double reconstructed_div_v = 0;
-
-                // Reconstruction needed for Eulerian case only
-				double reconstructed_v0_local = 0;
-				double reconstructed_v1_local = 0;
-				double reconstructed_v0_ambient = 0;
-				double reconstructed_v1_ambient = 0;
-				double reconstructed_v2_ambient = 0;
-				double reconstructed_h_grad0_local = 0;
-				double reconstructed_h_grad1_local = 0;
-				double reconstructed_h_grad0_ambient = 0;
-				double reconstructed_h_grad1_ambient = 0;
-				double reconstructed_h_grad2_ambient = 0;
-
-				const local_index_type my_index = neighborhood->getNeighbor(i,0);
-				double v_data_mine_0 = (my_index < nlocal) ? v_data(my_index, 0) : v_halo_data(my_index-nlocal, 0);
-				double v_data_mine_1 = (my_index < nlocal) ? v_data(my_index, 1) : v_halo_data(my_index-nlocal, 1);
-				double v_data_mine_2 = (my_index < nlocal) ? v_data(my_index, 2) : v_halo_data(my_index-nlocal, 2);
-
-				if (EULERIAN) {
-				    if (use_velocity_interpolation) {
-				    	for (local_index_type l = 0; l < num_neighbors; l++) {
-				    		const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
-				    		double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
-				    		double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
-				    		double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
-
-				    		double contracted_data[2] = {0,0};
-				    		for (local_index_type dim=0; dim<2; ++dim) {
-				    			contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
-				    			contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
-				    			contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
-				    		}
-				    		for (local_index_type dim=0; dim<2; ++dim) {
-				    			reconstructed_v0_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 0, l, dim);
-				    			reconstructed_v1_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 1, l, dim);
-				    		}
-				    	}
-
-                        // local view of tangent directions
-                        scratch_matrix_right_type td
-                                (tangent_directions.data() + i*3*3, 3, 3);
-
-                        // convert to ambient from local
-                        reconstructed_v0_ambient = td(0,0)*reconstructed_v0_local + td(1,0)*reconstructed_v1_local;
-                        reconstructed_v1_ambient = td(0,1)*reconstructed_v0_local + td(1,1)*reconstructed_v1_local;
-                        reconstructed_v2_ambient = td(0,2)*reconstructed_v0_local + td(1,2)*reconstructed_v1_local;
-
-				    } else {
-				    	reconstructed_v0_ambient = v_data_mine_0;
-				    	reconstructed_v1_ambient = v_data_mine_1;
-				    	reconstructed_v2_ambient = v_data_mine_2;
-				    }
-                }
-
-
-				for (local_index_type l = 0; l < num_neighbors; l++) {
-					const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
-
-					double h_data_0 = (neighbor_index < nlocal) ? h_data(neighbor_index, 0) : h_halo_data(neighbor_index-nlocal, 0);
-
-					double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
-					double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
-					double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
-
-					reconstructed_h += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo0Tensor(TargetOperation::ScalarPointEvaluation, i, l);
-
-
-					if (use_staggered_divergence_fix) {
-
-						double contracted_data = 0;
-						contracted_data += v_data_0 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, false /* for neighbor*/, 0, 0);
-						contracted_data += v_data_1 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, false /* for neighbor*/, 0, 1);
-						contracted_data += v_data_2 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, false /* for neighbor*/, 0, 2);
-						contracted_data += v_data_mine_0 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, true /* for neighbor*/, 0, 0);
-						contracted_data += v_data_mine_1 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, true /* for neighbor*/, 0, 1);
-						contracted_data += v_data_mine_2 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, true /* for neighbor*/, 0, 2);
-						reconstructed_div_v += contracted_data * my_GMLS_staggered_div.getAlpha0TensorTo0Tensor(TargetOperation::DivergenceOfVectorPointEvaluation, i, l);
-
-					} else {
-						double contracted_data[2] = {0,0};
-						for (local_index_type dim=0; dim<2; ++dim) {
-							contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
-							contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
-							contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
-						}
-						for (local_index_type dim=0; dim<2; ++dim) {
-							reconstructed_div_v += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::DivergenceOfVectorPointEvaluation, i, 0, l, dim);
-						}
-					}
-
-					if (EULERIAN) {
-						reconstructed_h_grad0_local += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
-						reconstructed_h_grad1_local += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
-					}
-				}
-
-                // convert to ambient from local
-                reconstructed_h_grad0_ambient = td(0,0)*reconstructed_h_grad0_local + td(1,0)*reconstructed_h_grad1_local;
-                reconstructed_h_grad1_ambient = td(0,1)*reconstructed_h_grad0_local + td(1,1)*reconstructed_h_grad1_local;
-                reconstructed_h_grad2_ambient = td(0,2)*reconstructed_h_grad0_local + td(1,2)*reconstructed_h_grad1_local;
-
-
-//				printf("%f %f\n", reconstructed_div_v, reconstructed_h);
-				b_data(row, 0) = - reconstructed_h * reconstructed_div_v;
-
-				// Eulerian
-				if (EULERIAN) {
-//					double transformed_h_grad0 = P[0][0]*reconstructed_h_grad0 + P[0][1]*reconstructed_h_grad1 + P[0][2]*reconstructed_h_grad2;
-//					double transformed_h_grad1 = P[1][0]*reconstructed_h_grad0 + P[1][1]*reconstructed_h_grad1 + P[1][2]*reconstructed_h_grad2;
-//					double transformed_h_grad2 = P[2][0]*reconstructed_h_grad0 + P[2][1]*reconstructed_h_grad1 + P[2][2]*reconstructed_h_grad2;
-//					b_data(row, 0) -= (reconstructed_v0*transformed_h_grad0 + reconstructed_v1*transformed_h_grad1 + reconstructed_v2*transformed_h_grad2);
-					b_data(row, 0) -= (reconstructed_v0_ambient*reconstructed_h_grad0_ambient + reconstructed_v1_ambient*reconstructed_h_grad1_ambient + reconstructed_v2_ambient*reconstructed_h_grad2_ambient);
-				}
-//			}
-
-		});
-
-	} else if (_particles->getFieldManager()->getIDOfFieldFromName("displacement") == field_one) {
-
-		if (use_velocity_interpolation) {
-			my_vector_GMLS.addTargets(TargetOperation::VectorPointEvaluation);
-			my_vector_GMLS.generateAlphas();
-		}
-        auto tangent_directions = my_vector_GMLS.getTangentDirections();
-
-		host_view_type b_data = _b->getLocalView<host_view_type>();
-		host_view_type v_data = _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
-		host_view_type v_halo_data = _particles->getFieldManager()->getFieldByName("velocity")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
-
-		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,nlocal), KOKKOS_LAMBDA(const int i) {
-
-			//xyz_type xyz = _particles->getCoordsConst()->getLocalCoords(i, include_halo, use_physical_coords);
-			//xyz_type normal_direction = xyz / xyz.magnitude();
-
-			const local_index_type num_neighbors = neighborhood->getNumNeighbors(i);
-
-			if (bc_id(i, 0) == 0) {
-
-				double reconstructed_v0_local = 0;
-				double reconstructed_v1_local = 0;
-				double reconstructed_v0_ambient = 0;
-				double reconstructed_v1_ambient = 0;
-				double reconstructed_v2_ambient = 0;
-
-				if (use_velocity_interpolation) {
-					for (local_index_type l = 0; l < num_neighbors; l++) {
-						const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
-						double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
-						double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
-						double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
-
-						double contracted_data[2] = {0,0};
-						for (local_index_type dim=0; dim<2; ++dim) {
-							contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
-							contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
-							contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
-						}
-						for (local_index_type dim=0; dim<2; ++dim) {
-							reconstructed_v0_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 0, l, dim);
-							reconstructed_v1_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 1, l, dim);
-						}
-					}
-
-                    // local view of tangent directions
-                    scratch_matrix_right_type td
-                            (tangent_directions.data() + i*3*3, 3, 3);
-
-                    // convert to ambient from local
-                    reconstructed_v0_ambient = td(0,0)*reconstructed_v0_local + td(1,0)*reconstructed_v1_local;
-                    reconstructed_v1_ambient = td(0,1)*reconstructed_v0_local + td(1,1)*reconstructed_v1_local;
-                    reconstructed_v2_ambient = td(0,2)*reconstructed_v0_local + td(1,2)*reconstructed_v1_local;
-
-				} else {
-					const local_index_type my_index = neighborhood->getNeighbor(i,0);
-					double v_data_mine_0 = (my_index < nlocal) ? v_data(my_index, 0) : v_halo_data(my_index, 0);
-					double v_data_mine_1 = (my_index < nlocal) ? v_data(my_index, 1) : v_halo_data(my_index, 1);
-					double v_data_mine_2 = (my_index < nlocal) ? v_data(my_index, 2) : v_halo_data(my_index, 2);
-					reconstructed_v0_ambient = v_data_mine_0;
-					reconstructed_v1_ambient = v_data_mine_1;
-					reconstructed_v2_ambient = v_data_mine_2;
-				}
-//				const local_index_type my_index = neighborhood->getNeighbor(i,0);
-//				reconstructed_v0 = (my_index < nlocal) ? v_data(my_index, 0) : v_halo_data(my_index-nlocal, 0);
-//				reconstructed_v1 = (my_index < nlocal) ? v_data(my_index, 1) : v_halo_data(my_index-nlocal, 1);
-//				reconstructed_v2 = (my_index < nlocal) ? v_data(my_index, 2) : v_halo_data(my_index-nlocal, 2);
-
-//				printf ("%f %f %f\n", reconstructed_v0, reconstructed_v1, reconstructed_v2);
-
-//				for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-//					local_index_type row = local_to_dof_map[i][field_one][k];
-//					if (k==0) {
-//						b_data(row, 0) = reconstructed_v0;
-//					} else if (k==1) {
-//						b_data(row, 0) = reconstructed_v1;
-//					} else if (k==2) {
-//						b_data(row, 0) = reconstructed_v2;
-//					}
-//				}
-
-
-
-				// remove normal contribution of forces
-				double force[3] = {reconstructed_v0_ambient,
-									reconstructed_v1_ambient,
-									reconstructed_v2_ambient};
-
-//				double dot_product = force[0]*normal_direction.x + force[1]*normal_direction.y + force[2]*normal_direction.z;
-//				force[0] -= dot_product * normal_direction.x;
-//				force[1] -= dot_product * normal_direction.y;
-//				force[2] -= dot_product * normal_direction.z;
-
-				for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-					local_index_type row = local_to_dof_map(i, field_one, k);
-					if (k==0) {
-						b_data(row, 0) = force[0];
-					} else if (k==1) {
-						b_data(row, 0) = force[1];
-					} else if (k==2) {
-						b_data(row, 0) = force[2];
-					}
-				}
-
+			// if height, set to -velocity
+			for (int i=0; i<b_data.extent(0); ++i) {
+				b_data(i,0) = -other_data(i,0);
 			}
-
-		});
-
+		}
 	}
-
-	ComputeMatrixTime->stop();
+//
+////	/*
+////	 *  Rigid body rotation test
+////	 */
+////
+////	double Omega = 2*PI;
+////
+////	host_view_type b_data = _b->getLocalView<host_view_type>();
+////	// get field_one and check which one it is
+////	int my_field = field_one;
+////	host_view_type other_data = _particles->getFieldManager()->getFieldByID(field_two)->getMultiVectorPtr()->getLocalView<host_view_type>();
+////
+////	if (field_two == field_one) {
+////		if (_particles->getFieldManager()->getIDOfFieldFromName("displacement") == my_field) {
+////
+////			const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
+////					this->_particles->getDOFManagerConst()->getDOFMap();
+////
+////			// if velocity, set to height
+////			for (int i=0; i<other_data.dimension_0(); ++i) {
+////				local_index_type dof_x = local_to_dof_map[i][field_one][0];
+////				b_data(dof_x,0) =  other_data(i,1) * Omega;
+////				local_index_type dof_y = local_to_dof_map[i][field_one][1];
+////				b_data(dof_y,0) = -other_data(i,0) * Omega;
+////				local_index_type dof_z = local_to_dof_map[i][field_one][2];
+////				b_data(dof_z,0) = 0;
+////			}
+////		}
+////	}
+//
+//	bool EULERIAN = true;
+//	if (_particles->getCoordsConst()->isLagrangian()) {
+//		EULERIAN = false;
+//	}
+//
+//
+//	bool include_halo = true;
+//
+//	bool use_physical_coords = true; // can be set on the operator in the future
+//
+//	TEUCHOS_TEST_FOR_EXCEPT_MSG(_b==NULL, "Tpetra multivector for Physics not yet specified.");
+//
+//	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
+//    const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
+//	const host_view_local_index_type bc_id = this->_particles->getFlags()->getLocalView<host_view_local_index_type>();
+//	const neighborhood_type * neighborhood = this->_particles->getNeighborhoodConst();
+//	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
+//
+//	//****************
+//	//
+//	//  Copying data from particles (std::vector's, multivectors, etc....) to views used by local reconstruction class
+//	//
+//	//****************
+//
+//	// generate the interpolation operator and call the coefficients needed (storing them)
+//	const coords_type* target_coords = this->_coords;
+//	const coords_type* source_coords = this->_coords;
+//
+//	size_t max_num_neighbors = neighborhood->computeMaxNumNeighbors(false /* use local processor max*/);
+//
+//	Kokkos::View<int**> kokkos_neighbor_lists("neighbor lists", target_coords->nLocal(), max_num_neighbors+1);
+//	Kokkos::View<int**>::HostMirror kokkos_neighbor_lists_host = Kokkos::create_mirror_view(kokkos_neighbor_lists);
+//
+//	// fill in the neighbor lists into a kokkos view. First entry is # of neighbors for that target
+//	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,target_coords->nLocal()), KOKKOS_LAMBDA(const int i) {
+//		const int num_i_neighbors = neighborhood->getNumNeighbors(i);
+//		for (int j=1; j<num_i_neighbors+1; ++j) {
+//			kokkos_neighbor_lists_host(i,j) = neighborhood->getNeighbor(i,j-1);
+//		}
+//		kokkos_neighbor_lists_host(i,0) = num_i_neighbors;
+//	});
+//
+//	Kokkos::View<double**> kokkos_augmented_source_coordinates("source_coordinates", source_coords->nLocal(true /* include halo in count */), source_coords->nDim());
+//	Kokkos::View<double**>::HostMirror kokkos_augmented_source_coordinates_host = Kokkos::create_mirror_view(kokkos_augmented_source_coordinates);
+//
+//	// fill in the source coords, adding regular with halo coordinates into a kokkos view
+//	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,source_coords->nLocal(true /* include halo in count*/)), KOKKOS_LAMBDA(const int i) {
+//		xyz_type coordinate = source_coords->getLocalCoords(i, true /*include halo*/, use_physical_coords);
+//		kokkos_augmented_source_coordinates_host(i,0) = coordinate.x;
+//		kokkos_augmented_source_coordinates_host(i,1) = coordinate.y;
+//		kokkos_augmented_source_coordinates_host(i,2) = coordinate.z;
+//	});
+//
+//	Kokkos::View<double**> kokkos_target_coordinates("target_coordinates", target_coords->nLocal(), target_coords->nDim());
+//	Kokkos::View<double**>::HostMirror kokkos_target_coordinates_host = Kokkos::create_mirror_view(kokkos_target_coordinates);
+//	// fill in the target, adding regular coordinates only into a kokkos view
+//	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,target_coords->nLocal()), KOKKOS_LAMBDA(const int i) {
+//		xyz_type coordinate = target_coords->getLocalCoords(i, false /*include halo*/, use_physical_coords);
+//		kokkos_target_coordinates_host(i,0) = coordinate.x;
+//		kokkos_target_coordinates_host(i,1) = coordinate.y;
+//		kokkos_target_coordinates_host(i,2) = coordinate.z;
+//	});
+//
+//	auto epsilons = neighborhood->getHSupportSizes()->getLocalView<const host_view_type>();
+//	Kokkos::View<double*> kokkos_epsilons("epsilons", target_coords->nLocal());
+//	Kokkos::View<double*>::HostMirror kokkos_epsilons_host = Kokkos::create_mirror_view(kokkos_epsilons);
+//	Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,target_coords->nLocal()), KOKKOS_LAMBDA(const int i) {
+//		kokkos_epsilons_host(i) = epsilons(i,0);
+//	});
+//
+//	//****************
+//	//
+//	// End of data copying
+//	//
+//	//****************
+//
+//	// GMLS operator
+//
+//        GMLS my_scalar_GMLS(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
+//                            target_coords->nDim(),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
+//	my_scalar_GMLS.setProblemData(
+//			kokkos_neighbor_lists_host,
+//			kokkos_augmented_source_coordinates_host,
+//			kokkos_target_coordinates,
+//			kokkos_epsilons_host);
+//	my_scalar_GMLS.setWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("weighting type"));
+//	my_scalar_GMLS.setWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("weighting power"));
+//	my_scalar_GMLS.setCurvatureWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("curvature weighting type"));
+//	my_scalar_GMLS.setCurvatureWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature weighting power"));
+//
+//        GMLS my_vector_GMLS(ReconstructionSpace::VectorOfScalarClonesTaylorPolynomial,
+//                            ManifoldVectorPointSample,
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
+//                            target_coords->nDim(),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
+//
+//	my_vector_GMLS.setProblemData(
+//			kokkos_neighbor_lists_host,
+//			kokkos_augmented_source_coordinates_host,
+//			kokkos_target_coordinates,
+//			kokkos_epsilons_host);
+//	my_vector_GMLS.setWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("weighting type"));
+//	my_vector_GMLS.setWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("weighting power"));
+//	my_vector_GMLS.setCurvatureWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("curvature weighting type"));
+//	my_vector_GMLS.setCurvatureWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature weighting power"));
+//
+//
+//	bool use_velocity_interpolation = true;//true;
+//	bool use_staggered_gradient_fix = false;
+//	int mountain_source_data = 0; // 0-GMLS, 1-GMLS-Staggered
+//	bool use_staggered_divergence_fix = false;
+//
+//
+//	if (_particles->getFieldManager()->getIDOfFieldFromName("velocity") == field_one) {
+//
+//		GMLS my_GMLS_staggered_grad (ReconstructionSpace::ScalarTaylorPolynomial,
+//                            StaggeredEdgeAnalyticGradientIntegralSample,
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
+//                            target_coords->nDim(),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
+//                            _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
+//
+//		my_GMLS_staggered_grad.setProblemData(
+//			kokkos_neighbor_lists_host,
+//			kokkos_augmented_source_coordinates_host,
+//			kokkos_target_coordinates,
+//			kokkos_epsilons_host);
+//		my_GMLS_staggered_grad.setWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("weighting type"));
+//		my_GMLS_staggered_grad.setWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("weighting power"));
+//		my_GMLS_staggered_grad.setCurvatureWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("curvature weighting type"));
+//		my_GMLS_staggered_grad.setCurvatureWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature weighting power"));
+//
+//		// add scalar sample targets
+//		my_scalar_GMLS.addTargets(TargetOperation::GradientOfScalarPointEvaluation);
+////		my_scalar_GMLS.addTargets(TargetOperation::LaplacianOfScalarPointEvaluation);
+//
+//		// add vector sample targets
+//		my_vector_GMLS.addTargets(TargetOperation::VectorPointEvaluation);
+//		my_vector_GMLS.addTargets(TargetOperation::VectorLaplacianPointEvaluation);
+//
+//		if (use_staggered_gradient_fix) {
+//			my_GMLS_staggered_grad.addTargets(TargetOperation::GradientOfScalarPointEvaluation);
+//			my_GMLS_staggered_grad.generateAlphas();
+//		}
+//		my_scalar_GMLS.generateAlphas();
+//		my_vector_GMLS.generateAlphas();
+//
+//        auto tangent_directions = my_scalar_GMLS.getTangentDirections();
+//
+//
+//		host_view_type b_data = _b->getLocalView<host_view_type>();
+//		host_view_type h_data = _particles->getFieldManager()->getFieldByName("height")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
+//		host_view_type h_halo_data = _particles->getFieldManager()->getFieldByName("height")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
+//		host_view_type v_data = _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
+//		host_view_type v_halo_data = _particles->getFieldManager()->getFieldByName("velocity")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
+//
+//		Teuchos::RCP<Compadre::ShallowWaterTestCases> swtc = Teuchos::rcp(new Compadre::ShallowWaterTestCases(_parameters->get<int>("shallow water test case"), 0 /*alpha*/));
+//		swtc->setMountain();
+//
+//		Teuchos::RCP<Compadre::CoriolisForce> cf = Teuchos::rcp(new Compadre::CoriolisForce(swtc->getOmega()));
+//
+//        auto global_min_h = _particles->getNeighborhood()->computeMinHSupportSize(true /*global min*/);
+//		const double artificial_viscosity_coeff = _parameters->get<Teuchos::ParameterList>("physics").get<double>("artificial viscosity") * global_min_h * global_min_h;
+//
+//		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,nlocal), KOKKOS_LAMBDA(const int i) {
+//			const local_index_type num_neighbors = neighborhood->getNumNeighbors(i);
+//
+//			xyz_type xyz = _particles->getCoordsConst()->getLocalCoords(i, include_halo, use_physical_coords);
+//			xyz_type normal_direction = xyz / xyz.magnitude();
+////			xyz_type normal_direction = xyz / swtc->getRadius();
+//
+//			double coriolis_force = cf->evalScalar(xyz);
+//
+////						std::vector<std::vector<double> > P(3, std::vector<double>(3,0));
+////						{
+////							xyz_type xyz = _particles->getCoordsConst()->getLocalCoords(i, include_halo, use_physical_coords);
+////							double r = 1;
+////							double scaling = 1. / (r*r);
+////
+////							P[0][0] = r*r - xyz.x*xyz.x;
+////							P[1][1] = r*r - xyz.y*xyz.y;
+////							P[2][2] = r*r - xyz.z*xyz.z;
+////
+////							P[0][1] = -xyz.x*xyz.y;
+////							P[0][2] = -xyz.x*xyz.z;
+////							P[1][0] = -xyz.x*xyz.y;
+////							P[2][0] = -xyz.x*xyz.z;
+////
+////							P[1][2] = -xyz.y*xyz.z;
+////							P[2][1] = -xyz.y*xyz.z;
+////
+////							for (int j=0; j<3; ++j) {
+////								for (int k=0; k<3; ++k) {
+////									P[j][k] = P[j][k]*scaling;
+////								}
+////							}
+////						}
+//
+//
+//            // local view of tangent directions
+//            scratch_matrix_right_type td
+//                    (tangent_directions.data() + i*3*3, 3, 3);
+//
+//
+//			if (bc_id(i, 0) == 0) {
+//
+//				double reconstructed_h_grad_0_local = 0;
+//				double reconstructed_h_grad_1_local = 0;
+//				double reconstructed_h_grad_0_ambient = 0;
+//				double reconstructed_h_grad_1_ambient = 0;
+//				double reconstructed_h_grad_2_ambient = 0;
+//				double reconstructed_v0_local = 0;
+//				double reconstructed_v1_local = 0;
+//				double reconstructed_v0_ambient = 0;
+//				double reconstructed_v1_ambient = 0;
+//				double reconstructed_v2_ambient = 0;
+//
+//				const local_index_type my_index = neighborhood->getNeighbor(i,0);
+//				double h_data_mine_0 = (my_index < nlocal) ? h_data(my_index, 0) : h_halo_data(my_index-nlocal, 0);
+//				double h_value_mine = swtc->evalScalar(xyz);
+//				double v_data_mine_0 = (my_index < nlocal) ? v_data(my_index, 0) : v_halo_data(my_index-nlocal, 0);
+//				double v_data_mine_1 = (my_index < nlocal) ? v_data(my_index, 1) : v_halo_data(my_index-nlocal, 1);
+//				double v_data_mine_2 = (my_index < nlocal) ? v_data(my_index, 2) : v_halo_data(my_index-nlocal, 2);
+//
+//				for (local_index_type l = 0; l < num_neighbors; l++) {
+//					const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
+//
+//					double h_data_0 = (neighbor_index < nlocal) ? h_data(neighbor_index, 0) : h_halo_data(neighbor_index-nlocal, 0);
+//					double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
+//					double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
+//					double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
+//
+//					if (use_staggered_gradient_fix) {
+//						reconstructed_h_grad_0_local += h_data_0 * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//						reconstructed_h_grad_1_local += h_data_0 * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//
+//						reconstructed_h_grad_0_local -= h_data_mine_0 * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//						reconstructed_h_grad_1_local -= h_data_mine_0 * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//					} else {
+//						reconstructed_h_grad_0_local += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//						reconstructed_h_grad_1_local += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//					}
+//
+//					if (use_velocity_interpolation) {
+//						double contracted_data[2] = {0,0};
+//						for (local_index_type dim=0; dim<2; ++dim) {
+//							contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
+//							contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
+//							contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
+//						}
+//						for (local_index_type dim=0; dim<2; ++dim) {
+//							reconstructed_v0_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 0, l, dim);
+//							reconstructed_v1_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 1, l, dim);
+//						}
+//					}
+//
+//
+//					if (_parameters->get<int>("shallow water test case") != 2) {
+//						xyz_type neighbor_xyz = _particles->getCoordsConst()->getLocalCoords(neighbor_index, include_halo, use_physical_coords);
+//						double h_value = swtc->evalScalar(neighbor_xyz);
+//						if (mountain_source_data==1 && use_staggered_gradient_fix) {
+//							reconstructed_h_grad_0_local += h_value * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//							reconstructed_h_grad_1_local += h_value * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//
+//							reconstructed_h_grad_0_local -= h_value_mine * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//							reconstructed_h_grad_1_local -= h_value_mine * my_GMLS_staggered_grad.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//						} else if (mountain_source_data==0) {
+//							reconstructed_h_grad_0_local += h_value * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//							reconstructed_h_grad_1_local += h_value * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//						}
+//					}
+//				}
+//                
+//
+//                // convert to ambient from local
+//                reconstructed_h_grad_0_ambient = td(0,0)*reconstructed_h_grad_0_local + td(1,0)*reconstructed_h_grad_1_local;
+//                reconstructed_h_grad_1_ambient = td(0,1)*reconstructed_h_grad_0_local + td(1,1)*reconstructed_h_grad_1_local;
+//                reconstructed_h_grad_2_ambient = td(0,2)*reconstructed_h_grad_0_local + td(1,2)*reconstructed_h_grad_1_local;
+//
+//				if (use_velocity_interpolation) {
+//                    reconstructed_v0_ambient = td(0,0)*reconstructed_v0_local + td(1,0)*reconstructed_v1_local;
+//                    reconstructed_v1_ambient = td(0,1)*reconstructed_v0_local + td(1,1)*reconstructed_v1_local;
+//                    reconstructed_v2_ambient = td(0,2)*reconstructed_v0_local + td(1,2)*reconstructed_v1_local;
+//                } else {
+//					reconstructed_v0_ambient = v_data_mine_0;
+//					reconstructed_v1_ambient = v_data_mine_1;
+//					reconstructed_v2_ambient = v_data_mine_2;
+//                }
+//
+//
+//				double coriolis_1=0;
+//				double coriolis_2=0;
+//				double coriolis_3=0;
+//
+//				// Eulerian
+//				double reconstructed_v0_grad0 = 0;
+//				double reconstructed_v0_grad1 = 0;
+//				double reconstructed_v0_grad2 = 0;
+//				double reconstructed_v1_grad0 = 0;
+//				double reconstructed_v1_grad1 = 0;
+//				double reconstructed_v1_grad2 = 0;
+//				double reconstructed_v2_grad0 = 0;
+//				double reconstructed_v2_grad1 = 0;
+//				double reconstructed_v2_grad2 = 0;
+//
+//				if (EULERIAN) {
+//					for (local_index_type l = 0; l < num_neighbors; l++) {
+//						const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
+//
+//						double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
+//						double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
+//						double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
+//
+//						{
+//							reconstructed_v0_grad0 += v_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//							reconstructed_v0_grad1 += v_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//							reconstructed_v0_grad2 += v_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 2, l);
+//						}
+//						{
+//							reconstructed_v1_grad0 += v_data_1 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//							reconstructed_v1_grad1 += v_data_1 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//							reconstructed_v1_grad2 += v_data_1 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 2, l);
+//						}
+//						{
+//							reconstructed_v2_grad0 += v_data_2 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//							reconstructed_v2_grad1 += v_data_2 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//							reconstructed_v2_grad2 += v_data_2 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 2, l);
+//						}
+//					}
+//				}
+//
+//				// remove normal contribution of forces
+//				double force[3] = {-coriolis_force * (normal_direction.y*reconstructed_v2_ambient - reconstructed_v1_ambient*normal_direction.z) - _gravity*reconstructed_h_grad_0_ambient,
+//						coriolis_force * (normal_direction.x*reconstructed_v2_ambient - reconstructed_v0_ambient*normal_direction.z) - _gravity*reconstructed_h_grad_1_ambient,
+//						-coriolis_force * (normal_direction.x*reconstructed_v1_ambient - reconstructed_v0_ambient*normal_direction.y) - _gravity*reconstructed_h_grad_2_ambient};
+//
+////				double dot_product = force[0]*normal_direction.x + force[1]*normal_direction.y + force[2]*normal_direction.z;
+////				force[0] -= dot_product * normal_direction.x;
+////				force[1] -= dot_product * normal_direction.y;
+////				force[2] -= dot_product * normal_direction.z;
+//
+//
+//				// remove normal contribution of forces
+//				double advective_force[3] = {-(reconstructed_v0_ambient*reconstructed_v0_grad0 + reconstructed_v1_ambient*reconstructed_v0_grad1 + reconstructed_v2_ambient*reconstructed_v0_grad2),
+//						-(reconstructed_v0_ambient*reconstructed_v1_grad0 + reconstructed_v1_ambient*reconstructed_v1_grad1 + reconstructed_v2_ambient*reconstructed_v1_grad2),
+//						-(reconstructed_v0_ambient*reconstructed_v2_grad0 + reconstructed_v1_ambient*reconstructed_v2_grad1 + reconstructed_v2_ambient*reconstructed_v2_grad2)};
+//
+////				double advective_dot_product = advective_force[0]*normal_direction.x + advective_force[1]*normal_direction.y + advective_force[2]*normal_direction.z;
+////				advective_force[0] -= advective_dot_product * normal_direction.x;
+////				advective_force[1] -= advective_dot_product * normal_direction.y;
+////				advective_force[2] -= advective_dot_product * normal_direction.z;
+//
+//
+//				double artificial_diffusion_force[3] = {0, 0, 0};
+//
+//				if (artificial_viscosity_coeff > 0) {
+//
+//					double reconstructed_laplace_u_0_local = 0;
+//					double reconstructed_laplace_u_1_local = 0;
+//
+//					for (local_index_type l = 0; l < num_neighbors; l++) {
+//						const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
+//
+//						double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
+//						double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
+//						double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
+//
+//						double contracted_data[2] = {0,0};
+//						for (local_index_type dim=0; dim<2; ++dim) {
+//							contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
+//							contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
+//							contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
+//						}
+//						for (local_index_type dim=0; dim<2; ++dim) {
+//							reconstructed_laplace_u_0_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorLaplacianPointEvaluation, i, 0, l, dim);
+//							reconstructed_laplace_u_1_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorLaplacianPointEvaluation, i, 1, l, dim);
+//						}
+//					}
+//                    double reconstructed_laplace_u_0_ambient = td(0,0)*reconstructed_v0_local + td(1,0)*reconstructed_v1_local;
+//                    double reconstructed_laplace_u_1_ambient = td(0,1)*reconstructed_v0_local + td(1,1)*reconstructed_v1_local;
+//                    double reconstructed_laplace_u_2_ambient = td(0,2)*reconstructed_v0_local + td(1,2)*reconstructed_v1_local;
+//
+//					artificial_diffusion_force[0] = artificial_viscosity_coeff * reconstructed_laplace_u_0_ambient;
+//					artificial_diffusion_force[1] = artificial_viscosity_coeff * reconstructed_laplace_u_1_ambient;
+//					artificial_diffusion_force[2] = artificial_viscosity_coeff * reconstructed_laplace_u_2_ambient;
+//
+////					double artificial_diffusion_dot_product = artificial_diffusion_force[0]*normal_direction.x + artificial_diffusion_force[1]*normal_direction.y + artificial_diffusion_force[2]*normal_direction.z;
+////					artificial_diffusion_force[0] -= artificial_diffusion_dot_product * normal_direction.x;
+////					artificial_diffusion_force[1] -= artificial_diffusion_dot_product * normal_direction.y;
+////					artificial_diffusion_force[2] -= artificial_diffusion_dot_product * normal_direction.z;
+//				}
+//
+//
+//				for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
+//					local_index_type row = local_to_dof_map(i, field_one, k);
+//
+//					b_data(row,0) = 0;
+//
+////					double coriolis_constant = 2*swtc->getOmega()*xyz.z / (swtc->getRadius()*swtc->getRadius());
+////					if (k==0) {
+////						b_data(row, 0) = coriolis_constant*(xyz.z*reconstructed_v1 - xyz.y*reconstructed_v2) - _gravity*reconstructed_h_grad_0;
+////					} else if (k==1) {
+////						b_data(row, 0) = -coriolis_constant*(xyz.z*reconstructed_v0 - xyz.x*reconstructed_v2) - _gravity*reconstructed_h_grad_1;
+////					} else if (k==2) {
+////						b_data(row, 0) = coriolis_constant*(xyz.y*reconstructed_v0 - xyz.x*reconstructed_v1) - _gravity*reconstructed_h_grad_2;
+////					}
+//
+//					if (k==0) {
+//						b_data(row, 0) -= 1./ (swtc->getRadius()*swtc->getRadius()) * xyz.x * (reconstructed_v0_ambient*reconstructed_v0_ambient + reconstructed_v1_ambient*reconstructed_v1_ambient + reconstructed_v2_ambient*reconstructed_v2_ambient);
+//					} else if (k==1) {
+//						b_data(row, 0) -= 1./ (swtc->getRadius()*swtc->getRadius()) * xyz.y * (reconstructed_v0_ambient*reconstructed_v0_ambient + reconstructed_v1_ambient*reconstructed_v1_ambient + reconstructed_v2_ambient*reconstructed_v2_ambient);
+//					} else if (k==2) {
+//						b_data(row, 0) -= 1./ (swtc->getRadius()*swtc->getRadius()) * xyz.z * (reconstructed_v0_ambient*reconstructed_v0_ambient + reconstructed_v1_ambient*reconstructed_v1_ambient + reconstructed_v2_ambient*reconstructed_v2_ambient);
+//					}
+//
+//					if (k==0) {
+//						b_data(row, 0) += force[0];//-coriolis_force * (normal_direction.y*reconstructed_v2 - reconstructed_v1*normal_direction.z) - _gravity*reconstructed_h_grad_0;
+//						coriolis_1 += -coriolis_force * (normal_direction.y*reconstructed_v2_ambient - reconstructed_v1_ambient*normal_direction.z);
+//					} else if (k==1) {
+//						b_data(row, 0) += force[1];//coriolis_force * (normal_direction.x*reconstructed_v2 - reconstructed_v0*normal_direction.z) - _gravity*reconstructed_h_grad_1;
+//						coriolis_2 += coriolis_force * (normal_direction.x*reconstructed_v2_ambient - reconstructed_v0_ambient*normal_direction.z);
+//
+//					} else if (k==2) {
+//						b_data(row, 0) += force[2];//-coriolis_force * (normal_direction.x*reconstructed_v1 - reconstructed_v0*normal_direction.y) - _gravity*reconstructed_h_grad_2;
+//						coriolis_3 += -coriolis_force * (normal_direction.x*reconstructed_v1_ambient - reconstructed_v0_ambient*normal_direction.y);
+//					}
+//
+//
+//					if (EULERIAN) {
+//						if (k==0) {
+//							b_data(row, 0) += advective_force[0];
+////							b_data(row, 0) += -(reconstructed_v0*reconstructed_v0_grad0 + reconstructed_v1*reconstructed_v1_grad0 + reconstructed_v2*reconstructed_v2_grad0);
+//						} else if (k==1) {
+//							b_data(row, 0) += advective_force[1];
+////							b_data(row, 0) += -(reconstructed_v0*reconstructed_v0_grad1 + reconstructed_v1*reconstructed_v1_grad1 + reconstructed_v2*reconstructed_v2_grad1);
+//						} else if (k==2) {
+//							b_data(row, 0) += advective_force[2];
+////							b_data(row, 0) += -(reconstructed_v0*reconstructed_v0_grad2 + reconstructed_v1*reconstructed_v1_grad2 + reconstructed_v2*reconstructed_v2_grad2);
+//						}
+//					}
+//
+//					if (artificial_viscosity_coeff > 0) {
+//						// artificial viscosity
+//						if (k==0) {
+//							b_data(row,0) -= artificial_diffusion_force[0];
+//						} else if (k==1) {
+//							b_data(row,0) -= artificial_diffusion_force[1];
+//						} else if (k==2) {
+//							b_data(row,0) -= artificial_diffusion_force[2];
+//						}
+//					}
+//				}
+//			}
+//		});
+//
+//	} else if (_particles->getFieldManager()->getIDOfFieldFromName("height") == field_one) {
+//
+//		GMLS my_GMLS_staggered_div (ReconstructionSpace::VectorTaylorPolynomial,
+//				StaggeredEdgeIntegralSample,
+//                                _parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"),
+//                                target_coords->nDim(),
+//                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("dense sovler type"),
+//                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("problem type"),
+//                                _parameters->get<Teuchos::ParameterList>("remap").get<std::string>("constraint type"),
+//                                _parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature porder"));
+//		my_GMLS_staggered_div.setProblemData(
+//			kokkos_neighbor_lists_host,
+//			kokkos_augmented_source_coordinates_host,
+//			kokkos_target_coordinates,
+//			kokkos_epsilons_host);
+//		my_GMLS_staggered_div.setWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("weighting type"));
+//		my_GMLS_staggered_div.setWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("weighting power"));
+//		my_GMLS_staggered_div.setCurvatureWeightingType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("curvature weighting type"));
+//		my_GMLS_staggered_div.setCurvatureWeightingPower(_parameters->get<Teuchos::ParameterList>("remap").get<int>("curvature weighting power"));
+//		my_GMLS_staggered_div.setOrderOfQuadraturePoints(_parameters->get<Teuchos::ParameterList>("remap").get<int>("quadrature order"));
+//		my_GMLS_staggered_div.setDimensionOfQuadraturePoints(_parameters->get<Teuchos::ParameterList>("remap").get<int>("quadrature dimension"));
+//		my_GMLS_staggered_div.setQuadratureType(_parameters->get<Teuchos::ParameterList>("remap").get<std::string>("quadrature type"));
+//
+//		my_scalar_GMLS.addTargets(TargetOperation::ScalarPointEvaluation);
+//		// for Eulerian
+//		my_scalar_GMLS.addTargets(TargetOperation::GradientOfScalarPointEvaluation);
+//		if (use_staggered_divergence_fix) {
+//			my_GMLS_staggered_div.addTargets(TargetOperation::DivergenceOfVectorPointEvaluation);
+//			my_GMLS_staggered_div.generateAlphas();
+//		} else {
+//			my_vector_GMLS.addTargets(TargetOperation::DivergenceOfVectorPointEvaluation);
+//			my_vector_GMLS.generateAlphas();
+//		}
+//		my_scalar_GMLS.generateAlphas();
+//
+//        auto tangent_directions = my_scalar_GMLS.getTangentDirections();
+//
+//
+//		host_view_type b_data = _b->getLocalView<host_view_type>();
+//		host_view_type h_data = _particles->getFieldManager()->getFieldByName("height")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
+//		host_view_type h_halo_data = _particles->getFieldManager()->getFieldByName("height")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
+//		host_view_type v_data = _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
+//		host_view_type v_halo_data = _particles->getFieldManager()->getFieldByName("velocity")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
+//
+//
+//		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,nlocal), KOKKOS_LAMBDA(const int i) {
+//
+//			const local_index_type num_neighbors = neighborhood->getNumNeighbors(i);
+//
+////			std::vector<std::vector<double> > P(3, std::vector<double>(3,0));
+////			{
+////				xyz_type xyz = _particles->getCoordsConst()->getLocalCoords(i, include_halo, use_physical_coords);
+////				double r = 1;
+////				double scaling = 1. / (r*r);
+////
+////				P[0][0] = r*r - xyz.x*xyz.x;
+////				P[1][1] = r*r - xyz.y*xyz.y;
+////				P[2][2] = r*r - xyz.z*xyz.z;
+////
+////				P[0][1] = -xyz.x*xyz.y;
+////				P[0][2] = -xyz.x*xyz.z;
+////				P[1][0] = -xyz.x*xyz.y;
+////				P[2][0] = -xyz.x*xyz.z;
+////
+////				P[1][2] = -xyz.y*xyz.z;
+////				P[2][1] = -xyz.y*xyz.z;
+////
+////				for (int j=0; j<3; ++j) {
+////					for (int k=0; k<3; ++k) {
+////						P[j][k] = P[j][k]*scaling;
+////					}
+////				}
+////			}
+//
+////			if (bc_id(i, 0) == 0) {
+//
+//                // local view of tangent directions
+//                scratch_matrix_right_type td
+//                        (tangent_directions.data() + i*3*3, 3, 3);
+//
+//				local_index_type row = local_to_dof_map(i, field_one, 0);
+//
+//				double reconstructed_h = 0;
+//				double reconstructed_div_v = 0;
+//
+//                // Reconstruction needed for Eulerian case only
+//				double reconstructed_v0_local = 0;
+//				double reconstructed_v1_local = 0;
+//				double reconstructed_v0_ambient = 0;
+//				double reconstructed_v1_ambient = 0;
+//				double reconstructed_v2_ambient = 0;
+//				double reconstructed_h_grad0_local = 0;
+//				double reconstructed_h_grad1_local = 0;
+//				double reconstructed_h_grad0_ambient = 0;
+//				double reconstructed_h_grad1_ambient = 0;
+//				double reconstructed_h_grad2_ambient = 0;
+//
+//				const local_index_type my_index = neighborhood->getNeighbor(i,0);
+//				double v_data_mine_0 = (my_index < nlocal) ? v_data(my_index, 0) : v_halo_data(my_index-nlocal, 0);
+//				double v_data_mine_1 = (my_index < nlocal) ? v_data(my_index, 1) : v_halo_data(my_index-nlocal, 1);
+//				double v_data_mine_2 = (my_index < nlocal) ? v_data(my_index, 2) : v_halo_data(my_index-nlocal, 2);
+//
+//				if (EULERIAN) {
+//				    if (use_velocity_interpolation) {
+//				    	for (local_index_type l = 0; l < num_neighbors; l++) {
+//				    		const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
+//				    		double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
+//				    		double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
+//				    		double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
+//
+//				    		double contracted_data[2] = {0,0};
+//				    		for (local_index_type dim=0; dim<2; ++dim) {
+//				    			contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
+//				    			contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
+//				    			contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
+//				    		}
+//				    		for (local_index_type dim=0; dim<2; ++dim) {
+//				    			reconstructed_v0_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 0, l, dim);
+//				    			reconstructed_v1_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 1, l, dim);
+//				    		}
+//				    	}
+//
+//                        // local view of tangent directions
+//                        scratch_matrix_right_type td
+//                                (tangent_directions.data() + i*3*3, 3, 3);
+//
+//                        // convert to ambient from local
+//                        reconstructed_v0_ambient = td(0,0)*reconstructed_v0_local + td(1,0)*reconstructed_v1_local;
+//                        reconstructed_v1_ambient = td(0,1)*reconstructed_v0_local + td(1,1)*reconstructed_v1_local;
+//                        reconstructed_v2_ambient = td(0,2)*reconstructed_v0_local + td(1,2)*reconstructed_v1_local;
+//
+//				    } else {
+//				    	reconstructed_v0_ambient = v_data_mine_0;
+//				    	reconstructed_v1_ambient = v_data_mine_1;
+//				    	reconstructed_v2_ambient = v_data_mine_2;
+//				    }
+//                }
+//
+//
+//				for (local_index_type l = 0; l < num_neighbors; l++) {
+//					const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
+//
+//					double h_data_0 = (neighbor_index < nlocal) ? h_data(neighbor_index, 0) : h_halo_data(neighbor_index-nlocal, 0);
+//
+//					double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
+//					double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
+//					double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
+//
+//					reconstructed_h += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo0Tensor(TargetOperation::ScalarPointEvaluation, i, l);
+//
+//
+//					if (use_staggered_divergence_fix) {
+//
+//						double contracted_data = 0;
+//						contracted_data += v_data_0 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, false /* for neighbor*/, 0, 0);
+//						contracted_data += v_data_1 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, false /* for neighbor*/, 0, 1);
+//						contracted_data += v_data_2 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, false /* for neighbor*/, 0, 2);
+//						contracted_data += v_data_mine_0 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, true /* for neighbor*/, 0, 0);
+//						contracted_data += v_data_mine_1 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, true /* for neighbor*/, 0, 1);
+//						contracted_data += v_data_mine_2 * my_GMLS_staggered_div.getPreStencilWeight(StaggeredEdgeIntegralSample, i, l, true /* for neighbor*/, 0, 2);
+//						reconstructed_div_v += contracted_data * my_GMLS_staggered_div.getAlpha0TensorTo0Tensor(TargetOperation::DivergenceOfVectorPointEvaluation, i, l);
+//
+//					} else {
+//						double contracted_data[2] = {0,0};
+//						for (local_index_type dim=0; dim<2; ++dim) {
+//							contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
+//							contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
+//							contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
+//						}
+//						for (local_index_type dim=0; dim<2; ++dim) {
+//							reconstructed_div_v += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::DivergenceOfVectorPointEvaluation, i, 0, l, dim);
+//						}
+//					}
+//
+//					if (EULERIAN) {
+//						reconstructed_h_grad0_local += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 0, l);
+//						reconstructed_h_grad1_local += h_data_0 * my_scalar_GMLS.getAlpha0TensorTo1Tensor(TargetOperation::GradientOfScalarPointEvaluation, i, 1, l);
+//					}
+//				}
+//
+//                // convert to ambient from local
+//                reconstructed_h_grad0_ambient = td(0,0)*reconstructed_h_grad0_local + td(1,0)*reconstructed_h_grad1_local;
+//                reconstructed_h_grad1_ambient = td(0,1)*reconstructed_h_grad0_local + td(1,1)*reconstructed_h_grad1_local;
+//                reconstructed_h_grad2_ambient = td(0,2)*reconstructed_h_grad0_local + td(1,2)*reconstructed_h_grad1_local;
+//
+//
+////				printf("%f %f\n", reconstructed_div_v, reconstructed_h);
+//				b_data(row, 0) = - reconstructed_h * reconstructed_div_v;
+//
+//				// Eulerian
+//				if (EULERIAN) {
+////					double transformed_h_grad0 = P[0][0]*reconstructed_h_grad0 + P[0][1]*reconstructed_h_grad1 + P[0][2]*reconstructed_h_grad2;
+////					double transformed_h_grad1 = P[1][0]*reconstructed_h_grad0 + P[1][1]*reconstructed_h_grad1 + P[1][2]*reconstructed_h_grad2;
+////					double transformed_h_grad2 = P[2][0]*reconstructed_h_grad0 + P[2][1]*reconstructed_h_grad1 + P[2][2]*reconstructed_h_grad2;
+////					b_data(row, 0) -= (reconstructed_v0*transformed_h_grad0 + reconstructed_v1*transformed_h_grad1 + reconstructed_v2*transformed_h_grad2);
+//					b_data(row, 0) -= (reconstructed_v0_ambient*reconstructed_h_grad0_ambient + reconstructed_v1_ambient*reconstructed_h_grad1_ambient + reconstructed_v2_ambient*reconstructed_h_grad2_ambient);
+//				}
+////			}
+//
+//		});
+//
+//	} else if (_particles->getFieldManager()->getIDOfFieldFromName("displacement") == field_one) {
+//
+//		if (use_velocity_interpolation) {
+//			my_vector_GMLS.addTargets(TargetOperation::VectorPointEvaluation);
+//			my_vector_GMLS.generateAlphas();
+//		}
+//        auto tangent_directions = my_vector_GMLS.getTangentDirections();
+//
+//		host_view_type b_data = _b->getLocalView<host_view_type>();
+//		host_view_type v_data = _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst()->getLocalView<host_view_type>();
+//		host_view_type v_halo_data = _particles->getFieldManager()->getFieldByName("velocity")->getHaloMultiVectorPtrConst()->getLocalView<host_view_type>();
+//
+//		Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(0,nlocal), KOKKOS_LAMBDA(const int i) {
+//
+//			//xyz_type xyz = _particles->getCoordsConst()->getLocalCoords(i, include_halo, use_physical_coords);
+//			//xyz_type normal_direction = xyz / xyz.magnitude();
+//
+//			const local_index_type num_neighbors = neighborhood->getNumNeighbors(i);
+//
+//			if (bc_id(i, 0) == 0) {
+//
+//				double reconstructed_v0_local = 0;
+//				double reconstructed_v1_local = 0;
+//				double reconstructed_v0_ambient = 0;
+//				double reconstructed_v1_ambient = 0;
+//				double reconstructed_v2_ambient = 0;
+//
+//				if (use_velocity_interpolation) {
+//					for (local_index_type l = 0; l < num_neighbors; l++) {
+//						const local_index_type neighbor_index = neighborhood->getNeighbor(i,l);
+//						double v_data_0 = (neighbor_index < nlocal) ? v_data(neighbor_index, 0) : v_halo_data(neighbor_index-nlocal, 0);
+//						double v_data_1 = (neighbor_index < nlocal) ? v_data(neighbor_index, 1) : v_halo_data(neighbor_index-nlocal, 1);
+//						double v_data_2 = (neighbor_index < nlocal) ? v_data(neighbor_index, 2) : v_halo_data(neighbor_index-nlocal, 2);
+//
+//						double contracted_data[2] = {0,0};
+//						for (local_index_type dim=0; dim<2; ++dim) {
+//							contracted_data[dim] += v_data_0 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 0);
+//							contracted_data[dim] += v_data_1 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 1);
+//							contracted_data[dim] += v_data_2 * my_vector_GMLS.getPreStencilWeight(ManifoldVectorPointSample, i, l, false /* for neighbor*/, dim, 2);
+//						}
+//						for (local_index_type dim=0; dim<2; ++dim) {
+//							reconstructed_v0_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 0, l, dim);
+//							reconstructed_v1_local += contracted_data[dim] * my_vector_GMLS.getAlpha1TensorTo1Tensor(TargetOperation::VectorPointEvaluation, i, 1, l, dim);
+//						}
+//					}
+//
+//                    // local view of tangent directions
+//                    scratch_matrix_right_type td
+//                            (tangent_directions.data() + i*3*3, 3, 3);
+//
+//                    // convert to ambient from local
+//                    reconstructed_v0_ambient = td(0,0)*reconstructed_v0_local + td(1,0)*reconstructed_v1_local;
+//                    reconstructed_v1_ambient = td(0,1)*reconstructed_v0_local + td(1,1)*reconstructed_v1_local;
+//                    reconstructed_v2_ambient = td(0,2)*reconstructed_v0_local + td(1,2)*reconstructed_v1_local;
+//
+//				} else {
+//					const local_index_type my_index = neighborhood->getNeighbor(i,0);
+//					double v_data_mine_0 = (my_index < nlocal) ? v_data(my_index, 0) : v_halo_data(my_index, 0);
+//					double v_data_mine_1 = (my_index < nlocal) ? v_data(my_index, 1) : v_halo_data(my_index, 1);
+//					double v_data_mine_2 = (my_index < nlocal) ? v_data(my_index, 2) : v_halo_data(my_index, 2);
+//					reconstructed_v0_ambient = v_data_mine_0;
+//					reconstructed_v1_ambient = v_data_mine_1;
+//					reconstructed_v2_ambient = v_data_mine_2;
+//				}
+////				const local_index_type my_index = neighborhood->getNeighbor(i,0);
+////				reconstructed_v0 = (my_index < nlocal) ? v_data(my_index, 0) : v_halo_data(my_index-nlocal, 0);
+////				reconstructed_v1 = (my_index < nlocal) ? v_data(my_index, 1) : v_halo_data(my_index-nlocal, 1);
+////				reconstructed_v2 = (my_index < nlocal) ? v_data(my_index, 2) : v_halo_data(my_index-nlocal, 2);
+//
+////				printf ("%f %f %f\n", reconstructed_v0, reconstructed_v1, reconstructed_v2);
+//
+////				for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
+////					local_index_type row = local_to_dof_map[i][field_one][k];
+////					if (k==0) {
+////						b_data(row, 0) = reconstructed_v0;
+////					} else if (k==1) {
+////						b_data(row, 0) = reconstructed_v1;
+////					} else if (k==2) {
+////						b_data(row, 0) = reconstructed_v2;
+////					}
+////				}
+//
+//
+//
+//				// remove normal contribution of forces
+//				double force[3] = {reconstructed_v0_ambient,
+//									reconstructed_v1_ambient,
+//									reconstructed_v2_ambient};
+//
+////				double dot_product = force[0]*normal_direction.x + force[1]*normal_direction.y + force[2]*normal_direction.z;
+////				force[0] -= dot_product * normal_direction.x;
+////				force[1] -= dot_product * normal_direction.y;
+////				force[2] -= dot_product * normal_direction.z;
+//
+//				for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
+//					local_index_type row = local_to_dof_map(i, field_one, k);
+//					if (k==0) {
+//						b_data(row, 0) = force[0];
+//					} else if (k==1) {
+//						b_data(row, 0) = force[1];
+//					} else if (k==2) {
+//						b_data(row, 0) = force[2];
+//					}
+//				}
+//
+//			}
+//
+//		});
+//
+//	}
+//
+//	ComputeMatrixTime->stop();
 
 }
 

--- a/physics/Compadre_LagrangianShallowWater_Sources.cpp
+++ b/physics/Compadre_LagrangianShallowWater_Sources.cpp
@@ -14,41 +14,43 @@ typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 
 void LagrangianShallowWaterSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
-//	Teuchos::RCP<Compadre::AnalyticFunction> function;
-//	function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::ConstantEachDimension(1,2,3)));
-//
-//	TEUCHOS_TEST_FOR_EXCEPT_MSG(this->_b.is_null(), "Tpetra Multivector for RHS not yet specified.");
-//	if (field_two == -1) {
-//		field_two = field_one;
-//	}
-//
-//	// temporary this will be a specific function
-//	// in the future, we can pass a Teuchos::ArrayRCP of functors
-//	host_view_local_index_type bc_id = this->_particles->getFlags()->getLocalView<host_view_local_index_type>();
-//	host_view_type rhs_vals = this->_b->getLocalView<host_view_type>();
-//	host_view_type pts = this->_coords->getPts()->getLocalView<host_view_type>();
-//
-//	const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
-//	const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
-//	const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-//			this->_particles->getDOFManagerConst()->getDOFMap();
-//
-//	for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
-//		// get dof corresponding to field
-//		if (bc_id(i,0)==0) {
-//			for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
-//				const local_index_type dof = local_to_dof_map[i][field_one][k];
-//				xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
-//				xyz_type bdry_val = function->evalVector(pt);
-//				rhs_vals(dof,0) = bdry_val[k]*time*time*time; // just for testing purposes
-//			}
-//		}
-//	}
+
+    if (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity")) {
+	    Teuchos::RCP<Compadre::AnalyticFunction> function;
+	    function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::ConstantEachDimension(1,2,3)));
+
+	    TEUCHOS_TEST_FOR_EXCEPT_MSG(_b==NULL, "Tpetra Multivector for RHS not yet specified.");
+	    if (field_two == -1) {
+	    	field_two = field_one;
+	    }
+
+	    // temporary this will be a specific function
+	    // in the future, we can pass a Teuchos::ArrayRCP of functors
+	    host_view_local_index_type bc_id = this->_particles->getFlags()->getLocalView<host_view_local_index_type>();
+	    host_view_type rhs_vals = this->_b->getLocalView<host_view_type>();
+	    host_view_type pts = this->_coords->getPts()->getLocalView<host_view_type>();
+
+	    const local_index_type nlocal = static_cast<local_index_type>(this->_coords->nLocal());
+	    const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
+        const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
+
+	    for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
+	    	// get dof corresponding to field
+	    	if (bc_id(i,0)==0) {
+	    		for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
+                    const local_index_type dof = local_to_dof_map(i, field_one, k);
+	    			xyz_type pt(pts(i, 0), pts(i, 1), pts(i, 2));
+	    			xyz_type bdry_val = function->evalVector(pt);
+	    			rhs_vals(dof,0) = bdry_val[k]*time*time*time; // just for testing purposes
+	    		}
+	    	}
+	    }
+    }
 }
 
 std::vector<InteractingFields> LagrangianShallowWaterSources::gatherFieldInteractions() {
 	std::vector<InteractingFields> field_interactions;
-//	field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getField("velocity")));
+	field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity")));
 //	field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getField("height")));
 //	printf("src: %d %d\n", _particles->getFieldManagerConst()->getField("velocity"), _particles->getFieldManagerConst()->getField("height"));
 	return field_interactions;

--- a/physics/Compadre_LaplaceBeltrami_Operator.cpp
+++ b/physics/Compadre_LaplaceBeltrami_Operator.cpp
@@ -97,10 +97,7 @@ Teuchos::RCP<crs_graph_type> LaplaceBeltramiPhysics::computeGraph(local_index_ty
         auto existing_row_map = _row_map;
         auto existing_col_map = _col_map;
 
-        size_t max_entries_per_row;
-        Teuchos::ArrayRCP<const size_t> empty_array;
-        bool bound_same_for_all_local_rows = true;
-        this->_A_graph->getNumEntriesPerLocalRowUpperBound(empty_array, max_entries_per_row, bound_same_for_all_local_rows);
+        size_t max_entries_per_row = this->_A_graph->getNodeMaxNumRowEntries();
 
         auto row_map_index_base = existing_row_map->getIndexBase();
         auto row_map_entries = existing_row_map->getMyGlobalIndices();
@@ -153,10 +150,7 @@ Teuchos::RCP<crs_graph_type> LaplaceBeltramiPhysics::computeGraph(local_index_ty
         auto existing_row_map = _row_map;
         auto existing_col_map = _col_map;
 
-        size_t max_entries_per_row;
-        Teuchos::ArrayRCP<const size_t> empty_array;
-        bool bound_same_for_all_local_rows = true;
-        this->_A_graph->getNumEntriesPerLocalRowUpperBound(empty_array, max_entries_per_row, bound_same_for_all_local_rows);
+        size_t max_entries_per_row = this->_A_graph->getNodeMaxNumRowEntries();
 
         auto col_map_index_base = existing_col_map->getIndexBase();
         auto col_map_entries = existing_col_map->getMyGlobalIndices();

--- a/src/CompadreHarness_Typedefs.hpp
+++ b/src/CompadreHarness_Typedefs.hpp
@@ -112,55 +112,6 @@ namespace Compadre {
     typedef typename z2_scalar_adapter_type::part_t z2_partition_type;
     typedef std::remove_reference<decltype(std::declval<z2_problem_type>().getSolution().getPartBoxesView()[0])>::type z2_box_type;
 
-    enum op_needing_interaction { bc, source, physics };
-
-    //! Whether DOF interactions in a field are global or locally supported
-    enum FieldSparsityType {
-        //! Locally supported DOF interaction leading to a banded matrix
-        Banded,
-        //! Globally supported DOF interaction leading to completely filled row or column of a matrix
-        Global
-    };
-
-    struct InteractingFields {
-        public:
-            std::string src_fieldname;
-            std::string trg_fieldname;
-            local_index_type src_fieldnum;
-            local_index_type trg_fieldnum;
-            std::vector<op_needing_interaction> ops_needing;
-
-            InteractingFields(op_needing_interaction op, const local_index_type source_num, const local_index_type target_num = -1) {
-                src_fieldnum = source_num;
-                if (target_num < 0) trg_fieldnum = source_num;
-                else trg_fieldnum = target_num;
-                ops_needing.push_back(op);
-            }
-
-            bool operator== (const InteractingFields& other) const
-            {
-                if (this->src_fieldnum == other.src_fieldnum &&  this->trg_fieldnum == other.trg_fieldnum)
-                    return true;
-                return false;
-            }
-
-            void operator+= (const InteractingFields& other)  {
-                // performs a merge of the ops_needing from both objects
-                for (op_needing_interaction an_op:other.ops_needing) {
-                    // check if an_op already exists, and if not push it
-                    bool found = false;
-                    for (op_needing_interaction my_op:this->ops_needing) {
-                        if (my_op==an_op) {
-                            found = true;
-                            break;
-                        }
-                    }
-                    if (!found) this->ops_needing.push_back(an_op);
-                }
-            }
-
-    };
-
 }
 
 #endif

--- a/src/Compadre_BoundaryConditionsT.hpp
+++ b/src/Compadre_BoundaryConditionsT.hpp
@@ -9,6 +9,7 @@ namespace Compadre {
 class CoordsT;
 class ParticlesT;
 class DOFData;
+class InteractingFields;
 
 class BoundaryConditionsT {
 

--- a/src/Compadre_FieldManager.cpp
+++ b/src/Compadre_FieldManager.cpp
@@ -11,6 +11,39 @@
 
 namespace Compadre {
 
+InteractingFields::InteractingFields(op_needing_interaction op, const local_index_type source_num, const local_index_type target_num) {
+            src_fieldnum = source_num;
+            if (target_num < 0) trg_fieldnum = source_num;
+            else trg_fieldnum = target_num;
+            ops_needing.push_back(op);
+}
+
+bool InteractingFields::operator== (const InteractingFields& other) const
+{
+    if (this->src_fieldnum == other.src_fieldnum &&  this->trg_fieldnum == other.trg_fieldnum)
+        return true;
+    return false;
+}
+
+void InteractingFields::operator+= (const InteractingFields& other)  {
+    // performs a merge of the ops_needing from both objects
+    // if they share the same source and target fields
+    for (op_needing_interaction an_op:other.ops_needing) {
+        // check if an_op already exists, and if not push it
+        bool found = false;
+        for (op_needing_interaction my_op:this->ops_needing) {
+            if (my_op==an_op) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            this->ops_needing.push_back(an_op);
+        }
+    }
+}
+
+
 FieldManager::FieldManager ( const particles_type* particles, Teuchos::RCP<Teuchos::ParameterList> parameters ) :
 			_parameters(parameters), _particles(particles), total_field_offsets(0), max_num_field_dimensions(0)
 {}

--- a/src/Compadre_FieldManager.hpp
+++ b/src/Compadre_FieldManager.hpp
@@ -3,17 +3,41 @@
 
 #include "CompadreHarness_Config.h"
 #include "CompadreHarness_Typedefs.hpp"
+#include "Compadre_FieldSparsity.hpp"
 
 namespace Compadre {
 
-/*
-*  This class wraps coordinates, fields, dof manager and manages them
-*/
 class CoordsT;
 class ParticlesT;
 class FieldT;
 class XyzVector;
 class DOFData;
+
+// which operation requires interaction between fields
+enum op_needing_interaction { bc, source, physics };
+
+struct InteractingFields {
+
+    public:
+
+        std::string src_fieldname;
+        std::string trg_fieldname;
+        local_index_type src_fieldnum;
+        local_index_type trg_fieldnum;
+        std::vector<op_needing_interaction> ops_needing;
+
+        InteractingFields(op_needing_interaction op, const local_index_type source_num, const local_index_type target_num = -1);
+
+        bool operator== (const InteractingFields& other) const;
+
+        void operator+= (const InteractingFields& other);
+
+};
+
+
+/*
+*  This class wraps coordinates, fields, dof manager and manages them
+*/
 
 class FieldManager {
 

--- a/src/Compadre_FieldSparsity.hpp
+++ b/src/Compadre_FieldSparsity.hpp
@@ -1,0 +1,12 @@
+#ifndef _COMPADRE_FIELDSPARSITY_HPP_
+#define _COMPADRE_FIELDSPARSITY_HPP_
+
+//! Whether DOF interactions in a field are global or locally supported
+enum FieldSparsityType {
+    //! Locally supported DOF interaction leading to a banded matrix
+    Banded,
+    //! Globally supported DOF interaction leading to completely filled row or column of a matrix
+    Global
+};
+
+#endif

--- a/src/Compadre_FieldT.hpp
+++ b/src/Compadre_FieldT.hpp
@@ -3,6 +3,7 @@
 
 #include "CompadreHarness_Config.h"
 #include "CompadreHarness_Typedefs.hpp"
+#include "Compadre_FieldSparsity.hpp"
 
 namespace Compadre {
 

--- a/src/Compadre_PhysicsT.hpp
+++ b/src/Compadre_PhysicsT.hpp
@@ -9,6 +9,7 @@ namespace Compadre {
 class CoordsT;
 class ParticlesT;
 class DOFData;
+class InteractingFields;
 
 class PhysicsT {
 

--- a/src/Compadre_ProblemExplicitTransientT.cpp
+++ b/src/Compadre_ProblemExplicitTransientT.cpp
@@ -25,142 +25,146 @@ namespace Compadre {
 
 
 
-ProblemExplicitTransientT::ProblemExplicitTransientT(	Teuchos::RCP<ProblemExplicitTransientT::particle_type> particles,
-			Teuchos::RCP<Teuchos::ParameterList> parameters,
-			Teuchos::RCP<ProblemExplicitTransientT::physics_type> physics,
-			Teuchos::RCP<ProblemExplicitTransientT::source_type> sources,
-			Teuchos::RCP<ProblemExplicitTransientT::bc_type> bcs) :
-			_particles(particles),
-			_parameters(parameters),
-			_coords(particles->getCoordsConst())
+ProblemExplicitTransientT::ProblemExplicitTransientT(    Teuchos::RCP<ProblemExplicitTransientT::particle_type> particles,
+            Teuchos::RCP<Teuchos::ParameterList> parameters,
+            Teuchos::RCP<ProblemExplicitTransientT::physics_type> physics,
+            Teuchos::RCP<ProblemExplicitTransientT::source_type> sources,
+            Teuchos::RCP<ProblemExplicitTransientT::bc_type> bcs) :
+            _particles(particles),
+            _parameters(parameters),
+            _coords(particles->getCoordsConst())
 {
-	_comm = particles->getCoordsConst()->getComm();
-	this->setPhysics(physics);
-	this->setSources(sources);
-	this->setBCS(bcs);
-	if (!_OP.is_null()) _OP->setParameters(*_parameters);
-	if (!_RHS.is_null()) _RHS->setParameters(*_parameters);
-	if (!_BCS.is_null()) _BCS->setParameters(*_parameters);
+    _comm = particles->getCoordsConst()->getComm();
+    this->setPhysics(physics);
+    this->setSources(sources);
+    this->setBCS(bcs);
+    if (!_OP.is_null()) _OP->setParameters(*_parameters);
+    if (!_RHS.is_null()) _RHS->setParameters(*_parameters);
+    if (!_BCS.is_null()) _BCS->setParameters(*_parameters);
 }
 
 
-ProblemExplicitTransientT::ProblemExplicitTransientT(	Teuchos::RCP<ProblemExplicitTransientT::particle_type> particles,
-			Teuchos::RCP<ProblemExplicitTransientT::parameter_manager_type> parameter_manager,
-			Teuchos::RCP<ProblemExplicitTransientT::physics_type> physics,
-			Teuchos::RCP<ProblemExplicitTransientT::source_type> sources,
-			Teuchos::RCP<ProblemExplicitTransientT::bc_type> bcs) :
-				ProblemExplicitTransientT(particles, parameter_manager->getList(), physics, sources, bcs)
+ProblemExplicitTransientT::ProblemExplicitTransientT(    Teuchos::RCP<ProblemExplicitTransientT::particle_type> particles,
+            Teuchos::RCP<ProblemExplicitTransientT::parameter_manager_type> parameter_manager,
+            Teuchos::RCP<ProblemExplicitTransientT::physics_type> physics,
+            Teuchos::RCP<ProblemExplicitTransientT::source_type> sources,
+            Teuchos::RCP<ProblemExplicitTransientT::bc_type> bcs) :
+                ProblemExplicitTransientT(particles, parameter_manager->getList(), physics, sources, bcs)
 {}
 
 
-ProblemExplicitTransientT::ProblemExplicitTransientT(	Teuchos::RCP<ProblemExplicitTransientT::particle_type> particles,
-					Teuchos::RCP<ProblemExplicitTransientT::physics_type> physics,
-					Teuchos::RCP<ProblemExplicitTransientT::source_type> sources,
-					Teuchos::RCP<ProblemExplicitTransientT::bc_type> bcs) :
-						ProblemExplicitTransientT(particles, particles->getParameters(), physics, sources, bcs)
+ProblemExplicitTransientT::ProblemExplicitTransientT(    Teuchos::RCP<ProblemExplicitTransientT::particle_type> particles,
+                    Teuchos::RCP<ProblemExplicitTransientT::physics_type> physics,
+                    Teuchos::RCP<ProblemExplicitTransientT::source_type> sources,
+                    Teuchos::RCP<ProblemExplicitTransientT::bc_type> bcs) :
+                        ProblemExplicitTransientT(particles, particles->getParameters(), physics, sources, bcs)
 {}
 
 void ProblemExplicitTransientT::setPhysics(Teuchos::RCP<ProblemExplicitTransientT::physics_type> physics) {
-	if (!physics.is_null()) {
-		_OP = physics;
-		this->registerFieldInteractions(_OP->gatherFieldInteractions());
-	}
+    if (!physics.is_null()) {
+        _OP = physics;
+        this->registerFieldInteractions(_OP->gatherFieldInteractions());
+    }
 }
 void ProblemExplicitTransientT::setSources(Teuchos::RCP<ProblemExplicitTransientT::source_type> sources) {
-	if (!sources.is_null()) {
-		_RHS = sources;
-		this->registerFieldInteractions(_RHS->gatherFieldInteractions());
-	}
+    if (!sources.is_null()) {
+        _RHS = sources;
+        this->registerFieldInteractions(_RHS->gatherFieldInteractions());
+    }
 }
 void ProblemExplicitTransientT::setBCS(Teuchos::RCP<ProblemExplicitTransientT::bc_type> bcs) {
-	if (!bcs.is_null()) {
-		_BCS = bcs;
-		this->registerFieldInteractions(_BCS->gatherFieldInteractions());
-	}
+    if (!bcs.is_null()) {
+        _BCS = bcs;
+        this->registerFieldInteractions(_BCS->gatherFieldInteractions());
+    }
 }
 
 void ProblemExplicitTransientT::registerFieldInteractions(const std::vector<InteractingFields>& ops_to_register) {
-	for (InteractingFields op : ops_to_register) {
-		bool similar_field_interaction = false;
-		for (InteractingFields op_already_in : _field_interactions) {
-			if (op==op_already_in) {
-				op_already_in += op; // add to the operations that need this interaction
-				similar_field_interaction = true;
-				break;
-			}
-		}
-		if (!similar_field_interaction) { // this needs added to the set because it hasn't been registered yet
-			_field_interactions.push_back(op);
-		}
-	}
+    for (InteractingFields fi : ops_to_register) {
+        bool similar_field_interaction = false;
+        for (InteractingFields& op_already_in : _field_interactions) {
+            if (fi==op_already_in) {
+                op_already_in += fi; // add to the operations that need this interaction
+                similar_field_interaction = true;
+                break;
+            }
+        }
+        if (!similar_field_interaction) { // this needs added to the set because it hasn't been registered yet
+            _field_interactions.push_back(fi);
+        }
+    }
+    for (InteractingFields fi : _field_interactions) {
+        // sort ops_needing list for each field interaction
+        std::sort(fi.ops_needing.begin(), fi.ops_needing.end());
+    }
 }
 
 Teuchos::RCP<const crs_matrix_type> ProblemExplicitTransientT::getA(local_index_type row_block, local_index_type col_block) const {
-	Teuchos::RCP<const crs_matrix_type> return_ptr = Teuchos::null;
-//	if (row_block==-1) return_ptr =  _A[0][0].getConst(); // default
-//	if (col_block==-1 && row_block>-1) return_ptr =  _A[row_block][row_block].getConst();
-//	else return_ptr =  _A[row_block][col_block].getConst();
-	return return_ptr;
+    Teuchos::RCP<const crs_matrix_type> return_ptr = Teuchos::null;
+//    if (row_block==-1) return_ptr =  _A[0][0].getConst(); // default
+//    if (col_block==-1 && row_block>-1) return_ptr =  _A[row_block][row_block].getConst();
+//    else return_ptr =  _A[row_block][col_block].getConst();
+    return return_ptr;
 }
 
 Teuchos::RCP<const mvec_type> ProblemExplicitTransientT::getb(local_index_type row_block) const {
-	if (row_block==-1) return _b[0].getConst();
-	else return _b[row_block].getConst();
+    if (row_block==-1) return _b[0].getConst();
+    else return _b[row_block].getConst();
 }
 
 void ProblemExplicitTransientT::initialize() {
-	// TODO: break function into an initialize and a reinitialize function that is selective
+    // TODO: break function into an initialize and a reinitialize function that is selective
 
-	// first get the max number of blocks that will be used
-	local_index_type max_blocks = 0;
-	for (InteractingFields interaction:_field_interactions) {
-		if (interaction.src_fieldnum > max_blocks) {
-			max_blocks = interaction.src_fieldnum;
-		} else if (interaction.trg_fieldnum > max_blocks) {
-			max_blocks = interaction.trg_fieldnum;
-		}
-	}
-	max_blocks = max_blocks + 1; // counting begins at 0
+    // first get the max number of blocks that will be used
+    local_index_type max_blocks = 0;
+    for (InteractingFields interaction:_field_interactions) {
+        if (interaction.src_fieldnum > max_blocks) {
+            max_blocks = interaction.src_fieldnum;
+        } else if (interaction.trg_fieldnum > max_blocks) {
+            max_blocks = interaction.trg_fieldnum;
+        }
+    }
+    max_blocks = max_blocks + 1; // counting begins at 0
 
-	// maps from field number to actual block of matrix
-	_field_to_block_row_map = std::vector<local_index_type>(max_blocks, -1);
-	_field_to_block_col_map = std::vector<local_index_type>(max_blocks, -1);
+    // maps from field number to actual block of matrix
+    _field_to_block_row_map = std::vector<local_index_type>(max_blocks, -1);
+    _field_to_block_col_map = std::vector<local_index_type>(max_blocks, -1);
 
-	local_index_type row_count = 0;
-	local_index_type col_count = 0;
-	for (local_index_type i=0; i<max_blocks; i++) {
-		bool row_found = false;
-		bool col_found = false;
-		for (InteractingFields interaction:_field_interactions) {
-			if (interaction.src_fieldnum == i) {
-				_field_to_block_row_map[i] = row_count;
-				row_found = true;
-				row_count++;
-			}
-			if (interaction.trg_fieldnum == i) {
-				_field_to_block_col_map[i] = col_count;
-				col_found = true;
-				col_count++;
-			}
-			if (row_found && col_found) break;
-		}
-	}
+    local_index_type row_count = 0;
+    local_index_type col_count = 0;
+    for (local_index_type i=0; i<max_blocks; i++) {
+        bool row_found = false;
+        bool col_found = false;
+        for (InteractingFields interaction:_field_interactions) {
+            if (interaction.src_fieldnum == i) {
+                _field_to_block_row_map[i] = row_count;
+                row_found = true;
+                row_count++;
+            }
+            if (interaction.trg_fieldnum == i) {
+                _field_to_block_col_map[i] = col_count;
+                col_found = true;
+                col_count++;
+            }
+            if (row_found && col_found) break;
+        }
+    }
 
-	// maps from block of matrix to field number
-	_block_row_to_field_map = std::vector<local_index_type>(row_count);
-	_block_col_to_field_map = std::vector<local_index_type>(col_count);
-	row_count = 0;
-	col_count = 0;
-	for (local_index_type i=0; i<max_blocks; i++) {
-		if (_field_to_block_row_map[i] > -1) {
-			_block_row_to_field_map[row_count] = i;
-			row_count++;
-		}
-		if (_field_to_block_col_map[i] > -1) {
-			_block_col_to_field_map[col_count] = i;
-			col_count++;
-		}
-	}
+    // maps from block of matrix to field number
+    _block_row_to_field_map = std::vector<local_index_type>(row_count);
+    _block_col_to_field_map = std::vector<local_index_type>(col_count);
+    row_count = 0;
+    col_count = 0;
+    for (local_index_type i=0; i<max_blocks; i++) {
+        if (_field_to_block_row_map[i] > -1) {
+            _block_row_to_field_map[row_count] = i;
+            row_count++;
+        }
+        if (_field_to_block_col_map[i] > -1) {
+            _block_col_to_field_map[col_count] = i;
+            col_count++;
+        }
+    }
 
     // now that we know actual # of blocks we can build a DOF data with the DOF manager
     // regenerate DOF information, because we have a local ordering specific to our field interactions
@@ -175,906 +179,926 @@ void ProblemExplicitTransientT::initialize() {
     row_map = std::vector<Teuchos::RCP<const map_type> > (row_count, Teuchos::null);
     col_map = std::vector<Teuchos::RCP<const map_type> > (col_count, Teuchos::null);
 
-	for (InteractingFields field_interaction : _field_interactions) {
-		buildMaps(field_interaction.src_fieldnum, field_interaction.trg_fieldnum);
-	}
+    for (InteractingFields field_interaction : _field_interactions) {
+        buildMaps(field_interaction.src_fieldnum, field_interaction.trg_fieldnum);
+    }
 
-//	// first is graph construction
-//	for (InteractingFields field_interaction : _field_interactions) {
-//		local_index_type field_one = field_interaction.src_fieldnum;
-//		local_index_type field_two = field_interaction.trg_fieldnum;
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(_OP.is_null(), "Physics not set before initialize() called.");
+    _OP->setParameters(*_parameters);
+    _OP->setDOFData(_problem_dof_data);
+
+    // generate all initial data needed for graphs and assembly
+    _OP->initialize();
+
+    //for (InteractingFields field_interaction : _field_interactions) {
+    //    local_index_type field_one = field_interaction.src_fieldnum;
+    //    local_index_type field_two = field_interaction.trg_fieldnum;
+
+    //    local_index_type row_block = _field_to_block_row_map[field_one];
+    //    local_index_type col_block = _field_to_block_col_map[field_two];
+
+    //    assembleOperator(field_one, field_two);
+    //    assembleBCS(field_one, field_two);
+    //    assembleRHS(field_one, field_two);
+    //    if (_A[row_block][col_block]->isFillActive()) {
+    //        _A[row_block][col_block]->fillComplete(_problem_dof_data->getRowMap(col_block), _problem_dof_data->getRowMap(row_block));
+    //    }
+    //}
+
+//    // first is graph construction
+//    for (InteractingFields field_interaction : _field_interactions) {
+//        local_index_type field_one = field_interaction.src_fieldnum;
+//        local_index_type field_two = field_interaction.trg_fieldnum;
 //
-//		local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-//		local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+//        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+//        local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
 //
-//		// build the graph
+//        // build the graph
 //
-//		this->buildGraphs(field_one, field_two);
+//        this->buildGraphs(field_one, field_two);
 //
-//		// complete each block after graph computed
-//		if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-//			A_graph[row_block][col_block]->fillComplete();
-//		}
-//	}
-//	if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==false) {
-//		A_graph[0][0]->fillComplete();
-//	}
+//        // complete each block after graph computed
+//        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+//            A_graph[row_block][col_block]->fillComplete();
+//        }
+//    }
+//    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==false) {
+//        A_graph[0][0]->fillComplete();
+//    }
 //
 //
-//	for (InteractingFields field_interaction : _field_interactions) {
-//		local_index_type field_one = field_interaction.src_fieldnum;
-//		local_index_type field_two = field_interaction.trg_fieldnum;
+//    for (InteractingFields field_interaction : _field_interactions) {
+//        local_index_type field_one = field_interaction.src_fieldnum;
+//        local_index_type field_two = field_interaction.trg_fieldnum;
 //
-//		local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-//		local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+//        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+//        local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
 //
-//		assembleBCS(field_one, field_two);
-//		assembleRHS(field_one, field_two);
-//		assembleOperatorToVector(field_one, field_two);
-////		if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-////			_A[row_block][col_block]->fillComplete();
-////		}
-//	}
-//	if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==false) {
-//		_A[0][0]->fillComplete();
-//	}
+//        assembleBCS(field_one, field_two);
+//        assembleRHS(field_one, field_two);
+//        assembleOperatorToVector(field_one, field_two);
+////        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+////            _A[row_block][col_block]->fillComplete();
+////        }
+//    }
+//    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==false) {
+//        _A[0][0]->fillComplete();
+//    }
 
 }
 
 void ProblemExplicitTransientT::solve(local_index_type rk_order, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename) {
 
-//	Compadre::ShallowWaterTestCases sw_function = Compadre::ShallowWaterTestCases(_parameters->get<int>("shallow water test case"), 0 /*alpha*/);
+//    Compadre::ShallowWaterTestCases sw_function = Compadre::ShallowWaterTestCases(_parameters->get<int>("shallow water test case"), 0 /*alpha*/);
 
-	// details for writing to files every nth timestep
-	Compadre::FileManager fm;
-	std::string base, extension;
+    // details for writing to files every nth timestep
+    Compadre::FileManager fm;
+    std::string base, extension;
 
-	if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") >= 0) {
-		// parse by removing extension of filename
+    if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") >= 0) {
+        // parse by removing extension of filename
 
-		// get extension
-		size_t pos = filename.rfind('.', filename.length());
+        // get extension
+        size_t pos = filename.rfind('.', filename.length());
 
-		// verify there was an extension extension
-		TEUCHOS_TEST_FOR_EXCEPT_MSG(pos <= 0, "Filename specified to solve(...) is missing an extension.");
+        // verify there was an extension extension
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(pos <= 0, "Filename specified to solve(...) is missing an extension.");
 
-		base = filename.substr(0, pos);
-		extension = filename.substr(pos+1, filename.length() - pos);
-	}
+        base = filename.substr(0, pos);
+        extension = filename.substr(pos+1, filename.length() - pos);
+    }
 
-	// dt given is a stable timestep, so any timestep adjustment must be equal to or smaller than this
+    // dt given is a stable timestep, so any timestep adjustment must be equal to or smaller than this
 
-	Teuchos::RCP<Teuchos::Time> RKSetupTime = Teuchos::TimeMonitor::getNewCounter ("RK Setup Time");
-	Teuchos::RCP<Teuchos::Time> RKAdvanceTime = Teuchos::TimeMonitor::getNewCounter ("RK Advance Time");
-	RKSetupTime->start();
-	// integrates using RK method
+    Teuchos::RCP<Teuchos::Time> RKSetupTime = Teuchos::TimeMonitor::getNewCounter ("RK Setup Time");
+    Teuchos::RCP<Teuchos::Time> RKAdvanceTime = Teuchos::TimeMonitor::getNewCounter ("RK Advance Time");
+    RKSetupTime->start();
+    // integrates using RK method
 
-	std::vector<scalar_type> c(rk_order);
-	std::vector<scalar_type> b(rk_order);
-	std::vector<std::vector<scalar_type> > a(rk_order, std::vector<scalar_type>(rk_order));
+    std::vector<scalar_type> c(rk_order);
+    std::vector<scalar_type> b(rk_order);
+    std::vector<std::vector<scalar_type> > a(rk_order, std::vector<scalar_type>(rk_order));
 
-	if (rk_order == 1) {
-		c[0] = 0;
-		b[0] = 1.;
-	} else if (rk_order == 2) {
-		c[0] = 0; c[1] = 0.5;
-		b[0] = 0; b[1] = 1.;
-		a[1][0] = 0.5;
-	} else if (rk_order == 3) {
-		c[0] = 0; c[1] = 1./3.; c[2] = 2./3.;
-		b[0] = 0.25; b[1] = 0; b[2] = 0.75;
-		a[1][0] = 1./3.;
-		a[2][1] = 2./3.;
-	} else if (rk_order == 4) {
-		c[0] = 0; c[1] = 0.5; c[2] = 0.5; c[3] = 1.0;
-		b[0] = 1./6.; b[1] = 1./3.; b[2] = 1./3.; b[3] = 1./6.;
-		a[1][0] = 0.5;
-		a[2][1] = 0.5;
-		a[3][2] = 1.0;
-	}
+    if (rk_order == 1) {
+        c[0] = 0;
+        b[0] = 1.;
+    } else if (rk_order == 2) {
+        c[0] = 0; c[1] = 0.5;
+        b[0] = 0; b[1] = 1.;
+        a[1][0] = 0.5;
+    } else if (rk_order == 3) {
+        c[0] = 0; c[1] = 1./3.; c[2] = 2./3.;
+        b[0] = 0.25; b[1] = 0; b[2] = 0.75;
+        a[1][0] = 1./3.;
+        a[2][1] = 2./3.;
+    } else if (rk_order == 4) {
+        c[0] = 0; c[1] = 0.5; c[2] = 0.5; c[3] = 1.0;
+        b[0] = 1./6.; b[1] = 1./3.; b[2] = 1./3.; b[3] = 1./6.;
+        a[1][0] = 0.5;
+        a[2][1] = 0.5;
+        a[3][2] = 1.0;
+    }
 
-//	local_index_type num_time_steps = std::ceil((t_end-t_0)/dt);
-//	dt = (t_end-t_0)/num_time_steps;
-	if (_particles->getCoordsConst()->getComm()->getRank()==0)
-		printf("solving beginning at t=%f and ending at te=%f with dt=%.16f\n", t_0, t_end, dt);
-//	printf(" with num time steps = %d\n", num_time_steps);
+//    local_index_type num_time_steps = std::ceil((t_end-t_0)/dt);
+//    dt = (t_end-t_0)/num_time_steps;
+    if (_particles->getCoordsConst()->getComm()->getRank()==0)
+        printf("solving beginning at t=%f and ending at te=%f with dt=%.16f\n", t_0, t_end, dt);
+//    printf(" with num time steps = %d\n", num_time_steps);
 
-	std::vector<Teuchos::RCP<mvec_type> > reference_solution(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
-	std::vector<Teuchos::RCP<mvec_type> > updated_solution(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
-	std::vector<Teuchos::RCP<mvec_type> > rk_offsets(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
+    std::vector<Teuchos::RCP<mvec_type> > reference_solution(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
+    std::vector<Teuchos::RCP<mvec_type> > updated_solution(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
+    std::vector<Teuchos::RCP<mvec_type> > rk_offsets(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
 
 
-	for (InteractingFields field_interaction : _field_interactions) {
+    for (InteractingFields field_interaction : _field_interactions) {
 
-		local_index_type field_one = field_interaction.src_fieldnum;
+        local_index_type field_one = field_interaction.src_fieldnum;
 
-		local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
 
-		// this allows us to overwrite the fields in _particles for each RK step and use
-		// existing tools to distribute halo data
-		// get all the vectors set up
-		if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-			if (reference_solution[row_block].is_null()) {
-				bool setToZero = true;
-				reference_solution[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
-				updated_solution[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
-				rk_offsets[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
-				// get solution from _particles and put it in reference_solution
-				_particles->getFieldManagerConst()->updateVectorFromFields(reference_solution[row_block], field_one, _problem_dof_data);
+        // this allows us to overwrite the fields in _particles for each RK step and use
+        // existing tools to distribute halo data
+        // get all the vectors set up
+        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+            if (reference_solution[row_block].is_null()) {
+                bool setToZero = true;
+                reference_solution[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+                updated_solution[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+                rk_offsets[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+                // get solution from _particles and put it in reference_solution
+                _particles->getFieldManagerConst()->updateVectorFromFields(reference_solution[row_block], field_one, _problem_dof_data);
 
-				// copy this to updated_solution so that it starts in the right place
-				host_view_type updated_data = updated_solution[row_block]->getLocalView<host_view_type>();
-				host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
-				host_view_type rk_offsets_data = rk_offsets[row_block]->getLocalView<host_view_type>();
-				for (size_t j=0; j<updated_data.extent(0); j++) {
-					updated_data(j,0) = reference_data(j,0);
-					rk_offsets_data(j,0) = reference_data(j,0);
-				}
-			}
-		} else {
-			bool setToZero = true;
-			reference_solution[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
-			updated_solution[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
-			rk_offsets[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
-			// get solution from _particles and put it in reference_solution
-			_particles->getFieldManagerConst()->updateVectorFromFields(reference_solution[0], -1, _problem_dof_data);
+                // copy this to updated_solution so that it starts in the right place
+                host_view_type updated_data = updated_solution[row_block]->getLocalView<host_view_type>();
+                host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
+                host_view_type rk_offsets_data = rk_offsets[row_block]->getLocalView<host_view_type>();
+                for (size_t j=0; j<updated_data.extent(0); j++) {
+                    updated_data(j,0) = reference_data(j,0);
+                    rk_offsets_data(j,0) = reference_data(j,0);
+                }
+            }
+        } else {
+            bool setToZero = true;
+            reference_solution[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
+            updated_solution[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
+            rk_offsets[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
+            // get solution from _particles and put it in reference_solution
+            _particles->getFieldManagerConst()->updateVectorFromFields(reference_solution[0], -1, _problem_dof_data);
 
-			// copy this to updated_solution so that it starts in the right place
-			host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
-			host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
-			host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
-			for (size_t j=0; j<updated_data.extent(0); j++) {
-				updated_data(j,0) = reference_data(j,0);
-				rk_offsets_data(j,0) = reference_data(j,0);
-			}
-			break;
-		}
-	}
+            // copy this to updated_solution so that it starts in the right place
+            host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
+            host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
+            host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
+            for (size_t j=0; j<updated_data.extent(0); j++) {
+                updated_data(j,0) = reference_data(j,0);
+                rk_offsets_data(j,0) = reference_data(j,0);
+            }
+            break;
+        }
+    }
 
-	RKSetupTime->stop();
+    RKSetupTime->stop();
 
-	// reference_solution now exists in multiple mvec_types
-	// we add RK offsets to this and then move onto _particles fields, which propagates
-	// the offset data onto halos, making it available on other processors
-	scalar_type t = t_0;
+    // reference_solution now exists in multiple mvec_types
+    // we add RK offsets to this and then move onto _particles fields, which propagates
+    // the offset data onto halos, making it available on other processors
+    scalar_type t = t_0;
 
-	local_index_type timestep_count = 0; // keeps track of how many timesteps computed
-	local_index_type write_count = 0; // keeps track of how many timesteps written
+    local_index_type timestep_count = 0; // keeps track of how many timesteps computed
+    local_index_type write_count = 0; // keeps track of how many timesteps written
 
-	while ( t < t_end && std::abs(t-t_end) >1e-15 ) {
-		scalar_type internal_dt = std::min(dt, t_end-t);
-//		dt = (dt > (t_end-t)) ? (t_end-t) : dt;
+    while ( t < t_end && std::abs(t-t_end) >1e-15 ) {
+        scalar_type internal_dt = std::min(dt, t_end-t);
+//        dt = (dt > (t_end-t)) ? (t_end-t) : dt;
 
-		for (local_index_type j=0; j<rk_order; ++j) {
+        for (local_index_type j=0; j<rk_order; ++j) {
 
-//			// TODO: temporary
-//			for (InteractingFields field_interaction : _field_interactions) {
-//				local_index_type field_one = field_interaction.src_fieldnum;
-//				local_index_type field_two = field_interaction.trg_fieldnum;
+//            // TODO: temporary
+//            for (InteractingFields field_interaction : _field_interactions) {
+//                local_index_type field_one = field_interaction.src_fieldnum;
+//                local_index_type field_two = field_interaction.trg_fieldnum;
 //
-//				local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-//				local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+//                local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+//                local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
 //
-//				// update _particles with reference data plus RK addition
-//				if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+//                // update _particles with reference data plus RK addition
+//                if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
 //
-//					// block reference solution plus offset
-//					host_view_type rk_offsets_data = rk_offsets[row_block]->getLocalView<host_view_type>();
-////					host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
-////					host_view_type updated_data = updated_solution[row_block]->getLocalView<host_view_type>();
-////					host_view_type step_data = _b[row_block]->getLocalView<host_view_type>();
+//                    // block reference solution plus offset
+//                    host_view_type rk_offsets_data = rk_offsets[row_block]->getLocalView<host_view_type>();
+////                    host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
+////                    host_view_type updated_data = updated_solution[row_block]->getLocalView<host_view_type>();
+////                    host_view_type step_data = _b[row_block]->getLocalView<host_view_type>();
 //
-//					// beginning of first stage
-//					if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("velocity")) {
+//                    // beginning of first stage
+//                    if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("velocity")) {
 //
-//						// TODO remove this
-//						// test by replacing solution with analytical at each updated point
-//						_particles->getFieldManager()->getFieldByName("velocity")->
-//								localInitFromVectorFunction(&sw_function);
-//						const mvec_type* velocity_ptr = _particles->getFieldManager()->getFieldByName("velocity")->
-//								getMultiVectorPtrConst();
-//						host_view_type velocity_data = velocity_ptr->getLocalView<host_view_type>();
+//                        // TODO remove this
+//                        // test by replacing solution with analytical at each updated point
+//                        _particles->getFieldManager()->getFieldByName("velocity")->
+//                                localInitFromVectorFunction(&sw_function);
+//                        const mvec_type* velocity_ptr = _particles->getFieldManager()->getFieldByName("velocity")->
+//                                getMultiVectorPtrConst();
+//                        host_view_type velocity_data = velocity_ptr->getLocalView<host_view_type>();
 //
-//						const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-//								this->_particles->getDOFManagerConst()->getDOFMap();
+//                        const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
+//                                this->_particles->getDOFManagerConst()->getDOFMap();
 //
-//						for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
-//							for (local_index_type l=0; l<3; ++l) {
-//								local_index_type vdof = local_to_dof_map[k][field_one][l];
-////								reference_data(vdof,0) = velocity_data(k,l);
-//								rk_offsets_data(vdof,0) = velocity_data(k,l);
-////								updated_data(vdof,0) = velocity_data(k,l);
-//							}
-//						}
-//					}
-//				}
-//			}
+//                        for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
+//                            for (local_index_type l=0; l<3; ++l) {
+//                                local_index_type vdof = local_to_dof_map[k][field_one][l];
+////                                reference_data(vdof,0) = velocity_data(k,l);
+//                                rk_offsets_data(vdof,0) = velocity_data(k,l);
+////                                updated_data(vdof,0) = velocity_data(k,l);
+//                            }
+//                        }
+//                    }
+//                }
+//            }
 
-			//if (_particles->getCoordsConst()->isLagrangian()) {
-			//	// TODO remove this
-			//	// test by replacing solution with analytical at each updated point
-			//	_particles->getFieldManager()->getFieldByName("velocity")->
-			//			localInitFromVectorFunction(&sw_function);
+            //if (_particles->getCoordsConst()->isLagrangian()) {
+            //    // TODO remove this
+            //    // test by replacing solution with analytical at each updated point
+            //    _particles->getFieldManager()->getFieldByName("velocity")->
+            //            localInitFromVectorFunction(&sw_function);
 
-//			//	// TODO: here is where we advance the coordinates based on field values for displacement
+//            //    // TODO: here is where we advance the coordinates based on field values for displacement
 //
-//			//	_particles->getFieldManager()->getFieldByName("reference velocity")->
-//			//			localInitFromVectorFunction(&sw_function);
-//			//	_particles->getCoords()->
-////			//			deltaUpdatePhysicalCoordsFromVectorByTimestep(c[j]*internal_dt,
-//			//					deltaUpdatePhysicalCoordsFromVectorByTimestep(internal_dt,
-//			//					_particles->getFieldManagerConst()->getFieldByName("velocity")->getMultiVectorPtrConst());
+//            //    _particles->getFieldManager()->getFieldByName("reference velocity")->
+//            //            localInitFromVectorFunction(&sw_function);
+//            //    _particles->getCoords()->
+////            //            deltaUpdatePhysicalCoordsFromVectorByTimestep(c[j]*internal_dt,
+//            //                    deltaUpdatePhysicalCoordsFromVectorByTimestep(internal_dt,
+//            //                    _particles->getFieldManagerConst()->getFieldByName("velocity")->getMultiVectorPtrConst());
 
 
-			//	_particles->getCoords()->updatePhysicalCoordinatesFromFieldData(_particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst(), c[j]*internal_dt);
+            //    _particles->getCoords()->updatePhysicalCoordinatesFromFieldData(_particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst(), c[j]*internal_dt);
 
-			//}
+            //}
 
-			// build the rk_offsets vector and put it in _particles
-			for (InteractingFields field_interaction : _field_interactions) {
-				local_index_type field_one = field_interaction.src_fieldnum;
+            // build the rk_offsets vector and put it in _particles
+            for (InteractingFields field_interaction : _field_interactions) {
+                local_index_type field_one = field_interaction.src_fieldnum;
 
-				local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+                local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
 
-				// update _particles with reference data plus RK addition
-				if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+                // update _particles with reference data plus RK addition
+                if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
 
-					_particles->getFieldManager()->updateFieldsFromVector(rk_offsets[row_block], field_one, _problem_dof_data);
+                    _particles->getFieldManager()->updateFieldsFromVector(rk_offsets[row_block], field_one, _problem_dof_data);
 
-				} else {
+                } else {
 
-					_particles->getFieldManager()->updateFieldsFromVector(rk_offsets[0], field_one, _problem_dof_data);
+                    _particles->getFieldManager()->updateFieldsFromVector(rk_offsets[0], field_one, _problem_dof_data);
 
-				}
-			}
+                }
+            }
 
-			// refresh fields' halo data
-			_particles->getFieldManager()->updateFieldsHaloData();
+            // refresh fields' halo data
+            _particles->getFieldManager()->updateFieldsHaloData();
 
 
-			if (_particles->getCoordsConst()->isLagrangian()) {
+            if (_particles->getCoordsConst()->isLagrangian()) {
 //
-				_particles->updatePhysicalCoordinatesFromField("displacement");
+                _particles->updatePhysicalCoordinatesFromField("displacement");
 //
-			}
+            }
 
-			RKAdvanceTime->start();
-			// continuation of finding this stages answer
-			// a different for loop than the last section because all rk_offsets for all blocks
-			// must be calculated before computing any field's contributions
-			for (InteractingFields field_interaction : _field_interactions) {
+            RKAdvanceTime->start();
 
-				local_index_type field_one = field_interaction.src_fieldnum;
-				local_index_type field_two = field_interaction.trg_fieldnum;
+            // print ordering of field interactions with their operations
+            //for (InteractingFields& fi : _field_interactions) {
+            //    std::sort(fi.ops_needing.begin(), fi.ops_needing.end());
+            //    printf("fieldnum: %d, ops_needing size: %d\n", fi.src_fieldnum, fi.ops_needing.size());
+            //    for (auto op : fi.ops_needing) {
+            //        printf("fieldnum: %d, ops_needing: %d\n", fi.src_fieldnum, op);
+            //    }
+            //}
+            
+            // continuation of finding this stages answer
+            // a different for loop than the last section because all rk_offsets for all blocks
+            // must be calculated before computing any field's contributions
+            for (InteractingFields field_interaction : _field_interactions) {
 
-				for (op_needing_interaction op : field_interaction.ops_needing) {
-					// (all store into _b), so _b holds stage solution
-					if (op == op_needing_interaction::bc)
-						assembleBCS(field_one, field_two, t + c[j]*internal_dt, internal_dt);
-					else if (op == op_needing_interaction::source)
-						assembleRHS(field_one, field_two, t + c[j]*internal_dt, internal_dt);
-					else if (op == op_needing_interaction::physics)
-						assembleOperatorToVector(field_one, field_two, t + c[j]*internal_dt, internal_dt);
-				}
-			}
+                local_index_type field_one = field_interaction.src_fieldnum;
+                local_index_type field_two = field_interaction.trg_fieldnum;
 
-			if (_particles->getCoordsConst()->isLagrangian()) {
-////				// undoing moving the particles
-////				_particles->getCoords()->
-//////						deltaUpdatePhysicalCoordsFromVectorByTimestep(-c[j]*internal_dt,
-////								deltaUpdatePhysicalCoordsFromVectorByTimestep(-internal_dt,
-////											_particles->getFieldManagerConst()->getFieldByName("velocity")->getMultiVectorPtrConst());
+                for (op_needing_interaction op : field_interaction.ops_needing) {
+                    // (all store into _b), so _b holds stage solution
+                    if (op == op_needing_interaction::bc) {
+                        assembleBCS(field_one, field_two, t + c[j]*internal_dt, internal_dt);
+                    }
+                    else if (op == op_needing_interaction::source) {
+                        assembleRHS(field_one, field_two, t + c[j]*internal_dt, internal_dt);
+                    }
+                    else if (op == op_needing_interaction::physics) {
+                        assembleOperatorToVector(field_one, field_two, t + c[j]*internal_dt, internal_dt);
+                    }
+                }
+            }
+
+            if (_particles->getCoordsConst()->isLagrangian()) {
+////                // undoing moving the particles
+////                _particles->getCoords()->
+//////                        deltaUpdatePhysicalCoordsFromVectorByTimestep(-c[j]*internal_dt,
+////                                deltaUpdatePhysicalCoordsFromVectorByTimestep(-internal_dt,
+////                                            _particles->getFieldManagerConst()->getFieldByName("velocity")->getMultiVectorPtrConst());
 //
-				_particles->updatePhysicalCoordinatesFromField("displacement", -1);
+                _particles->updatePhysicalCoordinatesFromField("displacement", -1);
 //
-////				_particles->getCoords()->updatePhysicalCoordinatesFromFieldData(_particles->getFieldManager()->getFieldByName("reference velocity")->getMultiVectorPtrConst(), -c[j]*internal_dt);
-			}
+////                _particles->getCoords()->updatePhysicalCoordinatesFromFieldData(_particles->getFieldManager()->getFieldByName("reference velocity")->getMultiVectorPtrConst(), -c[j]*internal_dt);
+            }
 //
-//			if (_particles->getCoordsConst()->isLagrangian()) {
-//				// TODO remove this
-//				// test by replacing solution with analytical at each updated point
-//				_particles->getFieldManager()->getFieldByName("velocity")->
-//						localInitFromVectorFunction(&sw_function);
+//            if (_particles->getCoordsConst()->isLagrangian()) {
+//                // TODO remove this
+//                // test by replacing solution with analytical at each updated point
+//                _particles->getFieldManager()->getFieldByName("velocity")->
+//                        localInitFromVectorFunction(&sw_function);
 //
-////				// TODO: here is where we advance the coordinates based on field values for displacement
+////                // TODO: here is where we advance the coordinates based on field values for displacement
 ////
-////				_particles->getFieldManager()->getFieldByName("reference velocity")->
-////						localInitFromVectorFunction(&sw_function);
-////				_particles->getCoords()->
-//////						deltaUpdatePhysicalCoordsFromVectorByTimestep(c[j]*internal_dt,
-////								deltaUpdatePhysicalCoordsFromVectorByTimestep(internal_dt,
-////								_particles->getFieldManagerConst()->getFieldByName("velocity")->getMultiVectorPtrConst());
+////                _particles->getFieldManager()->getFieldByName("reference velocity")->
+////                        localInitFromVectorFunction(&sw_function);
+////                _particles->getCoords()->
+//////                        deltaUpdatePhysicalCoordsFromVectorByTimestep(c[j]*internal_dt,
+////                                deltaUpdatePhysicalCoordsFromVectorByTimestep(internal_dt,
+////                                _particles->getFieldManagerConst()->getFieldByName("velocity")->getMultiVectorPtrConst());
 //
 //
-//				_particles->getCoords()->updatePhysicalCoordinatesFromFieldData(_particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst(), -c[j]*internal_dt);
+//                _particles->getCoords()->updatePhysicalCoordinatesFromFieldData(_particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst(), -c[j]*internal_dt);
 //
-//			}
+//            }
 
-			// Use this stages solution to update the update solution and also to update the rk_offsets vector
-			// step contribution k_i is in _b
-			for (InteractingFields field_interaction : _field_interactions) {
+            // Use this stages solution to update the update solution and also to update the rk_offsets vector
+            // step contribution k_i is in _b
+            for (InteractingFields field_interaction : _field_interactions) {
 
-				local_index_type field_one = field_interaction.src_fieldnum;
+                local_index_type field_one = field_interaction.src_fieldnum;
 
-				local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+                local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
 
-				// update _particles with reference data plus RK addition
-				if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+                // update _particles with reference data plus RK addition
+                if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
 
-					// block reference solution plus offset
-					host_view_type rk_offsets_data = rk_offsets[row_block]->getLocalView<host_view_type>();
-					host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
-					host_view_type updated_data = updated_solution[row_block]->getLocalView<host_view_type>();
-					host_view_type step_data = _b[row_block]->getLocalView<host_view_type>();
+                    // block reference solution plus offset
+                    host_view_type rk_offsets_data = rk_offsets[row_block]->getLocalView<host_view_type>();
+                    host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
+                    host_view_type updated_data = updated_solution[row_block]->getLocalView<host_view_type>();
+                    host_view_type step_data = _b[row_block]->getLocalView<host_view_type>();
 
-					for (size_t k=0; k<rk_offsets_data.extent(0); ++k) {
-						rk_offsets_data(k,0) = reference_data(k,0);
-						if (j<(rk_order-1))
-							rk_offsets_data(k,0) += internal_dt * a[j+1][j] * step_data(k,0); // previous steps contribution
+                    for (size_t k=0; k<rk_offsets_data.extent(0); ++k) {
+                        rk_offsets_data(k,0) = reference_data(k,0);
+                        if (j<(rk_order-1))
+                            rk_offsets_data(k,0) += internal_dt * a[j+1][j] * step_data(k,0); // previous steps contribution
 
-						updated_data(k,0) += internal_dt * b[j] * step_data(k,0);
-						step_data(k,0) = 0;
-					}
-				} else {
-					// reference solution plus offset
-					host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
-					host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
-					host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
-					host_view_type step_data = _b[0]->getLocalView<host_view_type>();
+                        updated_data(k,0) += internal_dt * b[j] * step_data(k,0);
+                        step_data(k,0) = 0;
+                    }
+                } else {
+                    // reference solution plus offset
+                    host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
+                    host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
+                    host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
+                    host_view_type step_data = _b[0]->getLocalView<host_view_type>();
 
-					for (size_t k=0; k<rk_offsets_data.extent(0); ++k) {
-						rk_offsets_data(k,0) = reference_data(k,0);
-						if (j<(rk_order-1))
-							rk_offsets_data(k,0) += internal_dt * a[j+1][j] * step_data(k,0); // previous steps contribution
+                    for (size_t k=0; k<rk_offsets_data.extent(0); ++k) {
+                        rk_offsets_data(k,0) = reference_data(k,0);
+                        if (j<(rk_order-1))
+                            rk_offsets_data(k,0) += internal_dt * a[j+1][j] * step_data(k,0); // previous steps contribution
 
-						updated_data(k,0) += internal_dt * b[j] * step_data(k,0);
-						step_data(k,0) = 0;
-					}
-					break;
-				}
-			}
-			RKAdvanceTime->stop();
-		}
+                        updated_data(k,0) += internal_dt * b[j] * step_data(k,0);
+                        step_data(k,0) = 0;
+                    }
+                    break;
+                }
+            }
+            RKAdvanceTime->stop();
+        }
 
-		// update the reference solution for beginning the next time step
-		for (InteractingFields field_interaction : _field_interactions) {
+        // update the reference solution for beginning the next time step
+        for (InteractingFields field_interaction : _field_interactions) {
 
-			local_index_type field_one = field_interaction.src_fieldnum;
+            local_index_type field_one = field_interaction.src_fieldnum;
 
-			local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+            local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
 
-//			if (_particles->getCoordsConst()->getComm()->getRank()==0)
-//				printf("field one: %d at timestep %d\n", field_one, timestep_count);
-			if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-				// copy this to updated_solution so that it starts in the right place
-				host_view_type updated_data = updated_solution[row_block]->getLocalView<host_view_type>();
-				host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
-				host_view_type rk_offsets_data = rk_offsets[row_block]->getLocalView<host_view_type>();
-				for (size_t k=0; k<updated_data.extent(0); ++k) {
-					reference_data(k,0) = updated_data(k,0);
-					rk_offsets_data(k,0) = updated_data(k,0);
-				}
+//            if (_particles->getCoordsConst()->getComm()->getRank()==0)
+//                printf("field one: %d at timestep %d\n", field_one, timestep_count);
+            if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+                // copy this to updated_solution so that it starts in the right place
+                host_view_type updated_data = updated_solution[row_block]->getLocalView<host_view_type>();
+                host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
+                host_view_type rk_offsets_data = rk_offsets[row_block]->getLocalView<host_view_type>();
+                for (size_t k=0; k<updated_data.extent(0); ++k) {
+                    reference_data(k,0) = updated_data(k,0);
+                    rk_offsets_data(k,0) = updated_data(k,0);
+                }
 
-//					if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("velocity")) {
+//                    if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("velocity")) {
 //
-//						// TODO remove this
-//						// test by replacing solution with analytical at each updated point
-//						_particles->getFieldManager()->getFieldByName("velocity")->
-//								localInitFromVectorFunction(&sw_function);
-//						const mvec_type* velocity_ptr = _particles->getFieldManager()->getFieldByName("velocity")->
-//								getMultiVectorPtrConst();
-//						host_view_type velocity_data = velocity_ptr->getLocalView<host_view_type>();
+//                        // TODO remove this
+//                        // test by replacing solution with analytical at each updated point
+//                        _particles->getFieldManager()->getFieldByName("velocity")->
+//                                localInitFromVectorFunction(&sw_function);
+//                        const mvec_type* velocity_ptr = _particles->getFieldManager()->getFieldByName("velocity")->
+//                                getMultiVectorPtrConst();
+//                        host_view_type velocity_data = velocity_ptr->getLocalView<host_view_type>();
 //
-//						const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-//								this->_particles->getDOFManagerConst()->getDOFMap();
+//                        const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
+//                                this->_particles->getDOFManagerConst()->getDOFMap();
 //
-//						for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
-//							for (local_index_type l=0; l<3; ++l) {
-//								local_index_type vdof = local_to_dof_map[k][field_one][l];
-//								reference_data(vdof,0) = velocity_data(k,l);
-//								rk_offsets_data(vdof,0) = velocity_data(k,l);
-//								updated_data(vdof,0) = velocity_data(k,l);
-//							}
-//						}
-//					}
-//					if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("height")) {
+//                        for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
+//                            for (local_index_type l=0; l<3; ++l) {
+//                                local_index_type vdof = local_to_dof_map[k][field_one][l];
+//                                reference_data(vdof,0) = velocity_data(k,l);
+//                                rk_offsets_data(vdof,0) = velocity_data(k,l);
+//                                updated_data(vdof,0) = velocity_data(k,l);
+//                            }
+//                        }
+//                    }
+//                    if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("height")) {
 //
-//						// TODO remove this
-//						// test by replacing solution with analytical at each updated point
-//						_particles->getFieldManager()->getFieldByName("height")->
-//								localInitFromScalarFunction(&sw_function);
-//						_particles->getFieldManager()->getFieldByName("height")->
-//								scale(1./sw_function.getGravity());
-//						const mvec_type* height_ptr = _particles->getFieldManager()->getFieldByName("height")->
-//								getMultiVectorPtrConst();
-//						host_view_type height_data = height_ptr->getLocalView<host_view_type>();
+//                        // TODO remove this
+//                        // test by replacing solution with analytical at each updated point
+//                        _particles->getFieldManager()->getFieldByName("height")->
+//                                localInitFromScalarFunction(&sw_function);
+//                        _particles->getFieldManager()->getFieldByName("height")->
+//                                scale(1./sw_function.getGravity());
+//                        const mvec_type* height_ptr = _particles->getFieldManager()->getFieldByName("height")->
+//                                getMultiVectorPtrConst();
+//                        host_view_type height_data = height_ptr->getLocalView<host_view_type>();
 //
-//						const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
-//								this->_particles->getDOFManagerConst()->getDOFMap();
+//                        const std::vector<std::vector<std::vector<local_index_type> > >& local_to_dof_map =
+//                                this->_particles->getDOFManagerConst()->getDOFMap();
 //
-//						for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
-//							for (local_index_type l=0; l<1; ++l) {
-//								local_index_type vdof = local_to_dof_map[k][field_one][l];
-//								reference_data(vdof,0) = height_data(k,l);
-//								rk_offsets_data(vdof,0) = height_data(k,l);
-//								updated_data(vdof,0) = height_data(k,l);
-//							}
-//						}
-//					}
-			} else {
-				// copy this to updated_solution so that it starts in the right place
-				host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
-				host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
-				host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
-				for (size_t k=0; k<updated_data.extent(0); ++k) {
-					reference_data(k,0) = updated_data(k,0);
-					rk_offsets_data(k,0) = updated_data(k,0);
-				}
-				break;
-			}
-		}
+//                        for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
+//                            for (local_index_type l=0; l<1; ++l) {
+//                                local_index_type vdof = local_to_dof_map[k][field_one][l];
+//                                reference_data(vdof,0) = height_data(k,l);
+//                                rk_offsets_data(vdof,0) = height_data(k,l);
+//                                updated_data(vdof,0) = height_data(k,l);
+//                            }
+//                        }
+//                    }
+            } else {
+                // copy this to updated_solution so that it starts in the right place
+                host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
+                host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
+                host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
+                for (size_t k=0; k<updated_data.extent(0); ++k) {
+                    reference_data(k,0) = updated_data(k,0);
+                    rk_offsets_data(k,0) = updated_data(k,0);
+                }
+                break;
+            }
+        }
 
-		t += internal_dt; // advance the time
-		timestep_count++;
+        t += internal_dt; // advance the time
+        timestep_count++;
 
-		bool displacement_data_moved_to_fields = false;
-		if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") > 0) {
+        bool displacement_data_moved_to_fields = false;
+        if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") > 0) {
 
-			// check if this is a timestep to write at
-			if (timestep_count % _parameters->get<Teuchos::ParameterList>("io").get<int>("write every") == 0) {
-				write_count++;
+            // check if this is a timestep to write at
+            if (timestep_count % _parameters->get<Teuchos::ParameterList>("io").get<int>("write every") == 0) {
+                write_count++;
 
-				// add in the write_count
-				filename = _parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file prefix") + base + "_" + std::to_string(write_count) + "." + extension;
+                // add in the write_count
+                filename = _parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file prefix") + base + "_" + std::to_string(write_count) + "." + extension;
 
-				fm.setWriter(filename, _particles);
-				if (_comm->getRank()==0)
-					std::cout << "Wrote " << filename << " to disk." << std::endl;
-
-
-				// requires mapping solution back in order to write particles to disk
-
-				// get solution back from vector onto particles (only at last time step)
-				for (InteractingFields field_interaction : _field_interactions) {
-
-					local_index_type field_one = field_interaction.src_fieldnum;
-
-					local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-
-					if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-						_particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one, _problem_dof_data);
-					} else {
-						_particles->getFieldManager()->updateFieldsFromVector(reference_solution[0], field_one, _problem_dof_data);
-					}
-				}
-
-				fm.write();
-				displacement_data_moved_to_fields = true;
-			}
-		}
-
-		if (!displacement_data_moved_to_fields && _particles->getCoordsConst()->isLagrangian()) {
-			// need to update displacements from vector to fields, but this has not
-			// already been performed by the writer
-
-			for (InteractingFields field_interaction : _field_interactions) {
-
-				local_index_type field_one = field_interaction.src_fieldnum;
-
-				// only update displacements from the rk solution
-				if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("displacement")) {
-
-					local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-
-					if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-						_particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one, _problem_dof_data);
-					} else {
-						_particles->getFieldManager()->updateFieldsFromVector(reference_solution[0], field_one, _problem_dof_data);
-					}
-
-					displacement_data_moved_to_fields = true;
-				}
-			}
-		}
+                fm.setWriter(filename, _particles);
+                if (_comm->getRank()==0)
+                    std::cout << "Wrote " << filename << " to disk." << std::endl;
 
 
-//		// TODO: just for diagnostics
-//		_particles->getFieldManager()->getFieldByName("reference velocity")->
-//				localInitFromVectorFunction(&sw_function);
-////	 		_particles->getFieldManager()->createField(1, "reference height", "m");
-//		_particles->getFieldManager()->getFieldByName("reference height")->
-//				localInitFromScalarFunction(&sw_function);
-//		_particles->getFieldManager()->getFieldByName("reference height")->
-//				scale(1./sw_function.getGravity());
+                // requires mapping solution back in order to write particles to disk
 
-		// refresh fields' halo data
-		_particles->getFieldManager()->updateFieldsHaloData();
+                // get solution back from vector onto particles (only at last time step)
+                for (InteractingFields field_interaction : _field_interactions) {
 
-		// increment the physical coordinates by the displacement field
-		if (_particles->getCoordsConst()->isLagrangian()) {
-			TEUCHOS_TEST_FOR_EXCEPT_MSG(displacement_data_moved_to_fields==false,
-					"Displacement data not updated in particles before up of coordinates.");
+                    local_index_type field_one = field_interaction.src_fieldnum;
 
-			//_particles->getCoords()->updatePhysicalCoordinatesFromFieldData(_particles->getFieldManager()->getFieldByName("reference velocity")->getMultiVectorPtrConst(), internal_dt);
+                    local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
 
-//			double scaling = 1./100.;
-//			_particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtr()->scale(scaling);
+                    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+                        _particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one, _problem_dof_data);
+                    } else {
+                        _particles->getFieldManager()->updateFieldsFromVector(reference_solution[0], field_one, _problem_dof_data);
+                    }
+                }
+
+                fm.write();
+                displacement_data_moved_to_fields = true;
+            }
+        }
+
+        if (!displacement_data_moved_to_fields && _particles->getCoordsConst()->isLagrangian()) {
+            // need to update displacements from vector to fields, but this has not
+            // already been performed by the writer
+
+            for (InteractingFields field_interaction : _field_interactions) {
+
+                local_index_type field_one = field_interaction.src_fieldnum;
+
+                // only update displacements from the rk solution
+                if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("displacement")) {
+
+                    local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+
+                    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+                        _particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one, _problem_dof_data);
+                    } else {
+                        _particles->getFieldManager()->updateFieldsFromVector(reference_solution[0], field_one, _problem_dof_data);
+                    }
+
+                    displacement_data_moved_to_fields = true;
+                }
+            }
+        }
+
+
+//        // TODO: just for diagnostics
+//        _particles->getFieldManager()->getFieldByName("reference velocity")->
+//                localInitFromVectorFunction(&sw_function);
+////             _particles->getFieldManager()->createField(1, "reference height", "m");
+//        _particles->getFieldManager()->getFieldByName("reference height")->
+//                localInitFromScalarFunction(&sw_function);
+//        _particles->getFieldManager()->getFieldByName("reference height")->
+//                scale(1./sw_function.getGravity());
+
+        // refresh fields' halo data
+        _particles->getFieldManager()->updateFieldsHaloData();
+
+        // increment the physical coordinates by the displacement field
+        if (_particles->getCoordsConst()->isLagrangian()) {
+            TEUCHOS_TEST_FOR_EXCEPT_MSG(displacement_data_moved_to_fields==false,
+                    "Displacement data not updated in particles before up of coordinates.");
+
+            //_particles->getCoords()->updatePhysicalCoordinatesFromFieldData(_particles->getFieldManager()->getFieldByName("reference velocity")->getMultiVectorPtrConst(), internal_dt);
+
+//            double scaling = 1./100.;
+//            _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtr()->scale(scaling);
 //
-//			for (int mm=0; mm<100; ++mm) {
-//				_particles->updatePhysicalCoordinatesFromField("displacement");
-////				_particles->getCoords()->snapToSphere(sw_function.getRadius());
-//			}
+//            for (int mm=0; mm<100; ++mm) {
+//                _particles->updatePhysicalCoordinatesFromField("displacement");
+////                _particles->getCoords()->snapToSphere(sw_function.getRadius());
+//            }
 
-			_particles->updatePhysicalCoordinatesFromField("displacement");
-//			_particles->getCoords()->snapToSphere(sw_function.getRadius());
-//			const mvec_type* velocity_ptr = _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst();
-//			host_view_type velocity_data = velocity_ptr->getLocalView<host_view_type>();
-//			host_view_type coords_data = _particles->getCoords()->getPts(false, true)->getLocalView<host_view_type>();
+            _particles->updatePhysicalCoordinatesFromField("displacement");
+//            _particles->getCoords()->snapToSphere(sw_function.getRadius());
+//            const mvec_type* velocity_ptr = _particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst();
+//            host_view_type velocity_data = velocity_ptr->getLocalView<host_view_type>();
+//            host_view_type coords_data = _particles->getCoords()->getPts(false, true)->getLocalView<host_view_type>();
 //
-//			Compadre::CangaSphereTransform sphere_transform(false);
+//            Compadre::CangaSphereTransform sphere_transform(false);
 //
-//			for (int m=0; m<_particles->getCoordsConst()->nLocal(); ++m) {
-//				Compadre::XyzVector xIn = _particles->getCoords()->getLocalCoords(m, false, true);
+//            for (int m=0; m<_particles->getCoordsConst()->nLocal(); ++m) {
+//                Compadre::XyzVector xIn = _particles->getCoords()->getLocalCoords(m, false, true);
 //
-//				const scalar_type lat = xIn.latitude(); // phi
-//				const scalar_type lon = xIn.longitude(); // lambda
-//				const scalar_type alpha = 0;
+//                const scalar_type lat = xIn.latitude(); // phi
+//                const scalar_type lon = xIn.longitude(); // lambda
+//                const scalar_type alpha = 0;
 //
-//				Teuchos::SerialDenseMatrix<int,double> Q(3,2);
-//				Teuchos::SerialDenseMatrix<int,double> NormalQ(2,2);
-//				Teuchos::SerialDenseMatrix<int,double> solution(2,1);
-//				Teuchos::SerialDenseMatrix<int,double> rhs(3,1);
-//				Teuchos::SerialDenseMatrix<int,double> NormalRhs(2,1);
+//                Teuchos::SerialDenseMatrix<int,double> Q(3,2);
+//                Teuchos::SerialDenseMatrix<int,double> NormalQ(2,2);
+//                Teuchos::SerialDenseMatrix<int,double> solution(2,1);
+//                Teuchos::SerialDenseMatrix<int,double> rhs(3,1);
+//                Teuchos::SerialDenseMatrix<int,double> NormalRhs(2,1);
 //
-//				Q(0,0) = -std::sin(lon); Q(0,1) = - std::sin(lat) * std::cos(lon);
-//				Q(1,0) = std::cos(lon);  Q(1,1) = - std::sin(lat) * std::sin(lon);
-//				Q(2,0) = 0;              Q(2,1) = std::cos(lat);
+//                Q(0,0) = -std::sin(lon); Q(0,1) = - std::sin(lat) * std::cos(lon);
+//                Q(1,0) = std::cos(lon);  Q(1,1) = - std::sin(lat) * std::sin(lon);
+//                Q(2,0) = 0;              Q(2,1) = std::cos(lat);
 //
-//				rhs(0,0) = velocity_data(m, 0);
-//				rhs(1,0) = velocity_data(m, 1);
-//				rhs(2,0) = velocity_data(m, 2);
+//                rhs(0,0) = velocity_data(m, 0);
+//                rhs(1,0) = velocity_data(m, 1);
+//                rhs(2,0) = velocity_data(m, 2);
 //
-//				NormalQ.multiply((Teuchos::ETransp)1,(Teuchos::ETransp)0,1,Q,Q,0);
-//				NormalRhs.multiply((Teuchos::ETransp)1,(Teuchos::ETransp)0,1,Q,rhs,0);
+//                NormalQ.multiply((Teuchos::ETransp)1,(Teuchos::ETransp)0,1,Q,Q,0);
+//                NormalRhs.multiply((Teuchos::ETransp)1,(Teuchos::ETransp)0,1,Q,rhs,0);
 //
-//				// invert the matrix
-//				Teuchos::SerialDenseSolver<int,double> solver;
-//				solver.setMatrix( Teuchos::rcp( &NormalQ , false ) );
-//				solver.setVectors( Teuchos::rcp( &solution, false ), Teuchos::rcp( &NormalRhs, false ) );
-//				solver.solve();
+//                // invert the matrix
+//                Teuchos::SerialDenseSolver<int,double> solver;
+//                solver.setMatrix( Teuchos::rcp( &NormalQ , false ) );
+//                solver.setVectors( Teuchos::rcp( &solution, false ), Teuchos::rcp( &NormalRhs, false ) );
+//                solver.solve();
 //
 ////
-////				const scalar_type U = _u0*(std::cos(lat)*std::cos(_alpha) +  std::cos(lon)*std::sin(lat)*std::sin(_alpha));
-////				const scalar_type V = -_u0*std::sin(lon)*std::sin(_alpha);
+////                const scalar_type U = _u0*(std::cos(lat)*std::cos(_alpha) +  std::cos(lon)*std::sin(lat)*std::sin(_alpha));
+////                const scalar_type V = -_u0*std::sin(lon)*std::sin(_alpha);
 ////
-////			    return xyz_type( -U * std::sin(lon) - V * std::sin(lat) * std::cos(lon),
-////			    					U * std::cos(lon) - V * std::sin(lat) * std::sin(lon),
-////									V * std::cos(lat) )
+////                return xyz_type( -U * std::sin(lon) - V * std::sin(lat) * std::cos(lon),
+////                                    U * std::cos(lon) - V * std::sin(lat) * std::sin(lon),
+////                                    V * std::cos(lat) )
 //
-//				double u_velocity = solution(0,0); // velocity with respect to lat and lon
-//				double v_velocity = solution(1,0);
+//                double u_velocity = solution(0,0); // velocity with respect to lat and lon
+//                double v_velocity = solution(1,0);
 //
-//				printf("u velocity %f\n", u_velocity);
-//				printf("v velocity %f\n", v_velocity);
+//                printf("u velocity %f\n", u_velocity);
+//                printf("v velocity %f\n", v_velocity);
 //
-//				const scalar_type new_lat = lat + internal_dt*u_velocity; // phi
-//				const scalar_type new_lon = lon + internal_dt*v_velocity; // lambda
+//                const scalar_type new_lat = lat + internal_dt*u_velocity; // phi
+//                const scalar_type new_lon = lon + internal_dt*v_velocity; // lambda
 //
-//				Compadre::XyzVector lat_lon_in(new_lat, new_lon, 0);
-//				Compadre::XyzVector transformed_lat_lon = sphere_transform.evalVector(lat_lon_in);
+//                Compadre::XyzVector lat_lon_in(new_lat, new_lon, 0);
+//                Compadre::XyzVector transformed_lat_lon = sphere_transform.evalVector(lat_lon_in);
 //
-//				scalar_type coord_norm = std::sqrt(transformed_lat_lon.x*transformed_lat_lon.x + transformed_lat_lon.y*transformed_lat_lon.y + transformed_lat_lon.z*transformed_lat_lon.z);
+//                scalar_type coord_norm = std::sqrt(transformed_lat_lon.x*transformed_lat_lon.x + transformed_lat_lon.y*transformed_lat_lon.y + transformed_lat_lon.z*transformed_lat_lon.z);
 //
-//				transformed_lat_lon.x *= sw_function.getRadius()*coord_norm;
-//				transformed_lat_lon.y *= sw_function.getRadius()*coord_norm;
-//				transformed_lat_lon.z *= sw_function.getRadius()*coord_norm;
+//                transformed_lat_lon.x *= sw_function.getRadius()*coord_norm;
+//                transformed_lat_lon.y *= sw_function.getRadius()*coord_norm;
+//                transformed_lat_lon.z *= sw_function.getRadius()*coord_norm;
 //
-//				coords_data(m, 0) = transformed_lat_lon.x;
-//				coords_data(m, 1) = transformed_lat_lon.y;
-//				coords_data(m, 2) = transformed_lat_lon.z;
+//                coords_data(m, 0) = transformed_lat_lon.x;
+//                coords_data(m, 1) = transformed_lat_lon.y;
+//                coords_data(m, 2) = transformed_lat_lon.z;
 //
-//			}
+//            }
 
 
-			// TODO: just for diagnos// scale displacements to zero
-						for (InteractingFields field_interaction : _field_interactions) {
-			
-							local_index_type field_one = field_interaction.src_fieldnum;
-			
-							// only update displacements from the rk solution
-							if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("displacement")) {
-			
-								local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-			
-								if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-									reference_solution[row_block]->scale(0);
-									rk_offsets[row_block]->scale(0);
-									updated_solution[row_block]->scale(0);
-									_particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one, _problem_dof_data);
-								} else {
-									host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
-									host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
-									host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
+            // TODO: just for diagnos// scale displacements to zero
+                        for (InteractingFields field_interaction : _field_interactions) {
+            
+                            local_index_type field_one = field_interaction.src_fieldnum;
+            
+                            // only update displacements from the rk solution
+                            if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("displacement")) {
+            
+                                local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+            
+                                if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+                                    reference_solution[row_block]->scale(0);
+                                    rk_offsets[row_block]->scale(0);
+                                    updated_solution[row_block]->scale(0);
+                                    _particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one, _problem_dof_data);
+                                } else {
+                                    host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
+                                    host_view_type rk_offsets_data = rk_offsets[0]->getLocalView<host_view_type>();
+                                    host_view_type updated_data = updated_solution[0]->getLocalView<host_view_type>();
 
-									const local_dof_map_view_type local_to_dof_map =
-											this->_particles->getDOFManagerConst()->getDOFMap();
+                                    const local_dof_map_view_type local_to_dof_map =
+                                            this->_particles->getDOFManagerConst()->getDOFMap();
 
-									for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
-										for (local_index_type l=0; l<3; ++l) {
-											local_index_type vdof = local_to_dof_map(k, field_one, l);
-											reference_data(vdof,0) = 0;
-											rk_offsets_data(vdof,0) = 0;
-											updated_data(vdof,0) = 0;
-										}
-									}
-									_particles->getFieldManager()->updateFieldsFromVector(reference_solution[0], field_one, _problem_dof_data);
-								}
-			
-								displacement_data_moved_to_fields = true;
-							}
-						}
-//			_particles->getFieldManager()->getFieldByName("reference velocity")->
-//					localInitFromVectorFunction(&sw_function);
-////	 		_particles->getFieldManager()->createField(1, "reference height", "m");
-//			_particles->getFieldManager()->getFieldByName("reference height")->
-//					localInitFromScalarFunction(&sw_function);
-//			_particles->getFieldManager()->getFieldByName("reference height")->
-//					scale(1./sw_function.getGravity());
-
-
-
-			// zero out displacements
-			//_particles->getFieldManager()->getFieldByName("displacement")->scale(0);
+                                    for (local_index_type k=0; k<_particles->getCoordsConst()->nLocal(); ++k) {
+                                        for (local_index_type l=0; l<3; ++l) {
+                                            local_index_type vdof = local_to_dof_map(k, field_one, l);
+                                            reference_data(vdof,0) = 0;
+                                            rk_offsets_data(vdof,0) = 0;
+                                            updated_data(vdof,0) = 0;
+                                        }
+                                    }
+                                    _particles->getFieldManager()->updateFieldsFromVector(reference_solution[0], field_one, _problem_dof_data);
+                                }
+            
+                                displacement_data_moved_to_fields = true;
+                            }
+                        }
+//            _particles->getFieldManager()->getFieldByName("reference velocity")->
+//                    localInitFromVectorFunction(&sw_function);
+////             _particles->getFieldManager()->createField(1, "reference height", "m");
+//            _particles->getFieldManager()->getFieldByName("reference height")->
+//                    localInitFromScalarFunction(&sw_function);
+//            _particles->getFieldManager()->getFieldByName("reference height")->
+//                    scale(1./sw_function.getGravity());
 
 
-//			// scale displacements to zero
-//			for (InteractingFields field_interaction : _field_interactions) {
+
+            // zero out displacements
+            //_particles->getFieldManager()->getFieldByName("displacement")->scale(0);
+
+
+//            // scale displacements to zero
+//            for (InteractingFields field_interaction : _field_interactions) {
 //
-//				local_index_type field_one = field_interaction.src_fieldnum;
-//				local_index_type field_two = field_interaction.trg_fieldnum;
+//                local_index_type field_one = field_interaction.src_fieldnum;
+//                local_index_type field_two = field_interaction.trg_fieldnum;
 //
-//				// only update displacements from the rk solution
-//				if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("displacement")) {
+//                // only update displacements from the rk solution
+//                if (field_one == _particles->getFieldManager()->getIDOfFieldFromName("displacement")) {
 //
-//					local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-//					local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+//                    local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+//                    local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
 //
-//					if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-//						reference_solution[row_block]->scale(0);
-//						rk_offsets[row_block]->scale(0);
-//						updated_solution[row_block]->scale(0);
-//						_particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one);
-//					} else {
-//						// TODO: would need to scale just this fields portions by zero
-//					}
+//                    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+//                        reference_solution[row_block]->scale(0);
+//                        rk_offsets[row_block]->scale(0);
+//                        updated_solution[row_block]->scale(0);
+//                        _particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one);
+//                    } else {
+//                        // TODO: would need to scale just this fields portions by zero
+//                    }
 //
-//					displacement_data_moved_to_fields = true;
-//				}
-//			}
+//                    displacement_data_moved_to_fields = true;
+//                }
+//            }
 
-			// find new neighborhoods
-			{
-				// get old search size
-				scalar_type h_min = _particles->getNeighborhood()->computeMinHSupportSize(true /*global min*/);
+            // find new neighborhoods
+            {
+                // get old search size
+                scalar_type h_min = _particles->getNeighborhood()->computeMinHSupportSize(true /*global min*/);
 
-				// destroy old neighborhood and create new one
-				_particles->createNeighborhood();
-				_particles->getNeighborhood()->setAllHSupportSizes(h_min);
+                // destroy old neighborhood and create new one
+                _particles->createNeighborhood();
+                _particles->getNeighborhood()->setAllHSupportSizes(h_min);
 
-				if (_particles->getCoordsConst()->getComm()->getRank()==0)
-					printf("hmin: %f\n", h_min);
-				// determine number of neighbors needed and construct list
-				local_index_type neighbors_needed = GMLS::getNP(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"), 2);
-				_particles->getNeighborhood()->constructAllNeighborLists(_particles->getCoordsConst()->getHaloSize(), 
+                if (_particles->getCoordsConst()->getComm()->getRank()==0)
+                    printf("hmin: %f\n", h_min);
+                // determine number of neighbors needed and construct list
+                local_index_type neighbors_needed = GMLS::getNP(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"), 2);
+                _particles->getNeighborhood()->constructAllNeighborLists(_particles->getCoordsConst()->getHaloSize(), 
                         _parameters->get<Teuchos::ParameterList>("neighborhood").get<std::string>("search type"), 
                         neighbors_needed,
                         _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("cutoff multiplier"),
                         _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("size"),
                         _parameters->get<Teuchos::ParameterList>("neighborhood").get<bool>("uniform radii"),
                         _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("radii post search scaling"));
-			}
+            }
 
-		}
-	}
+        }
+    }
 
-	// refresh fields' halo data
-	_particles->getFieldManager()->updateFieldsHaloData();
+    // refresh fields' halo data
+    _particles->getFieldManager()->updateFieldsHaloData();
 
-	// get solution back from vector onto particles (only at last time step)
-	for (InteractingFields field_interaction : _field_interactions) {
+    // get solution back from vector onto particles (only at last time step)
+    for (InteractingFields field_interaction : _field_interactions) {
 
-		local_index_type field_one = field_interaction.src_fieldnum;
+        local_index_type field_one = field_interaction.src_fieldnum;
 
-		local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
 
-		if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-			_particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one, _problem_dof_data);
-		} else {
-			_particles->getFieldManager()->updateFieldsFromVector(reference_solution[0], field_one, _problem_dof_data);
-		}
-	}
+        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+            _particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one, _problem_dof_data);
+        } else {
+            _particles->getFieldManager()->updateFieldsFromVector(reference_solution[0], field_one, _problem_dof_data);
+        }
+    }
 
-	// user selected to only output as last time step
-	if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") == 0) {
-		// only write last timestep data
+    // user selected to only output as last time step
+    if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") == 0) {
+        // only write last timestep data
 
-		filename = _parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file prefix") + base + "." + extension;
-		if (_particles->getCoordsConst()->getComm()->getRank()==0)
-			printf("filename: %s\n", filename.c_str());
+        filename = _parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file prefix") + base + "." + extension;
+        if (_particles->getCoordsConst()->getComm()->getRank()==0)
+            printf("filename: %s\n", filename.c_str());
 
-		fm.setWriter(filename, _particles);
+        fm.setWriter(filename, _particles);
 
-		fm.write();
-	}
+        fm.write();
+    }
 
 
-	if (_particles->getCoordsConst()->getComm()->getRank()==0)
-		printf("final time: %.16f\n", t);
-//		if (_particles->getCoordsConst()->isLagrangian()) {
-//			printf("Lagrangian!");
-//			// temporary
-//			// retrieve the displacement from the solution and put it in the particles
-//			for (InteractingFields field_interaction : _field_interactions) {
+    if (_particles->getCoordsConst()->getComm()->getRank()==0)
+        printf("final time: %.16f\n", t);
+//        if (_particles->getCoordsConst()->isLagrangian()) {
+//            printf("Lagrangian!");
+//            // temporary
+//            // retrieve the displacement from the solution and put it in the particles
+//            for (InteractingFields field_interaction : _field_interactions) {
 //
-//				local_index_type field_one = field_interaction.src_fieldnum;
-//				local_index_type field_two = field_interaction.trg_fieldnum;
+//                local_index_type field_one = field_interaction.src_fieldnum;
+//                local_index_type field_two = field_interaction.trg_fieldnum;
 //
-//				local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-//				local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+//                local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+//                local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
 //
-//				if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-//					_particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one);
-//				} else {
-//					_particles->getFieldManager()->updateFieldsFromVector(reference_solution[0]);
-//					break;
-//				}
-//			}
+//                if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+//                    _particles->getFieldManager()->updateFieldsFromVector(reference_solution[row_block], field_one);
+//                } else {
+//                    _particles->getFieldManager()->updateFieldsFromVector(reference_solution[0]);
+//                    break;
+//                }
+//            }
 //
-//			// update the coordinates by the displacements calculated
-//			_particles->updatePhysicalCoordinatesFromField("displacement");
-////			_particles->getCoords()->snapToSphere();
+//            // update the coordinates by the displacements calculated
+//            _particles->updatePhysicalCoordinatesFromField("displacement");
+////            _particles->getCoords()->snapToSphere();
 //
-//			// zero out displacements
-//			_particles->getFieldManager()->getFieldByName("displacement")]->scale(0);
+//            // zero out displacements
+//            _particles->getFieldManager()->getFieldByName("displacement")]->scale(0);
 //
-//			printf("time: %.16f\n", t);
-//		}
+//            printf("time: %.16f\n", t);
+//        }
 
-//	// get new neighborhoods before going to next timestep
-//	{
-//		// get old search size
-//		scalar_type h_min = _particles->getNeighborhood()->getMinimumHSupportSize();
+//    // get new neighborhoods before going to next timestep
+//    {
+//        // get old search size
+//        scalar_type h_min = _particles->getNeighborhood()->getMinimumHSupportSize();
 //
-//		// destroy old neighborhood and create new one
-//		_particles->createNeighborhood();
-//		_particles->getNeighborhood()->setAllHSupportSizes(h_min);
+//        // destroy old neighborhood and create new one
+//        _particles->createNeighborhood();
+//        _particles->getNeighborhood()->setAllHSupportSizes(h_min);
 //
-//		// determine number of neighbors needed and construct list
-//		local_index_type neighbors_needed = GMLS::getNP(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"), 2);
-//		local_index_type extra_neighbors = _parameters->get<Teuchos::ParameterList>("remap").get<double>("neighbors needed multiplier") * neighbors_needed;
-//		_particles->getNeighborhood()->constructAllNeighborList(_particles->getCoordsConst()->getHaloSize(), extra_neighbors);
-//	}
+//        // determine number of neighbors needed and construct list
+//        local_index_type neighbors_needed = GMLS::getNP(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"), 2);
+//        local_index_type extra_neighbors = _parameters->get<Teuchos::ParameterList>("remap").get<double>("neighbors needed multiplier") * neighbors_needed;
+//        _particles->getNeighborhood()->constructAllNeighborList(_particles->getCoordsConst()->getHaloSize(), extra_neighbors);
+//    }
 
 
-//	for (InteractingFields field_interaction : _field_interactions) {
+//    for (InteractingFields field_interaction : _field_interactions) {
 //
-//		local_index_type field_one = field_interaction.src_fieldnum;
-//		local_index_type field_two = field_interaction.trg_fieldnum;
+//        local_index_type field_one = field_interaction.src_fieldnum;
+//        local_index_type field_two = field_interaction.trg_fieldnum;
 //
-//		local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
-//		local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
+//        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+//        local_index_type col_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_col_map[field_two] : 0;
 //
-//		if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-//			// copy this to updated_solution so that it starts in the right place
-//			host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
-//			for (local_index_type k=0; k<reference_data.extent(0); ++k) {
-//				printf("field #%d: index #%d: val:%.16f\n", field_one, k, reference_data(k,0));
-//			}
-//		} else {
-//			// copy this to updated_solution so that it starts in the right place
-//			host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
-//			for (local_index_type k=0; k<reference_data.extent(0); ++k) {
-//				printf("field #%d: index #%d: val:%.16f\n", field_one, k, reference_data(k,0));
-//			}
-//			break;
-//		}
-//	}
+//        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+//            // copy this to updated_solution so that it starts in the right place
+//            host_view_type reference_data = reference_solution[row_block]->getLocalView<host_view_type>();
+//            for (local_index_type k=0; k<reference_data.extent(0); ++k) {
+//                printf("field #%d: index #%d: val:%.16f\n", field_one, k, reference_data(k,0));
+//            }
+//        } else {
+//            // copy this to updated_solution so that it starts in the right place
+//            host_view_type reference_data = reference_solution[0]->getLocalView<host_view_type>();
+//            for (local_index_type k=0; k<reference_data.extent(0); ++k) {
+//                printf("field #%d: index #%d: val:%.16f\n", field_one, k, reference_data(k,0));
+//            }
+//            break;
+//        }
+//    }
 }
 
 void ProblemExplicitTransientT::buildMaps(local_index_type field_one, local_index_type field_two) {
-	if (field_two<0) field_two = field_one;
-	local_index_type row_block = _field_to_block_row_map[field_one];
-	local_index_type col_block = _field_to_block_col_map[field_two];
+    if (field_two<0) field_two = field_one;
+    local_index_type row_block = _field_to_block_row_map[field_one];
+    local_index_type col_block = _field_to_block_col_map[field_two];
 
-	if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-		if (row_map[row_block].is_null()) {
-			row_map[row_block] = _particles->getDOFManagerConst()->getRowMap(field_one);
-		}
-		if (col_map[col_block].is_null()) {
-			col_map[col_block] = _particles->getDOFManagerConst()->getColMap(field_two);
-		}
-	} else {
-		if (row_map[0].is_null()) {
-			row_map[0] = _particles->getDOFManagerConst()->getRowMap(); // get all dofs
-		}
-		if (col_map[0].is_null()) {
-			col_map[0] = _particles->getDOFManagerConst()->getColMap();
-		}
-	}
+    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+        if (row_map[row_block].is_null()) {
+            row_map[row_block] = _particles->getDOFManagerConst()->getRowMap(field_one);
+        }
+        if (col_map[col_block].is_null()) {
+            col_map[col_block] = _particles->getDOFManagerConst()->getColMap(field_two);
+        }
+    } else {
+        if (row_map[0].is_null()) {
+            row_map[0] = _particles->getDOFManagerConst()->getRowMap(); // get all dofs
+        }
+        if (col_map[0].is_null()) {
+            col_map[0] = _particles->getDOFManagerConst()->getColMap();
+        }
+    }
 }
 
 void ProblemExplicitTransientT::assembleOperatorToVector(local_index_type field_one, local_index_type field_two, scalar_type simulation_time, scalar_type delta_time) {
-	if (field_two<0) field_two = field_one;
-	local_index_type row_block = _field_to_block_row_map[field_one];
+    if (field_two<0) field_two = field_one;
+    local_index_type row_block = _field_to_block_row_map[field_one];
 
-	TEUCHOS_TEST_FOR_EXCEPT_MSG(_OP.is_null(), "Physics not set before assembleOperator() called.");
-	_OP->setParameters(*_parameters);
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(_OP.is_null(), "Physics not set before assembleOperator() called.");
+    _OP->setParameters(*_parameters);
 
-	if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-		if (_b[row_block].is_null()) {
-			bool setToZero = true;
-			_b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
-		}
-		_OP->setMultiVector(_b[row_block].getRawPtr());
-	} else {
-		if (_b[0].is_null()) {
-			bool setToZero = true;
-			_b[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
-		}
-			_OP->setMultiVector(_b[0].getRawPtr());
-	}
-	_OP->computeVector(field_one, field_two, simulation_time);
+    if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+        if (_b[row_block].is_null()) {
+            bool setToZero = true;
+            _b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+        }
+        _OP->setMultiVector(_b[row_block].getRawPtr());
+    } else {
+        if (_b[0].is_null()) {
+            bool setToZero = true;
+            _b[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
+        }
+            _OP->setMultiVector(_b[0].getRawPtr());
+    }
+    _OP->computeVector(field_one, field_two, simulation_time);
 }
 
 void ProblemExplicitTransientT::assembleRHS(local_index_type field_one, local_index_type field_two, scalar_type simulation_time, scalar_type delta_time) {
-	if (field_two<0) field_two = field_one;
-	local_index_type row_block = _field_to_block_row_map[field_one];
+    if (field_two<0) field_two = field_one;
+    local_index_type row_block = _field_to_block_row_map[field_one];
 
-	TEUCHOS_TEST_FOR_EXCEPT_MSG(_RHS.is_null(), "Sources not set before assembleRHS() called.");
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(_RHS.is_null(), "Sources not set before assembleRHS() called.");
 
-	_RHS->setParameters(*_parameters);
+    _RHS->setParameters(*_parameters);
 
-	if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-		if (_b[row_block].is_null()) {
-			bool setToZero = true;
-			_b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
-		}
-		_RHS->setMultiVector(_b[row_block].getRawPtr());
-	} else {
-		if (_b[0].is_null()) {
-			bool setToZero = true;
-			_b[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
-		}
-		_RHS->setMultiVector(_b[0].getRawPtr());
-	}
-
-	_RHS->evaluateRHS(field_one, field_two, simulation_time);
+    if (_b[row_block].is_null()) {
+        bool setToZero = true;
+        _b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+    }
+    _RHS->setMultiVector(_b[row_block].getRawPtr());
+    _RHS->setDOFData(_problem_dof_data);
+    _RHS->evaluateRHS(field_one, field_two, simulation_time);
 }
 
 void ProblemExplicitTransientT::assembleBCS(local_index_type field_one, local_index_type field_two, scalar_type simulation_time, scalar_type delta_time) {
-	if (field_two<0) field_two = field_one;
-	local_index_type row_block = _field_to_block_row_map[field_one];
+    if (field_two<0) field_two = field_one;
+    local_index_type row_block = _field_to_block_row_map[field_one];
 
-	TEUCHOS_TEST_FOR_EXCEPT_MSG(_BCS.is_null(), "Boundary conditions not set before assembleBCS() called.");
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(_BCS.is_null(), "Boundary conditions not set before assembleBCS() called.");
 
-	_BCS->setParameters(*_parameters);
+    _BCS->setParameters(*_parameters);
 
-	if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
-		// fill out this row block of b
-		if (_b[row_block].is_null()) {
-			bool setToZero = true;
-			_b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
-		}
-		_BCS->setMultiVector(_b[row_block].getRawPtr());
-	} else {
-		// generate b if in the zero, zero block
-		if (_b[0].is_null()) {
-			bool setToZero = true;
-			_b[0] = Teuchos::rcp(new mvec_type(row_map[0], 1, setToZero));
-		}
-		_BCS->setMultiVector(_b[0].getRawPtr());
-	}
-	_BCS->applyBoundaries(field_one, field_two, simulation_time);
+    // fill out this row block of b
+    if (_b[row_block].is_null()) {
+        bool setToZero = true;
+        _b[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+    }
+    _BCS->setMultiVector(_b[row_block].getRawPtr());
+    _BCS->setDOFData(_problem_dof_data);
+    _BCS->flagBoundaries();
+    _BCS->applyBoundaries(field_one, field_two, simulation_time);
 
 }
 

--- a/src/Compadre_ProblemExplicitTransientT.hpp
+++ b/src/Compadre_ProblemExplicitTransientT.hpp
@@ -16,6 +16,7 @@ class SourcesT;
 class BoundaryConditionsT;
 class ParameterManager;
 class DOFData;
+class InteractingFields;
 
 
 

--- a/src/Compadre_ProblemT.hpp
+++ b/src/Compadre_ProblemT.hpp
@@ -16,6 +16,7 @@ class SourcesT;
 class BoundaryConditionsT;
 class ParameterManager;
 class DOFData;
+class InteractingFields;
 
 
 /*

--- a/src/Compadre_SourcesT.hpp
+++ b/src/Compadre_SourcesT.hpp
@@ -10,6 +10,7 @@ class CoordsT;
 class ParticlesT;
 class FieldT;
 class DOFData;
+class InteractingFields;
 
 class SourcesT {
 

--- a/test_data/parameter_lists/shallow_water/parameters_case2.xml
+++ b/test_data/parameter_lists/shallow_water/parameters_case2.xml
@@ -34,7 +34,7 @@
     <Parameter name="coordinates layout" type="string" value="lat_lon_separate"/>
     <Parameter name="output file prefix" type="string" value="../test_data/"/>
     <Parameter name="output file" type="string" value="shallow_water.nc"/>
-    <Parameter name="write every" type="int" value="1"/>
+    <Parameter name="write every" type="int" value="20"/>
     <Parameter name="keep original lat lon" type="bool" value="true"/>
     <Parameter name="coordinate 0 name" type="string" value="grid_center_lat"/>
     <Parameter name="coordinate 1 name" type="string" value="grid_center_lon"/>


### PR DESCRIPTION
Compadre_FieldManager.hpp. Similar for enum for operation type.

FieldSparsity enum moved to Compadre_FieldSparsity.hpp

ProblemExplicitTransientT updated so that operations needing
performed for field interactions are sorted resulting in Dirichlet
boundary conditions being performed first, RHS being assembled 2nd,
and the action of the operator last.