### PR TITLE
Simplify the KokkosParser functionality

### DIFF
--- a/examples/Compadre_UnitTests.cpp
+++ b/examples/Compadre_UnitTests.cpp
@@ -19,19 +19,14 @@ TEST (KokkosInitialize, NoArgsGiven) {
     ASSERT_NO_DEATH({
             // default constructor is hidden for KokkosParser
             // but still visible from this test
-            auto kp = Compadre::KokkosParser(-1,-1,-1,-1,false);
+            auto kp = Compadre::KokkosParser(false);
             kp.finalize();
     });
 }
 TEST (KokkosInitialize, NoCommandLineArgsGiven) { 
-    std::vector<std::string> arguments = {"application"};
-    std::vector<char*> argv;
-    for (const auto& arg : arguments) {
-        argv.push_back((char*)arg.data());
-    }
-    argv.push_back(nullptr);
     ASSERT_NO_DEATH({
-            auto kp = KokkosParser(argv.size()-1, argv.data());
+            std::vector<std::string> arguments = {"--kokkos-threads=4"};
+            auto kp = KokkosParser(arguments);
             kp.finalize();
     });
 }

--- a/examples/Python_3D_Convergence.py.in
+++ b/examples/Python_3D_Convergence.py.in
@@ -11,14 +11,6 @@ import numpy as np
 import math
 import random
 
-import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument("--kokkos-threads", help="number of threads to use", default=-1)
-parser.add_argument("--kokkos-numa", help="numa region to use", default=-1)
-parser.add_argument("--kokkos-device", help="number of device to use", default=-1)
-parser.add_argument("--kokkos-ngpus", help="number of total devices available", default=-1)
-args = parser.parse_args()
-
 # just for formatting
 class colors:
     HEADER = '\033[95m'
@@ -134,9 +126,7 @@ def test1(ND):
     
     return (l2_error, h1_seminorm_error)
 
-kokkos_obj=pycompadre.KokkosParser(int(args.kokkos_threads), int(args.kokkos_numa),
-                                    int(args.kokkos_device), int(args.kokkos_ngpus),
-                                    True) # print state after initializing
+kokkos_obj=pycompadre.KokkosParser(sys.argv, True) # print state after initializing
 
 # of points in each dimension to run the test over
 ND = [5, 10, 20, 40]

--- a/examples/unittests/test_LinearAlgebra.hpp
+++ b/examples/unittests/test_LinearAlgebra.hpp
@@ -13,7 +13,9 @@ public:
 
     ParallelManager pm;
     Kokkos::View<double*, host_execution_space> A;
+    Kokkos::View<double*, device_execution_space> A_d;
     Kokkos::View<double*, host_execution_space> B;
+    Kokkos::View<double*, device_execution_space> B_d;
 
     LinearAlgebraTest( ) {
         // initialization
@@ -29,8 +31,11 @@ public:
 
         // multiple full rank matrices
         Kokkos::resize(A, lda*nda*num_matrices);
+        Kokkos::resize(A_d, lda*nda*num_matrices);
         Kokkos::deep_copy(A, 0.0);
+
         Kokkos::resize(B, ldb*ndb*num_matrices);
+        Kokkos::resize(B_d, ldb*ndb*num_matrices);
         Kokkos::deep_copy(B, 0.0);
 
         if (M==N) { // square case
@@ -86,6 +91,9 @@ public:
                 }
             }
         }
+        Kokkos::deep_copy(A_d, A);
+        Kokkos::deep_copy(B_d, B);
+        Kokkos::fence();
     }
 
     void TearDown( ) {
@@ -108,7 +116,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Same_LDA_NDA_LRA
     int lda=3, nda=3;
     int ldb=3, ndb=3;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -138,7 +148,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Same_LDA_NDA_Lar
     int ldb=3, ndb=4;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
     // LU expects layout left B, so ndb and ldb reverse ordered
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -165,7 +177,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDA_NDA_L
     int lda=7, nda=12;
     int ldb=3, ndb=3;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -189,7 +203,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
     int lda=3, nda=3;
     int ldb=7, ndb=13;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -212,7 +228,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
     int lda=3, nda=3;
     int ldb=12, ndb=8;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -238,7 +256,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Same_LDA_NDA_LRA
     int lda=3, nda=3;
     int ldb=3, ndb=3;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -268,7 +288,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Same_LDA_NDA_Lar
     int ldb=3, ndb=4;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
     // QR expects layout left B, so ndb and ldb reverse ordered
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -295,7 +317,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDA_NDA_L
     int lda=7, nda=12;
     int ldb=3, ndb=3;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -319,7 +343,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
     int lda=3, nda=3;
     int ldb=7, ndb=13;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -342,7 +368,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
     int lda=3, nda=3;
     int ldb=12, ndb=8;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -368,7 +396,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Same_LDA_NDA_LLA
     int lda=3, nda=3;
     int ldb=3, ndb=3;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -398,7 +428,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Same_LDA_NDA_Lar
     int ldb=3, ndb=4;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
     // LU expects layout left B, so ndb and ldb reverse ordered
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -425,7 +457,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDA_NDA_L
     int lda=7, nda=12;
     int ldb=3, ndb=3;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -449,7 +483,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
     int lda=3, nda=3;
     int ldb=7, ndb=13;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -472,7 +508,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
     int lda=3, nda=3;
     int ldb=12, ndb=8;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -498,7 +536,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Same_LDA_NDA_LLA
     int lda=3, nda=3;
     int ldb=3, ndb=3;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -528,7 +568,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Same_LDA_NDA_Lar
     int ldb=3, ndb=4;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
     // QR expects layout left B, so ndb and ldb reverse ordered
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -555,7 +597,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDA_NDA_L
     int lda=7, nda=12;
     int ldb=3, ndb=3;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -579,7 +623,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
     int lda=3, nda=3;
     int ldb=7, ndb=13;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                   0  -0.071428571428571  -0.035714285714286
     //                   0  -0.285714285714286  -0.142857142857143
@@ -602,7 +648,9 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
     int lda=3, nda=3;
     int ldb=12, ndb=8;
     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_right>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
+    Kokkos::deep_copy(B, B_d);
+    Kokkos::fence();
     // solution: X = [
     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -628,7 +676,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=3, ndb=3;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -658,7 +706,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int ldb=3, ndb=4;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
 //LLX!    // LU expects layout left B, so ndb and ldb reverse ordered
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //LLX!    //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -685,7 +733,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=7, nda=12;
 //LLX!    int ldb=3, ndb=3;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -709,7 +757,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=7, ndb=13;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -732,7 +780,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=12, ndb=8;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //LLX!    //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -758,7 +806,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=3, ndb=3;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -788,7 +836,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int ldb=3, ndb=4;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
 //LLX!    // QR expects layout left B, so ndb and ldb reverse ordered
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //LLX!    //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -815,7 +863,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=7, nda=12;
 //LLX!    int ldb=3, ndb=3;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -839,7 +887,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=7, ndb=13;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -862,7 +910,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=12, ndb=8;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_right,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //LLX!    //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -888,7 +936,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=3, ndb=3;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -918,7 +966,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int ldb=3, ndb=4;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
 //LLX!    // LU expects layout left B, so ndb and ldb reverse ordered
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //LLX!    //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -945,7 +993,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=7, nda=12;
 //LLX!    int ldb=3, ndb=3;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -969,7 +1017,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=7, ndb=13;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -992,7 +1040,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=12, ndb=8;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, false/*B is LL*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_left,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //LLX!    //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -1018,7 +1066,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=3, ndb=3;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -1048,7 +1096,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int ldb=3, ndb=4;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
 //LLX!    // QR expects layout left B, so ndb and ldb reverse ordered
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //LLX!    //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -1075,7 +1123,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=7, nda=12;
 //LLX!    int ldb=3, ndb=3;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -1099,7 +1147,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=7, ndb=13;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                   0  -0.071428571428571  -0.035714285714286
 //LLX!    //                   0  -0.285714285714286  -0.142857142857143
@@ -1122,7 +1170,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //LLX!    int lda=3, nda=3;
 //LLX!    int ldb=12, ndb=8;
 //LLX!    SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank, true/*A is LR*/, true/*B is LR*/);
-//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//LLX!    GMLS_LinearAlgebra::batchQRPivotingSolve<layout_left,layout_right,layout_left>(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //LLX!    // solution: X = [
 //LLX!    //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //LLX!    //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -1149,7 +1197,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //     int ldb=3, ndb=3; // relative to layout right
 //     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank);
 //     // LU expects layout left B, so ndb and ldb reverse ordered
-//     GMLS_LinearAlgebra::batchQRPivotingSolve(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//     GMLS_LinearAlgebra::batchQRPivotingSolve(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //     // solution: X = [
 //     //                   0  -0.071428571428571  -0.035714285714286
 //     //                   0  -0.285714285714286  -0.142857142857143
@@ -1179,7 +1227,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //     int ldb=4, ndb=3; // relative to layout right
 //     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank);
 //     // LU expects layout left B, so ndb and ldb reverse ordered
-//     GMLS_LinearAlgebra::batchQRFactorize(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//     GMLS_LinearAlgebra::batchQRFactorize(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //     // solution: X = [
 //     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714
@@ -1207,7 +1255,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //     int ldb=3, ndb=3; // relative to layout right
 //     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank);
 //     // LU expects layout left B, so ndb and ldb reverse ordered
-//     GMLS_LinearAlgebra::batchQRFactorize(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//     GMLS_LinearAlgebra::batchQRFactorize(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //     // solution: X = [
 //     //                   0  -0.071428571428571  -0.035714285714286
 //     //                   0  -0.285714285714286  -0.142857142857143
@@ -1232,7 +1280,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //     int ldb=7, ndb=13; // relative to layout right
 //     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank);
 //     // LU expects layout left B, so ndb and ldb reverse ordered
-//     GMLS_LinearAlgebra::batchQRFactorize(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//     GMLS_LinearAlgebra::batchQRFactorize(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //     // solution: X = [
 //     //                   0  -0.071428571428571  -0.035714285714286
 //     //                   0  -0.285714285714286  -0.142857142857143
@@ -1256,7 +1304,7 @@ TEST_F (LinearAlgebraTest, Square_FullRank_batchQRPivotingSolve_Larger_LDB_NDB_L
 //     int ldb=12, ndb=8; // relative to layout right
 //     SetUp(lda, nda, ldb, ndb, M, N, NRHS, num_matrices, rank);
 //     // LU expects layout left B, so ndb and ldb reverse ordered
-//     GMLS_LinearAlgebra::batchQRFactorize(pm, A.data(), lda, nda, B.data(), ldb, ndb, M, N, NRHS, num_matrices);
+//     GMLS_LinearAlgebra::batchQRFactorize(pm, A_d.data(), lda, nda, B_d.data(), ldb, ndb, M, N, NRHS, num_matrices);
 //     // solution: X = [
 //     //                  0  -0.071428571428571  -0.035714285714286  -0.053571428571429
 //     //                  0  -0.285714285714286  -0.142857142857143  -0.214285714285714

--- a/pycompadre/pycompadre.cpp
+++ b/pycompadre/pycompadre.cpp
@@ -14,6 +14,7 @@
 
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <pybind11/stl.h>
 
 using namespace Compadre;
 namespace py = pybind11;
@@ -672,7 +673,9 @@ PYBIND11_MODULE(pycompadre, m) {
     .def("getTotalNeighborsOverAllLists", &NeighborLists<ParticleHelper::int_1d_view_type_in_gmls>::getTotalNeighborsOverAllListsHost, "Get total storage size of all neighbor lists combined.");
 
     py::class_<KokkosParser>(m, "KokkosParser")
-    .def(py::init<int,int,int,int,bool>(), py::arg("num_threads") = -1, py::arg("numa") = -1, py::arg("device") = -1, py::arg("ngpu") = -1, py::arg("print") = false);
+    .def(py::init<std::vector<std::string>,bool>(), py::arg("args"), py::arg("print") = false)
+    .def(py::init<bool>(), py::arg("print") = false)
+    .def("status", &KokkosParser::status);
 
     m.def("getNP", &GMLS::getNP, R"pbdoc(
         Get size of basis.

--- a/src/Compadre_KokkosParser.hpp
+++ b/src/Compadre_KokkosParser.hpp
@@ -13,11 +13,6 @@ class KokkosParser {
 
 private:
 
-  int _num_threads;
-  int _numa;
-  int _device;
-  int _ngpu;
-
   bool _called_initialize;
 
   // prevent default constructor
@@ -28,8 +23,11 @@ public:
   // call with command line arguments
   KokkosParser(int argc, char* args[], bool print_status = false);
 
-  // call with integer arguments
-  KokkosParser(int num_threads = -1, int numa = -1, int device = -1, int ngpu = -1, bool print_status = false);
+  // call with std::vector of std::string's
+  KokkosParser(std::vector<std::string> args, bool print_status = false);
+
+  // call for default arguments
+  KokkosParser(bool print_status = false);
 
   // destructor
   ~KokkosParser() {
@@ -41,30 +39,17 @@ public:
 
   // initialize Kokkos if not already initialized using
   // arguments provided at object construction
-  int initialize();
+  int initialize(int argc, char*[], bool print_status = false);
   
   // finalize Kokkos if this object initialized it
   // or if hard_finalize is true
   int finalize(bool hard_finalize = false);
 
-  // retrieve arguments from a previous initialized Kokkos state
-  void retrievePreviouslyInstantiatedKokkosInitArguments();
-
-  // use this object's state to create a Kokkos object used
-  // later for initialization
-  Kokkos::InitArguments createInitArguments() const;
-
-  int getNumberOfThreads() const { return _num_threads; }
-  int getNuma() const { return _numa; }
-  int getDeviceID() const { return _device; }
-  int getNumberOfGPUs() const { return _ngpu; }
-
-  // prints status
+  // prints Kokkos configuration
   void status() const;
 
   // prohibit using the assignment constructor
   KokkosParser& operator=( const KokkosParser& ) = delete;
-  //KokkosParser( const KokkosParser& ) = delete;
 
 };
 

--- a/src/Compadre_Misc.hpp
+++ b/src/Compadre_Misc.hpp
@@ -122,7 +122,6 @@ KOKKOS_INLINE_FUNCTION
 XYZ operator / ( const XYZ& vecA, const scalar_type& constant ) {
     return XYZ( vecA.x / constant, vecA.y / constant, vecA.z / constant); }
 
-KOKKOS_INLINE_FUNCTION
 std::ostream& operator << ( std::ostream& os, const XYZ& vec ) {
     os << "(" << vec.x << ", " << vec.y << ", " << vec.z << ")" ; return os; }
 


### PR DESCRIPTION
Removed all of the manual setting of numa, threads, ngpus, etc...
from the KokkosParser class. Added convenient constructors to the
KokkosParser class that allow for command line argc and argv to be
given or a std::vector<std::string> or an empty constructor.

KokkosParser::status(...) now will get Kokkos::print_configuration.

This ensures that all Kokkos configuration settings are set via command line like arguments.