### PR TITLE
Add 'newmark' as a time integrator

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -389,16 +389,22 @@ if (CompadreHarness_EXAMPLES)
 
     ## EXPLICIT TIME DEPENDENT TESTS
     
-    ADD_TEST(NAME ExplicitTimeDependentExact COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 4 ${CMAKE_CURRENT_BINARY_DIR}/explicitTimeDependent.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_exact.xml" "--kokkos-threads=2")
-    SET_TESTS_PROPERTIES(ExplicitTimeDependentExact PROPERTIES LABELS "explicit;exact")
+    ADD_TEST(NAME ExplicitTimeDependentRKExact COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 4 ${CMAKE_CURRENT_BINARY_DIR}/explicitTimeDependent.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_rk_exact.xml" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(ExplicitTimeDependentRKExact PROPERTIES LABELS "explicit;exact;rk")
     
-    ADD_TEST(NAME ExplicitTimeDependentAnalytical COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 3 ${CMAKE_CURRENT_BINARY_DIR}/explicitTimeDependent.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_nonpolynomial.xml" "--kokkos-threads=2")
-    SET_TESTS_PROPERTIES(ExplicitTimeDependentAnalytical PROPERTIES LABELS "explicit;analytical")
+    ADD_TEST(NAME ExplicitTimeDependentRKAnalytical COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 3 ${CMAKE_CURRENT_BINARY_DIR}/explicitTimeDependent.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_rk_nonpolynomial.xml" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(ExplicitTimeDependentRKAnalytical PROPERTIES LABELS "explicit;analytical;rk")
+
+    ADD_TEST(NAME ExplicitTimeDependentNewmarkExact COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 4 ${CMAKE_CURRENT_BINARY_DIR}/explicitTimeDependent.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_newmark_exact.xml" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(ExplicitTimeDependentNewmarkExact PROPERTIES LABELS "explicit;exact;newmark")
+    
+    ADD_TEST(NAME ExplicitTimeDependentNewmarkAnalytical COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 3 ${CMAKE_CURRENT_BINARY_DIR}/explicitTimeDependent.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_newmark_nonpolynomial.xml" "--kokkos-threads=2")
+    SET_TESTS_PROPERTIES(ExplicitTimeDependentNewmarkAnalytical PROPERTIES LABELS "explicit;analytical;newmark")
 
     ## UNIT TESTS
 
     ADD_TEST(NAME UnitTests COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 1 ${CMAKE_CURRENT_BINARY_DIR}/unitTests.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_unittests.xml" "--kokkos-threads=2")
-    SET_TESTS_PROPERTIES(ExplicitTimeDependentAnalytical PROPERTIES LABELS "explicit;analytical")
+    SET_TESTS_PROPERTIES(UnitTests PROPERTIES LABELS "unit;")
 
 
     ## RT0 REMAP TO VECTOR TEST

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -403,7 +403,7 @@ if (CompadreHarness_EXAMPLES)
 
     ## UNIT TESTS
 
-    ADD_TEST(NAME UnitTests COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 1 ${CMAKE_CURRENT_BINARY_DIR}/unitTests.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_unittests.xml" "--kokkos-threads=2")
+    ADD_TEST(NAME UnitTests COMMAND "mpirun" ${OPENMPI_FLAG} "-np" 1 ${CMAKE_CURRENT_BINARY_DIR}/unitTests.exe "--i=${CMAKE_CURRENT_SOURCE_DIR}/../test_data/parameter_lists/explicit/parameters_rk_exact.xml" "--kokkos-threads=2")
     SET_TESTS_PROPERTIES(UnitTests PROPERTIES LABELS "unit;")
 
 

--- a/examples/Compadre_ExplicitTimeDependent.cpp
+++ b/examples/Compadre_ExplicitTimeDependent.cpp
@@ -167,6 +167,7 @@ int main (int argc, char* args[]) {
             } else if (timestepper_type=="newmark") {
                 particles->getFieldManager()->createField(1, "d", "m/s");
                 particles->getFieldManager()->createField(1, "d_velocity", "m/s");
+                particles->getFieldManager()->createField(1, "d_acceleration", "m/s");
                 particles->getFieldManager()->getFieldByName("d")->
                         localInitFromScalarFunction(h_boundary_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
                         //localInitFromScalarFunction(zero_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));

--- a/examples/Compadre_ExplicitTimeDependent.cpp
+++ b/examples/Compadre_ExplicitTimeDependent.cpp
@@ -63,7 +63,7 @@ int main (int argc, char* args[]) {
 
     auto solution_type = parameters->get<std::string>("solution type");
     auto simulation_type = parameters->get<std::string>("simulation type");
-    //auto dimension = parameters->get<Teuchos::ParameterList>("io").get<std::string>("input dimensions");
+    auto timestepper_type = parameters->get<Teuchos::ParameterList>("time").get<std::string>("type");
 
     {
 
@@ -105,21 +105,37 @@ int main (int argc, char* args[]) {
         if (solution_type=="polynomial time" && simulation_type=="eulerian") {
             // exact solution is t^5/5 + 2*t - (t0^5/5 + 2*t0), rhs is: t^4 + 2
             Teuchos::RCP<Compadre::AnalyticFunction> t = Teuchos::rcp<Compadre::AnalyticFunction>(new Compadre::LinearInT());
-            vel_source_function = pow(t,4) + 2;//zero_function;
-            vel_boundary_function = .2*pow(t,5) + 2*t - (pow(t0,5)/5.0 + 2.0*t0);// (t/zero_function;
-            // exact solution is t^3/3 - 10*t - (t0^3/3 - 10*t0), rhs is: t^2 - 10
-            h_boundary_function = pow(t,3)/3 - 10*t - (pow(t0,3)/3.0 - 10.0*t0);//zero_function;
-            h_source_function = t*t - 10;//zero_function;
+            if (timestepper_type=="rk") {
+                vel_source_function = pow(t,4) + 2;//zero_function;
+                vel_boundary_function = .2*pow(t,5) + 2*t - (pow(t0,5)/5.0 + 2.0*t0);// (t/zero_function;
+                // exact solution is t^3/3 - 10*t - (t0^3/3 - 10*t0), rhs is: t^2 - 10
+                h_boundary_function = pow(t,3)/3 - 10*t - (pow(t0,3)/3.0 - 10.0*t0);//zero_function;
+                h_source_function = t*t - 10;//zero_function;
+            } else if (timestepper_type=="newmark") {
+                // exact solution is d: t^2/2 - 10*t, v: t - 10, a: 1
+                h_boundary_function = pow(t,2)/2 - 10*t;
+                h_source_function = t - 10;
+                vel_source_function = 1 + zero_function;
+                vel_boundary_function = t - 10;
+            }
         }
         else if (solution_type=="nonpolynomial time" && simulation_type=="eulerian") {
             // exact solution is -cos(t)+cos(t0)
             Teuchos::RCP<Compadre::AnalyticFunction> cos_t = Teuchos::rcp<Compadre::AnalyticFunction>(new Compadre::CosT());
             Teuchos::RCP<Compadre::AnalyticFunction> sin_t = Teuchos::rcp<Compadre::AnalyticFunction>(new Compadre::SinT());
-            vel_source_function = sin_t;
-            vel_boundary_function = -1*cos_t + std::cos(t0);//zero_function;
-            // exact solution is sin(t)-sin(t0)
-            h_boundary_function = sin_t - std::sin(t0);
-            h_source_function = cos_t;
+            if (timestepper_type=="rk") {
+                vel_source_function = sin_t;
+                vel_boundary_function = -1*cos_t + std::cos(t0);//zero_function;
+                // exact solution is sin(t)-sin(t0)
+                h_boundary_function = sin_t - std::sin(t0);
+                h_source_function = cos_t;
+            } else if (timestepper_type=="newmark") {
+                // exact solution is sin(t)-sin(t0)
+                h_boundary_function = sin_t - std::sin(t0);
+                h_source_function = cos_t;
+                vel_source_function = -1*sin_t;
+                vel_boundary_function = cos_t;
+            }
         } else {
             TEUCHOS_ASSERT(false); // invalid choice
         }
@@ -137,17 +153,28 @@ int main (int argc, char* args[]) {
             particles->buildHalo(halo_size);
 
 
-//             particles->getFieldManager()->listFields(std::cout);
-             particles->getFieldManager()->createField(1, "velocity", "m/s");
-             particles->getFieldManager()->createField(1, "height", "m");
+            if (timestepper_type=="rk") {
+                particles->getFieldManager()->createField(1, "velocity", "m/s");
+                particles->getFieldManager()->createField(1, "height", "m");
 
 
-            particles->getFieldManager()->getFieldByName("velocity")->
-                    localInitFromScalarFunction(vel_boundary_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
-                    //localInitFromScalarFunction(zero_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
-            particles->getFieldManager()->getFieldByName("height")->
-                    localInitFromScalarFunction(h_boundary_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
-                    //localInitFromScalarFunction(zero_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+                particles->getFieldManager()->getFieldByName("velocity")->
+                        localInitFromScalarFunction(vel_boundary_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+                        //localInitFromScalarFunction(zero_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+                particles->getFieldManager()->getFieldByName("height")->
+                        localInitFromScalarFunction(h_boundary_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+                        //localInitFromScalarFunction(zero_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+            } else if (timestepper_type=="newmark") {
+                particles->getFieldManager()->createField(1, "d", "m/s");
+                particles->getFieldManager()->createField(1, "d_velocity", "m/s");
+                particles->getFieldManager()->getFieldByName("d")->
+                        localInitFromScalarFunction(h_boundary_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+                        //localInitFromScalarFunction(zero_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+                particles->getFieldManager()->getFieldByName("d_velocity")->
+                        localInitFromScalarFunction(vel_boundary_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+                        //localInitFromScalarFunction(zero_function.getRawPtr(), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"));
+
+            }
 
             Compadre::ConstantEachDimension proc_func = Compadre::ConstantEachDimension(comm->getRank(),1,1);
             particles->getFieldManager()->createField(1, "processor", "none");
@@ -189,8 +216,10 @@ int main (int argc, char* args[]) {
                 Teuchos::rcp( new Compadre::ExplicitTimeDependentPhysics(particles));
             Teuchos::RCP<Compadre::ExplicitTimeDependentSources> source =
                 Teuchos::rcp( new Compadre::ExplicitTimeDependentSources(particles));
+            source->setParameters(*parameters);
             Teuchos::RCP<Compadre::ExplicitTimeDependentBoundaryConditions> bcs =
                 Teuchos::rcp( new Compadre::ExplicitTimeDependentBoundaryConditions(particles));
+            bcs->setParameters(*parameters);
 
 
             // set physics, sources, and boundary conditions in the problem
@@ -222,7 +251,7 @@ int main (int argc, char* args[]) {
 
             //solving
             SolvingTime->start();
-            problem->solve(parameters->get<Teuchos::ParameterList>("time").get<int>("rk order") /* rk 4*/, parameters->get<Teuchos::ParameterList>("time").get<double>("t0"), parameters->get<Teuchos::ParameterList>("time").get<double>("t_end"), stable_timestep_size, parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file"));
+            problem->solve(parameters->get<Teuchos::ParameterList>("time"), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"), parameters->get<Teuchos::ParameterList>("time").get<double>("t_end"), stable_timestep_size, parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file"));
             SolvingTime->stop();
 
 //            WriteTime->start();
@@ -248,10 +277,19 @@ int main (int argc, char* args[]) {
 
             Compadre::host_view_type initial_coords = 
                 particles->getCoords()->getPts(false /*halo*/, false /*use_physical_coords*/)->getLocalView<Compadre::host_view_type>();
-            Compadre::host_view_type velocity_field = 
-                particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst()->getLocalView<Compadre::host_view_type>();
-            Compadre::host_view_type height_field = 
-                particles->getFieldManager()->getFieldByName("height")->getMultiVectorPtrConst()->getLocalView<Compadre::host_view_type>();
+
+            Compadre::host_view_type velocity_field, height_field;
+            if (timestepper_type=="rk") {
+                velocity_field = 
+                    particles->getFieldManager()->getFieldByName("velocity")->getMultiVectorPtrConst()->getLocalView<Compadre::host_view_type>();
+                height_field = 
+                    particles->getFieldManager()->getFieldByName("height")->getMultiVectorPtrConst()->getLocalView<Compadre::host_view_type>();
+            } else if (timestepper_type=="newmark") {
+                velocity_field = 
+                    particles->getFieldManager()->getFieldByName("d_velocity")->getMultiVectorPtrConst()->getLocalView<Compadre::host_view_type>();
+                height_field = 
+                    particles->getFieldManager()->getFieldByName("d")->getMultiVectorPtrConst()->getLocalView<Compadre::host_view_type>();
+            }
             //auto integral_vel_function = Compadre::CosT(parameters->get<Teuchos::ParameterList>("time").get<double>("t_end"),-1)+1;
             //auto integral_h_function = Compadre::CosT(parameters->get<Teuchos::ParameterList>("time").get<double>("t_end"),-1)+1;
             //auto integral_vel_function = 1+Compadre::CosT(parameters->get<Teuchos::ParameterList>("time").get<double>("t_end"),-1);
@@ -273,11 +311,11 @@ int main (int argc, char* args[]) {
                 if (solution_type=="polynomial time" && simulation_type=="eulerian") {
                     double this_diff = exact[0] - velocity_field(j,0);
                     if (std::abs(this_diff)>1e-8) {
-                        printf("%.16g vs %.16g: %.16f\n", exact[0], velocity_field(j,0), exact[0] - velocity_field(j,0));
+                        printf("v: %.16g vs %.16g: %.16f\n", exact[0], velocity_field(j,0), exact[0] - velocity_field(j,0));
                     }
                     this_diff = exact_height - height_field(j,0);
                     if (std::abs(this_diff)>1e-15) {
-                        printf("%.16g vs %.16g: %.16f\n", exact_height, velocity_field(j,0), exact_height - height_field(j,0));
+                        printf("h: %.16g vs %.16g: %.16f\n", exact_height, height_field(j,0), exact_height - height_field(j,0));
                     }
 
                 }

--- a/examples/Compadre_LagrangianShallowWater.cpp
+++ b/examples/Compadre_LagrangianShallowWater.cpp
@@ -56,7 +56,6 @@ int main (int argc, char* args[]) {
 	Kokkos::initialize(argc, args);
 
 	Teuchos::RCP<Teuchos::Time> SphericalParticleTime = Teuchos::TimeMonitor::getNewCounter ("Spherical Particle Time");
-	Teuchos::RCP<Teuchos::Time> NeighborSearchTime = Teuchos::TimeMonitor::getNewCounter ("Neighbor Search Time");
 	Teuchos::RCP<Teuchos::Time> FirstReadTime = Teuchos::TimeMonitor::getNewCounter ("1st Read Time");
 	Teuchos::RCP<Teuchos::Time> AssemblyTime = Teuchos::TimeMonitor::getNewCounter ("Assembly Time");
 	Teuchos::RCP<Teuchos::Time> SolvingTime = Teuchos::TimeMonitor::getNewCounter ("Solving Time");
@@ -230,7 +229,6 @@ int main (int argc, char* args[]) {
 			particles->createDOFManager();
 			particles->getDOFManager()->generateDOFMap();
 
-			NeighborSearchTime->start();
 			const ST h_support = parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("size")*sw_function.getRadius();
 
 			particles->createNeighborhood();
@@ -247,7 +245,6 @@ int main (int argc, char* args[]) {
 
 			double h_min = particles->getNeighborhood()->computeMinHSupportSize(true /*global min*/);
 
-			NeighborSearchTime->stop();
 
 			Teuchos::RCP<Compadre::ProblemExplicitTransientT> problem =
 				Teuchos::rcp( new Compadre::ProblemExplicitTransientT(particles));
@@ -290,7 +287,7 @@ int main (int argc, char* args[]) {
 
 			//solving
 			SolvingTime->start();
-			problem->solve(parameters->get<Teuchos::ParameterList>("time").get<int>("rk order") /* rk 4*/, parameters->get<Teuchos::ParameterList>("time").get<double>("t0"), parameters->get<Teuchos::ParameterList>("time").get<double>("t_end"), stable_timestep_size, parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file"));
+			problem->solve(parameters->get<Teuchos::ParameterList>("time"), parameters->get<Teuchos::ParameterList>("time").get<double>("t0"), parameters->get<Teuchos::ParameterList>("time").get<double>("t_end"), stable_timestep_size, parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file"));
 			SolvingTime->stop();
 
 

--- a/physics/Compadre_ExplicitTimeDependent_BoundaryConditions.cpp
+++ b/physics/Compadre_ExplicitTimeDependent_BoundaryConditions.cpp
@@ -28,7 +28,7 @@ void ExplicitTimeDependentBoundaryConditions::flagBoundaries() {
 
 }
 
-void ExplicitTimeDependentBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void ExplicitTimeDependentBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     bool is_velocity = false, is_height = false, is_d = false;
     try { 
@@ -58,6 +58,28 @@ void ExplicitTimeDependentBoundaryConditions::applyBoundaries(local_index_type f
     const std::vector<Teuchos::RCP<fields_type> >& fields = this->_particles->getFieldManagerConst()->getVectorOfFields();
     const local_dof_map_view_type local_to_dof_map = _dof_data->getDOFMap();
 
+    // Dirichlet boundary condition for explicit Newmark is enforced by setting the acceleration
+    // appropriately at time t_n in order to get the correct displacement at time t_{n+1}
+    // This requires knowledge of timestep sizes and previous velocities and accelerations
+    // as well as the current (t_{n+1}) displacements.
+    double gamma = 0.0;
+    host_view_type displacement_data, velocity_data, acceleration_data;
+    if (is_d) {
+        if (_velocity_id.size() < fields.size()) {
+            _velocity_id = std::vector<int>(fields.size(), -1);
+            _acceleration_id = std::vector<int>(fields.size(), -1);
+        }
+        gamma = _parameters->get<Teuchos::ParameterList>("time").get<double>("gamma");
+        if (previous_timestep_size<0.0) {
+            auto this_src_field_name = _particles->getFieldManagerConst()->getFieldByID(field_one)->getName();
+            _velocity_id[field_one] = _particles->getFieldManagerConst()->getIDOfFieldFromName(this_src_field_name+"_velocity");
+            _acceleration_id[field_one] = _particles->getFieldManagerConst()->getIDOfFieldFromName(this_src_field_name+"_acceleration");
+        }
+        displacement_data = fields[field_one]->getMultiVectorPtrConst()->getLocalView<host_view_type>();
+        velocity_data = fields[_velocity_id[field_one]]->getMultiVectorPtrConst()->getLocalView<host_view_type>();
+        acceleration_data = fields[_acceleration_id[field_one]]->getMultiVectorPtrConst()->getLocalView<host_view_type>();
+    }
+
     for (local_index_type i=0; i<nlocal; ++i) { // parallel_for causes cache thrashing
     	// get dof corresponding to field
     	for (local_index_type k = 0; k < fields[field_one]->nDim(); ++k) {
@@ -69,7 +91,16 @@ void ExplicitTimeDependentBoundaryConditions::applyBoundaries(local_index_type f
                 } else if (is_height) {
                     rhs_vals(dof,0) = _physics->h_boundary_function->evalScalar(pt, 0, time);
                 } else if (is_d) {
-                    rhs_vals(dof,0) = _physics->vel_source_function->evalScalar(pt, 0, time);
+                    // for setting acceleration at initial timestep
+                    if (previous_timestep_size<0.0) {
+                        rhs_vals(dof,0) = 2.0/(current_timestep_size*current_timestep_size)*(_physics->h_boundary_function->evalScalar(pt, 0, time+current_timestep_size)-displacement_data(dof,0)-current_timestep_size*velocity_data(dof,0));
+                        //printf("calc: %.16f::: t: %.16f, ts: %.16f, exd: %.16f, oldd: %.16f, oldv: %.16f\n", attempt, time, current_timestep_size, _physics->h_boundary_function->evalScalar(pt, 0, time+current_timestep_size), displacement_data(dof,0), velocity_data(dof,0));
+                    } else {
+                        rhs_vals(dof,0) = 1.0/(current_timestep_size*current_timestep_size*(gamma+0.5))*(_physics->h_boundary_function->evalScalar(pt, 0, time+current_timestep_size)-displacement_data(dof,0)-current_timestep_size*velocity_data(dof,0)-current_timestep_size*current_timestep_size*(1-gamma)*acceleration_data(dof,0));
+                        //printf("calc: %.16f::: t: %.16f, ts: %.16f, exd: %.16f, oldd: %.16f, oldv: %.16f, olda: %.16f\n", attempt, time, current_timestep_size, _physics->h_boundary_function->evalScalar(pt, 0, time+current_timestep_size), displacement_data(dof,0), velocity_data(dof,0), acceleration_data(dof,0));
+                    }
+                    // exact acceleration
+                    //rhs_vals(dof,0) = _physics->vel_source_function->evalScalar(pt, 0, time);
                 }
             }
     	}

--- a/physics/Compadre_ExplicitTimeDependent_BoundaryConditions.hpp
+++ b/physics/Compadre_ExplicitTimeDependent_BoundaryConditions.hpp
@@ -17,6 +17,8 @@ class ExplicitTimeDependentBoundaryConditions : public BoundaryConditionsT {
 
         ExplicitTimeDependentPhysics* _physics;
 
+        std::vector<int> _velocity_id, _acceleration_id;
+
 	public:
 
 		ExplicitTimeDependentBoundaryConditions( Teuchos::RCP<particle_type> particles,
@@ -28,7 +30,7 @@ class ExplicitTimeDependentBoundaryConditions : public BoundaryConditionsT {
 
 		virtual void flagBoundaries();
 
-		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_ExplicitTimeDependent_Operator.cpp
+++ b/physics/Compadre_ExplicitTimeDependent_Operator.cpp
@@ -32,7 +32,7 @@ typedef Compadre::NeighborhoodT neighborhood_type;
 typedef Compadre::XyzVector xyz_type;
 
 
-void ExplicitTimeDependentPhysics::computeVector(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void ExplicitTimeDependentPhysics::computeVector(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 

--- a/physics/Compadre_ExplicitTimeDependent_Operator.hpp
+++ b/physics/Compadre_ExplicitTimeDependent_Operator.hpp
@@ -42,7 +42,7 @@ class ExplicitTimeDependentPhysics : public PhysicsT {
 
 		virtual ~ExplicitTimeDependentPhysics() {}
 
-		virtual void computeVector(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void computeVector(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual const std::vector<InteractingFields> gatherFieldInteractions();
     

--- a/physics/Compadre_ExplicitTimeDependent_Sources.cpp
+++ b/physics/Compadre_ExplicitTimeDependent_Sources.cpp
@@ -16,8 +16,19 @@ typedef Compadre::XyzVector xyz_type;
 
 void ExplicitTimeDependentSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
 
-    bool is_velocity = (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity"));
-    bool is_height = (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("height"));
+    bool is_velocity = false, is_height = false, is_d = false;
+    try { 
+       is_velocity = (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity"));
+    } catch (...) {
+    }
+    try { 
+        is_height = (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("height"));
+    } catch (...) {
+    }
+    try { 
+        is_d = (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("d"));
+    } catch (...) {
+    }
 
     //if (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity")) {
 	//Teuchos::RCP<Compadre::AnalyticFunction> function;
@@ -48,8 +59,11 @@ void ExplicitTimeDependentSources::evaluateRHS(local_index_type field_one, local
 				//rhs_vals(dof,0) = function->evalScalar(pt);
                 if (is_velocity) {
                     rhs_vals(dof,0) = _physics->vel_source_function->evalScalar(pt, 0, time);
-                } else {
+                } else if (is_height) {
                     rhs_vals(dof,0) = _physics->h_source_function->evalScalar(pt, 0, time);
+                } else if (is_d) {
+                    rhs_vals(dof,0) = _physics->vel_source_function->evalScalar(pt, 0, time);
+                    //printf("ppp(%f): %.16f\n",time,_physics->vel_source_function->evalScalar(pt, 0, time));
                 }
 				//xyz_type bdry_val = function->evalVector(pt);
 				//rhs_vals(dof,0) = bdry_val[k]*time*time*time; // just for testing purposes
@@ -60,9 +74,14 @@ void ExplicitTimeDependentSources::evaluateRHS(local_index_type field_one, local
 }
 
 std::vector<InteractingFields> ExplicitTimeDependentSources::gatherFieldInteractions() {
+    auto timestepper_type = _parameters->get<Teuchos::ParameterList>("time").get<std::string>("type");
 	std::vector<InteractingFields> field_interactions;
-	field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity")));
-	field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getIDOfFieldFromName("height")));
+    if (timestepper_type=="rk") {
+	    field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity")));
+	    field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getIDOfFieldFromName("height")));
+    } else if (timestepper_type=="newmark") {
+	    field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getIDOfFieldFromName("d")));
+    }
 //	field_interactions.push_back(InteractingFields(op_needing_interaction::source, _particles->getFieldManagerConst()->getField("height")));
 //	printf("src: %d %d\n", _particles->getFieldManagerConst()->getField("velocity"), _particles->getFieldManagerConst()->getField("height"));
 	return field_interactions;

--- a/physics/Compadre_ExplicitTimeDependent_Sources.cpp
+++ b/physics/Compadre_ExplicitTimeDependent_Sources.cpp
@@ -14,7 +14,7 @@ namespace Compadre {
 typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 
-void ExplicitTimeDependentSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void ExplicitTimeDependentSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     bool is_velocity = false, is_height = false, is_d = false;
     try { 

--- a/physics/Compadre_ExplicitTimeDependent_Sources.hpp
+++ b/physics/Compadre_ExplicitTimeDependent_Sources.hpp
@@ -24,7 +24,7 @@ class ExplicitTimeDependentSources : public SourcesT {
 
 		virtual ~ExplicitTimeDependentSources() {};
 
-		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_CurlCurl_BoundaryConditions.cpp
+++ b/physics/Compadre_GMLS_CurlCurl_BoundaryConditions.cpp
@@ -28,7 +28,7 @@ void GMLS_CurlCurlBoundaryConditions::flagBoundaries() {
 
 }
 
-void GMLS_CurlCurlBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_CurlCurlBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Compadre::AnalyticFunction> function;
 	if (_parameters->get<std::string>("solution type")=="sine") {
 		function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::CurlCurlSineTest));

--- a/physics/Compadre_GMLS_CurlCurl_BoundaryConditions.hpp
+++ b/physics/Compadre_GMLS_CurlCurl_BoundaryConditions.hpp
@@ -24,7 +24,7 @@ class GMLS_CurlCurlBoundaryConditions : public BoundaryConditionsT {
 
 		virtual void flagBoundaries();
 
-		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 };

--- a/physics/Compadre_GMLS_CurlCurl_Operator.cpp
+++ b/physics/Compadre_GMLS_CurlCurl_Operator.cpp
@@ -71,7 +71,7 @@ Teuchos::RCP<crs_graph_type> GMLS_CurlCurlPhysics::computeGraph(local_index_type
     return this->_A_graph;
 }
 
-void GMLS_CurlCurlPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_CurlCurlPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 

--- a/physics/Compadre_GMLS_CurlCurl_Operator.hpp
+++ b/physics/Compadre_GMLS_CurlCurl_Operator.hpp
@@ -27,7 +27,7 @@ class GMLS_CurlCurlPhysics : public PhysicsT {
 
 		virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
 
-		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual const std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_CurlCurl_Sources.cpp
+++ b/physics/Compadre_GMLS_CurlCurl_Sources.cpp
@@ -13,7 +13,7 @@ namespace Compadre {
 typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 
-void GMLS_CurlCurlSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_CurlCurlSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Compadre::AnalyticFunction> function;
 	if (_parameters->get<std::string>("solution type")=="sine") {
 		function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::CurlCurlSineTestRHS));

--- a/physics/Compadre_GMLS_CurlCurl_Sources.hpp
+++ b/physics/Compadre_GMLS_CurlCurl_Sources.hpp
@@ -20,7 +20,7 @@ class GMLS_CurlCurlSources : public SourcesT {
 
 		virtual ~GMLS_CurlCurlSources() {};
 
-		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_PinnedLaplacian_BoundaryConditions.cpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_BoundaryConditions.cpp
@@ -27,7 +27,7 @@ void GMLS_PinnedLaplacianBoundaryConditions::flagBoundaries() {
 
 }
 
-void GMLS_PinnedLaplacianBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_PinnedLaplacianBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Compadre::AnalyticFunction> function;
 	if (_parameters->get<std::string>("solution type")=="sine") {
 		function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::SineProducts));

--- a/physics/Compadre_GMLS_PinnedLaplacian_BoundaryConditions.hpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_BoundaryConditions.hpp
@@ -24,7 +24,7 @@ class GMLS_PinnedLaplacianBoundaryConditions : public BoundaryConditionsT {
 
 		virtual void flagBoundaries();
 
-		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 };

--- a/physics/Compadre_GMLS_PinnedLaplacian_Operator.cpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_Operator.cpp
@@ -66,7 +66,7 @@ Teuchos::RCP<crs_graph_type> GMLS_LaplacianPhysics::computeGraph(local_index_typ
     return this->_A_graph;
 }
 
-void GMLS_LaplacianPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_LaplacianPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 

--- a/physics/Compadre_GMLS_PinnedLaplacian_Operator.hpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_Operator.hpp
@@ -29,7 +29,7 @@ class GMLS_LaplacianPhysics : public PhysicsT {
 		
 		virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
 
-		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual const std::vector<InteractingFields> gatherFieldInteractions();
     

--- a/physics/Compadre_GMLS_PinnedLaplacian_Sources.cpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_Sources.cpp
@@ -13,7 +13,7 @@ namespace Compadre {
 typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 
-void GMLS_PinnedLaplacianSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_PinnedLaplacianSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Compadre::AnalyticFunction> function;
 	if (_parameters->get<std::string>("solution type")=="sine") {
 		function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::SineProducts));

--- a/physics/Compadre_GMLS_PinnedLaplacian_Sources.hpp
+++ b/physics/Compadre_GMLS_PinnedLaplacian_Sources.hpp
@@ -20,7 +20,7 @@ class GMLS_PinnedLaplacianSources : public SourcesT {
 
 		virtual ~GMLS_PinnedLaplacianSources() {};
 
-		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_PoissonNeumann_BoundaryConditions.cpp
+++ b/physics/Compadre_GMLS_PoissonNeumann_BoundaryConditions.cpp
@@ -16,7 +16,7 @@ typedef Compadre::XyzVector xyz_type;
 void GMLS_PoissonNeumannBoundaryConditions::flagBoundaries() {
 }
 
-void GMLS_PoissonNeumannBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_PoissonNeumannBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
     Teuchos::RCP<Compadre::AnalyticFunction> function;
     if (_parameters->get<std::string>("solution type")=="sine") {
         function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::SineProducts));

--- a/physics/Compadre_GMLS_PoissonNeumann_BoundaryConditions.hpp
+++ b/physics/Compadre_GMLS_PoissonNeumann_BoundaryConditions.hpp
@@ -19,7 +19,7 @@ class GMLS_PoissonNeumannBoundaryConditions : public BoundaryConditionsT {
 
         virtual void flagBoundaries();
 
-        virtual void applyBoundaries(local_index_type field_one, local_index_type field_two=-1, scalar_type time=0.0);
+        virtual void applyBoundaries(local_index_type field_one, local_index_type field_two=-1, scalar_type time=0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual std::vector<InteractingFields> gatherFieldInteractions();
 };

--- a/physics/Compadre_GMLS_PoissonNeumann_Operator.cpp
+++ b/physics/Compadre_GMLS_PoissonNeumann_Operator.cpp
@@ -227,7 +227,7 @@ Teuchos::RCP<crs_graph_type> GMLS_PoissonNeumannPhysics::computeGraph(local_inde
     return this->_A_graph;
 }
 
-void GMLS_PoissonNeumannPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_PoissonNeumannPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     bool use_physical_coords = true; // can be set on the operator in the future
 

--- a/physics/Compadre_GMLS_PoissonNeumann_Operator.hpp
+++ b/physics/Compadre_GMLS_PoissonNeumann_Operator.hpp
@@ -35,7 +35,7 @@ class GMLS_PoissonNeumannPhysics : public PhysicsT{
 
         virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
 
-        virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+        virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual const std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_PoissonNeumann_Sources.cpp
+++ b/physics/Compadre_GMLS_PoissonNeumann_Sources.cpp
@@ -17,7 +17,7 @@ typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 typedef Compadre::NeighborhoodT neighborhood_type;
 
-void GMLS_PoissonNeumannSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_PoissonNeumannSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
     Teuchos::RCP<Compadre::AnalyticFunction> function;
     if (_parameters->get<std::string>("solution type")=="sine") {
         function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::SineProducts));

--- a/physics/Compadre_GMLS_PoissonNeumann_Sources.hpp
+++ b/physics/Compadre_GMLS_PoissonNeumann_Sources.hpp
@@ -19,7 +19,7 @@ class GMLS_PoissonNeumannSources : public SourcesT{
 
         virtual ~GMLS_PoissonNeumannSources() {};
 
-        virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+        virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_StaggeredAnalytic_PinnedLaplacian_Operator.cpp
+++ b/physics/Compadre_GMLS_StaggeredAnalytic_PinnedLaplacian_Operator.cpp
@@ -66,7 +66,7 @@ Teuchos::RCP<crs_graph_type> GMLS_StaggeredAnalytic_LaplacianPhysics::computeGra
     return this->_A_graph;
 }
 
-void GMLS_StaggeredAnalytic_LaplacianPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_StaggeredAnalytic_LaplacianPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 

--- a/physics/Compadre_GMLS_StaggeredAnalytic_PinnedLaplacian_Operator.hpp
+++ b/physics/Compadre_GMLS_StaggeredAnalytic_PinnedLaplacian_Operator.hpp
@@ -25,7 +25,7 @@ class GMLS_StaggeredAnalytic_LaplacianPhysics : public PhysicsT {
 
 		virtual ~GMLS_StaggeredAnalytic_LaplacianPhysics() {}
 		virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
-		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 		virtual const std::vector<InteractingFields> gatherFieldInteractions();
 };
 

--- a/physics/Compadre_GMLS_StaggeredIntegral_PinnedLaplacian_Operator.cpp
+++ b/physics/Compadre_GMLS_StaggeredIntegral_PinnedLaplacian_Operator.cpp
@@ -66,7 +66,7 @@ Teuchos::RCP<crs_graph_type> GMLS_StaggeredIntegral_LaplacianPhysics::computeGra
     return this->_A_graph;
 }
 
-void GMLS_StaggeredIntegral_LaplacianPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_StaggeredIntegral_LaplacianPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 

--- a/physics/Compadre_GMLS_StaggeredIntegral_PinnedLaplacian_Operator.hpp
+++ b/physics/Compadre_GMLS_StaggeredIntegral_PinnedLaplacian_Operator.hpp
@@ -25,7 +25,7 @@ class GMLS_StaggeredIntegral_LaplacianPhysics : public PhysicsT {
 
 		virtual ~GMLS_StaggeredIntegral_LaplacianPhysics() {}
 		virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
-		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 		virtual const std::vector<InteractingFields> gatherFieldInteractions();
 };
 

--- a/physics/Compadre_GMLS_Staggered_PoissonNeumann_Operator.cpp
+++ b/physics/Compadre_GMLS_Staggered_PoissonNeumann_Operator.cpp
@@ -231,7 +231,7 @@ Teuchos::RCP<crs_graph_type> GMLS_Staggered_PoissonNeumannPhysics::computeGraph(
     return this->_A_graph;
 }
 
-void GMLS_Staggered_PoissonNeumannPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_Staggered_PoissonNeumannPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     bool use_physical_coords = true; // can be set on the operator in the future
 

--- a/physics/Compadre_GMLS_Staggered_PoissonNeumann_Operator.hpp
+++ b/physics/Compadre_GMLS_Staggered_PoissonNeumann_Operator.hpp
@@ -35,7 +35,7 @@ class GMLS_Staggered_PoissonNeumannPhysics : public PhysicsT{
 
         virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
 
-        virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+        virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual const std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_Staggered_PoissonNeumann_Sources.cpp
+++ b/physics/Compadre_GMLS_Staggered_PoissonNeumann_Sources.cpp
@@ -17,7 +17,7 @@ typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 typedef Compadre::NeighborhoodT neighborhood_type;
 
-void GMLS_Staggered_PoissonNeumannSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_Staggered_PoissonNeumannSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
     Teuchos::RCP<Compadre::AnalyticFunction> function;
     if (_parameters->get<std::string>("solution type")=="sine") {
         function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::SineProducts));

--- a/physics/Compadre_GMLS_Staggered_PoissonNeumann_Sources.hpp
+++ b/physics/Compadre_GMLS_Staggered_PoissonNeumann_Sources.hpp
@@ -19,7 +19,7 @@ class GMLS_Staggered_PoissonNeumannSources : public SourcesT{
 
         virtual ~GMLS_Staggered_PoissonNeumannSources() {};
 
-        virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+        virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_Stokes_BoundaryConditions.cpp
+++ b/physics/Compadre_GMLS_Stokes_BoundaryConditions.cpp
@@ -16,7 +16,7 @@ typedef Compadre::XyzVector xyz_type;
 void GMLS_StokesBoundaryConditions::flagBoundaries() {
 }
 
-void GMLS_StokesBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_StokesBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
     Teuchos::RCP<Compadre::AnalyticFunction> velocity_function, pressure_function;
     if (_parameters->get<std::string>("solution type")=="sine") {
         velocity_function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::CurlCurlSineTest));

--- a/physics/Compadre_GMLS_Stokes_BoundaryConditions.hpp
+++ b/physics/Compadre_GMLS_Stokes_BoundaryConditions.hpp
@@ -19,7 +19,7 @@ class GMLS_StokesBoundaryConditions : public BoundaryConditionsT {
 
         virtual void flagBoundaries();
 
-        virtual void applyBoundaries(local_index_type field_one, local_index_type field_two=-1, scalar_type time=0.0);
+        virtual void applyBoundaries(local_index_type field_one, local_index_type field_two=-1, scalar_type time=0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual std::vector<InteractingFields> gatherFieldInteractions();
 };

--- a/physics/Compadre_GMLS_Stokes_Operator.cpp
+++ b/physics/Compadre_GMLS_Stokes_Operator.cpp
@@ -469,7 +469,7 @@ Teuchos::RCP<crs_graph_type> GMLS_StokesPhysics::computeGraph(local_index_type f
     return this->_A_graph;
 }
 
-void GMLS_StokesPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_StokesPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     bool use_physical_coords = true; // can be set on the operator in the future
 

--- a/physics/Compadre_GMLS_Stokes_Operator.hpp
+++ b/physics/Compadre_GMLS_Stokes_Operator.hpp
@@ -34,7 +34,7 @@ class GMLS_StokesPhysics : public PhysicsT {
 
         virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
 
-        virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+        virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual const std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_GMLS_Stokes_Sources.cpp
+++ b/physics/Compadre_GMLS_Stokes_Sources.cpp
@@ -17,7 +17,7 @@ typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 typedef Compadre::NeighborhoodT neighborhood_type;
 
-void GMLS_StokesSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void GMLS_StokesSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
     Teuchos::RCP<Compadre::AnalyticFunction> velocity_function, velocity_true_function, pressure_function;
     if (_parameters->get<std::string>("solution type")=="sine") {
         velocity_function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::CurlCurlSineTestRHS));

--- a/physics/Compadre_GMLS_Stokes_Sources.hpp
+++ b/physics/Compadre_GMLS_Stokes_Sources.hpp
@@ -19,7 +19,7 @@ class GMLS_StokesSources : public SourcesT{
 
         virtual ~GMLS_StokesSources() {};
 
-        virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+        virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_LagrangianShallowWater_BoundaryConditions.cpp
+++ b/physics/Compadre_LagrangianShallowWater_BoundaryConditions.cpp
@@ -27,7 +27,7 @@ void LagrangianShallowWaterBoundaryConditions::flagBoundaries() {
 
 }
 
-void LagrangianShallowWaterBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void LagrangianShallowWaterBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     //if (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity")) {
 	//    Teuchos::RCP<Compadre::AnalyticFunction> function;

--- a/physics/Compadre_LagrangianShallowWater_BoundaryConditions.hpp
+++ b/physics/Compadre_LagrangianShallowWater_BoundaryConditions.hpp
@@ -24,7 +24,7 @@ class LagrangianShallowWaterBoundaryConditions : public BoundaryConditionsT {
 
 		virtual void flagBoundaries();
 
-		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 };

--- a/physics/Compadre_LagrangianShallowWater_Operator.cpp
+++ b/physics/Compadre_LagrangianShallowWater_Operator.cpp
@@ -32,7 +32,7 @@ typedef Compadre::NeighborhoodT neighborhood_type;
 typedef Compadre::XyzVector xyz_type;
 
 
-void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void LagrangianShallowWaterPhysics::computeVector(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 

--- a/physics/Compadre_LagrangianShallowWater_Operator.hpp
+++ b/physics/Compadre_LagrangianShallowWater_Operator.hpp
@@ -36,7 +36,7 @@ class LagrangianShallowWaterPhysics : public PhysicsT {
 
 		virtual ~LagrangianShallowWaterPhysics() {}
 
-		virtual void computeVector(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void computeVector(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual const std::vector<InteractingFields> gatherFieldInteractions();
     

--- a/physics/Compadre_LagrangianShallowWater_Sources.cpp
+++ b/physics/Compadre_LagrangianShallowWater_Sources.cpp
@@ -13,7 +13,7 @@ namespace Compadre {
 typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 
-void LagrangianShallowWaterSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void LagrangianShallowWaterSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     //if (field_one == _particles->getFieldManagerConst()->getIDOfFieldFromName("velocity")) {
 	//    Teuchos::RCP<Compadre::AnalyticFunction> function;

--- a/physics/Compadre_LagrangianShallowWater_Sources.hpp
+++ b/physics/Compadre_LagrangianShallowWater_Sources.hpp
@@ -20,7 +20,7 @@ class LagrangianShallowWaterSources : public SourcesT {
 
 		virtual ~LagrangianShallowWaterSources() {};
 
-		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_LaplaceBeltrami_BoundaryConditions.cpp
+++ b/physics/Compadre_LaplaceBeltrami_BoundaryConditions.cpp
@@ -23,7 +23,7 @@ void LaplaceBeltramiBoundaryConditions::flagBoundaries() {
 	}
 }
 
-void LaplaceBeltramiBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void LaplaceBeltramiBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Compadre::AnalyticFunction> function;
 //	function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::ConstantEachDimension(1,1,1)));
 	if (_parameters->get<local_index_type>("physics number")<3) {

--- a/physics/Compadre_LaplaceBeltrami_BoundaryConditions.hpp
+++ b/physics/Compadre_LaplaceBeltrami_BoundaryConditions.hpp
@@ -26,7 +26,7 @@ class LaplaceBeltramiBoundaryConditions : public BoundaryConditionsT {
 
 		virtual void flagBoundaries();
 
-		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_LaplaceBeltrami_Operator.cpp
+++ b/physics/Compadre_LaplaceBeltrami_Operator.cpp
@@ -314,7 +314,7 @@ Teuchos::RCP<crs_graph_type> LaplaceBeltramiPhysics::computeGraph(local_index_ty
     return _A_graph;
 }
 
-void LaplaceBeltramiPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void LaplaceBeltramiPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 

--- a/physics/Compadre_LaplaceBeltrami_Operator.hpp
+++ b/physics/Compadre_LaplaceBeltrami_Operator.hpp
@@ -30,7 +30,7 @@ class LaplaceBeltramiPhysics : public PhysicsT {
 		
 		virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
 
-		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual const std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_LaplaceBeltrami_Sources.cpp
+++ b/physics/Compadre_LaplaceBeltrami_Sources.cpp
@@ -13,7 +13,7 @@ namespace Compadre {
 typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 
-void LaplaceBeltramiSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void LaplaceBeltramiSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Compadre::AnalyticFunction> function;
 //	function = Teuchos::rcp_static_cast<Compadre::AnalyticFunction>(Teuchos::rcp(new Compadre::ConstantEachDimension(1,1,1)));
 	if (_parameters->get<local_index_type>("physics number")<3) {

--- a/physics/Compadre_LaplaceBeltrami_Sources.hpp
+++ b/physics/Compadre_LaplaceBeltrami_Sources.hpp
@@ -20,7 +20,7 @@ class LaplaceBeltramiSources : public SourcesT {
 
 		virtual ~LaplaceBeltramiSources() {};
 
-		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_PinnedGraphLaplacian_BoundaryConditions.cpp
+++ b/physics/Compadre_PinnedGraphLaplacian_BoundaryConditions.cpp
@@ -23,7 +23,7 @@ void PinnedGraphLaplacianBoundaryConditions::flagBoundaries() {
 
 }
 
-void PinnedGraphLaplacianBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void PinnedGraphLaplacianBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	TEUCHOS_TEST_FOR_EXCEPT_MSG(_b==NULL, "Tpetra Multivector for BCS not yet specified.");
 	if (field_two == -1) {
 		field_two = field_one;

--- a/physics/Compadre_PinnedGraphLaplacian_BoundaryConditions.hpp
+++ b/physics/Compadre_PinnedGraphLaplacian_BoundaryConditions.hpp
@@ -24,7 +24,7 @@ class PinnedGraphLaplacianBoundaryConditions : public BoundaryConditionsT {
 
 		virtual void flagBoundaries();
 
-		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 };

--- a/physics/Compadre_PinnedGraphLaplacian_Operator.cpp
+++ b/physics/Compadre_PinnedGraphLaplacian_Operator.cpp
@@ -57,7 +57,7 @@ Teuchos::RCP<crs_graph_type> PinnedGraphLaplacianPhysics::computeGraph(local_ind
     return this->_A_graph;
 }
 
-void PinnedGraphLaplacianPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void PinnedGraphLaplacianPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	Teuchos::RCP<Teuchos::Time> ComputeMatrixTime = Teuchos::TimeMonitor::getNewCounter ("Compute Matrix Time");
 	ComputeMatrixTime->start();
 	TEUCHOS_TEST_FOR_EXCEPT_MSG(this->_A.is_null(), "Tpetra CrsMatrix for Physics not yet specified.");

--- a/physics/Compadre_PinnedGraphLaplacian_Operator.hpp
+++ b/physics/Compadre_PinnedGraphLaplacian_Operator.hpp
@@ -21,7 +21,7 @@ class PinnedGraphLaplacianPhysics : public PhysicsT {
 
 		virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
 
-		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual const std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_PinnedGraphLaplacian_Sources.cpp
+++ b/physics/Compadre_PinnedGraphLaplacian_Sources.cpp
@@ -10,7 +10,7 @@ namespace Compadre {
 
 typedef Compadre::FieldT fields_type;
 
-void PinnedGraphLaplacianSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void PinnedGraphLaplacianSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 	TEUCHOS_TEST_FOR_EXCEPT_MSG(_b==NULL, "Tpetra Multivector for RHS not yet specified.");
 	if (field_two == -1) {
 		field_two = field_one;

--- a/physics/Compadre_PinnedGraphLaplacian_Sources.hpp
+++ b/physics/Compadre_PinnedGraphLaplacian_Sources.hpp
@@ -20,7 +20,7 @@ class PinnedGraphLaplacianSources : public SourcesT {
 
 		virtual ~PinnedGraphLaplacianSources() {};
 
-		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 };

--- a/physics/Compadre_ReactionDiffusion_BoundaryConditions.cpp
+++ b/physics/Compadre_ReactionDiffusion_BoundaryConditions.cpp
@@ -14,7 +14,7 @@ namespace Compadre {
 void ReactionDiffusionBoundaryConditions::flagBoundaries() {
 }
 
-void ReactionDiffusionBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void ReactionDiffusionBoundaryConditions::applyBoundaries(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     if (field_one != _physics->_pressure_field_id || field_two != _physics->_pressure_field_id) return;
 

--- a/physics/Compadre_ReactionDiffusion_BoundaryConditions.hpp
+++ b/physics/Compadre_ReactionDiffusion_BoundaryConditions.hpp
@@ -28,7 +28,7 @@ class ReactionDiffusionBoundaryConditions : public BoundaryConditionsT {
 
         virtual void flagBoundaries();
 
-        virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+        virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_ReactionDiffusion_Operator.cpp
+++ b/physics/Compadre_ReactionDiffusion_Operator.cpp
@@ -1232,7 +1232,7 @@ Teuchos::RCP<crs_graph_type> ReactionDiffusionPhysics::computeGraph(local_index_
 }
 
 
-void ReactionDiffusionPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void ReactionDiffusionPhysics::computeMatrix(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     bool use_physical_coords = true; // can be set on the operator in the future
 

--- a/physics/Compadre_ReactionDiffusion_Operator.hpp
+++ b/physics/Compadre_ReactionDiffusion_Operator.hpp
@@ -154,7 +154,7 @@ class ReactionDiffusionPhysics : public PhysicsT {
         
         virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1);
 
-        virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+        virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
         virtual const std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/physics/Compadre_ReactionDiffusion_Sources.cpp
+++ b/physics/Compadre_ReactionDiffusion_Sources.cpp
@@ -17,7 +17,7 @@ namespace Compadre {
 typedef Compadre::FieldT fields_type;
 typedef Compadre::XyzVector xyz_type;
 
-void ReactionDiffusionSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time) {
+void ReactionDiffusionSources::evaluateRHS(local_index_type field_one, local_index_type field_two, scalar_type time, scalar_type current_timestep_size, scalar_type previous_timestep_size) {
 
     auto cell_vertices = _physics->_cells->getFieldManager()->getFieldByName("vertex_points")->getMultiVectorPtr()->getLocalView<host_view_type>();
     if (field_one != field_two) return;

--- a/physics/Compadre_ReactionDiffusion_Sources.hpp
+++ b/physics/Compadre_ReactionDiffusion_Sources.hpp
@@ -24,7 +24,7 @@ class ReactionDiffusionSources : public SourcesT {
 
 		virtual ~ReactionDiffusionSources() {};
 
-		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0);
+		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0);
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions();
 

--- a/src/Compadre_BoundaryConditionsT.hpp
+++ b/src/Compadre_BoundaryConditionsT.hpp
@@ -45,7 +45,7 @@ class BoundaryConditionsT {
 
 		virtual void flagBoundaries() = 0;
 
-		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0) = 0;
+		virtual void applyBoundaries(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0) = 0;
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions() = 0;
 };

--- a/src/Compadre_FieldManager.cpp
+++ b/src/Compadre_FieldManager.cpp
@@ -192,6 +192,7 @@ void FieldManager::updateFieldsFromVector(Teuchos::RCP<mvec_type> source, local_
 			field_vals(i,j) = source_data(i*this->_fields[field_num]->nDim() + j,0);
 		}
 	});
+    Kokkos::fence();
 
 	this->updateFieldsHaloData(field_num);
 
@@ -222,6 +223,7 @@ void FieldManager::updateVectorFromFields(Teuchos::RCP<mvec_type> target, local_
 			target_data(i*this->_fields[field_num]->nDim() + j,0) = field_vals(i,j);
 		}
 	});
+    Kokkos::fence();
 }
 
 const std::vector<Teuchos::RCP<FieldManager::field_type> >& FieldManager::getVectorOfFields() const {

--- a/src/Compadre_ParameterManager.cpp
+++ b/src/Compadre_ParameterManager.cpp
@@ -152,9 +152,10 @@ void ParameterManager::setDefaultParameters() {
 
 	// Timestepping Details
 	Teuchos::RCP<Teuchos::ParameterList> timeList = Teuchos::rcp(new Teuchos::ParameterList("time"));
+	timeList->set("type", "rk"); // time stepper type (rk, newmark)
 	timeList->set("dt", (scalar_type)-1); // explicitly setting the timestep, negative means not set
 	timeList->set("dt multiplier", (scalar_type)-1); // multiplier times the CFL
-	timeList->set("rk order", (local_index_type)4); // runge-kutta order
+	timeList->set("order", (local_index_type)4); // order of method
 	timeList->set("t_0", (scalar_type)0.0); // initial simulation time
 	timeList->set("t_end", (scalar_type)0.0); // ending simulation time
 

--- a/src/Compadre_PhysicsT.hpp
+++ b/src/Compadre_PhysicsT.hpp
@@ -66,9 +66,9 @@ class PhysicsT {
 
 		virtual Teuchos::RCP<crs_graph_type> computeGraph(local_index_type field_one, local_index_type field_two = -1) { return Teuchos::null; };
 
-		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0) {};
+		virtual void computeMatrix(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0) {};
 
-		virtual void computeVector(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0) {};
+		virtual void computeVector(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0) {};
 
 		virtual const std::vector<InteractingFields> gatherFieldInteractions() = 0;
 

--- a/src/Compadre_ProblemExplicitTransientT.cpp
+++ b/src/Compadre_ProblemExplicitTransientT.cpp
@@ -14,9 +14,6 @@
 
 #include "Compadre_SolverT.hpp"
 
-// TODO: temporary, remove later when analytic solution not needed
-#include <Teuchos_SerialDenseMatrix.hpp>
-#include <Teuchos_SerialDenseSolver.hpp>
 #include <Compadre_AnalyticFunctions.hpp>
 #include <Compadre_XyzVector.hpp>
 #include <Compadre_GMLS.hpp> // for getNP()
@@ -255,9 +252,42 @@ void ProblemExplicitTransientT::initialize() {
 
 }
 
-void ProblemExplicitTransientT::solve(local_index_type rk_order, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename) {
+void ProblemExplicitTransientT::solve(Teuchos::ParameterList& parameters_time, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename) {
+
+    int order = parameters_time.get<int>("order");
+
+    // details for writing to files every nth timestep
+    Compadre::FileManager fm;
+    std::string base, extension;
+
+    if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") >= 0) {
+        // parse by removing extension of filename
+
+        // get extension
+        size_t pos = filename.rfind('.', filename.length());
+
+        // verify there was an extension extension
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(pos <= 0, "Filename specified to solve(...) is missing an extension.");
+
+        base = filename.substr(0, pos);
+        extension = filename.substr(pos+1, filename.length() - pos);
+    }
+
+    auto stepper_type = parameters_time.get<std::string>("type");
+    std::transform(stepper_type.begin(), stepper_type.end(), stepper_type.begin(), ::tolower);
+    if (stepper_type == "rk") {
+        this->solveRK(parameters_time, t_0, t_end, dt, filename);
+    } else if (stepper_type == "newmark") {
+        this->solveNewmark(parameters_time, t_0, t_end, dt, filename);
+    } else {
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(true, "Filename specified to solve(...) is missing an extension.");
+    }
+}
+
+void ProblemExplicitTransientT::solveRK(Teuchos::ParameterList& parameters_time, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename) {
 
 //    Compadre::ShallowWaterTestCases sw_function = Compadre::ShallowWaterTestCases(_parameters->get<int>("shallow water test case"), 0 /*alpha*/);
+    int rk_order = parameters_time.get<int>("order");
 
     // details for writing to files every nth timestep
     Compadre::FileManager fm;
@@ -681,8 +711,7 @@ void ProblemExplicitTransientT::solve(local_index_type rk_order, scalar_type t_0
 
                 fm.setWriter(filename, _particles);
                 if (_comm->getRank()==0)
-                    std::cout << "Wrote " << filename << " to disk." << std::endl;
-
+                    std::cout << "Wrote " << filename << " to disk for simulation time t=" << t << "." << std::endl;
 
                 // requires mapping solution back in order to write particles to disk
 
@@ -904,27 +933,28 @@ void ProblemExplicitTransientT::solve(local_index_type rk_order, scalar_type t_0
 //                }
 //            }
 
-            // find new neighborhoods
-            {
-                // get old search size
-                scalar_type h_min = _particles->getNeighborhood()->computeMinHSupportSize(true /*global min*/);
+            // don't find new neighborhoods, keep old ones from original configuration
+            //// find new neighborhoods
+            //{
+            //    // get old search size
+            //    scalar_type h_min = _particles->getNeighborhood()->computeMinHSupportSize(true /*global min*/);
 
-                // destroy old neighborhood and create new one
-                _particles->createNeighborhood();
-                _particles->getNeighborhood()->setAllHSupportSizes(h_min);
+            //    // destroy old neighborhood and create new one
+            //    _particles->createNeighborhood();
+            //    _particles->getNeighborhood()->setAllHSupportSizes(h_min);
 
-                if (_particles->getCoordsConst()->getComm()->getRank()==0)
-                    printf("hmin: %f\n", h_min);
-                // determine number of neighbors needed and construct list
-                local_index_type neighbors_needed = GMLS::getNP(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"), 2);
-                _particles->getNeighborhood()->constructAllNeighborLists(_particles->getCoordsConst()->getHaloSize(), 
-                        _parameters->get<Teuchos::ParameterList>("neighborhood").get<std::string>("search type"), 
-                        neighbors_needed,
-                        _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("cutoff multiplier"),
-                        _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("size"),
-                        _parameters->get<Teuchos::ParameterList>("neighborhood").get<bool>("uniform radii"),
-                        _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("radii post search scaling"));
-            }
+            //    if (_particles->getCoordsConst()->getComm()->getRank()==0)
+            //        printf("hmin: %f\n", h_min);
+            //    // determine number of neighbors needed and construct list
+            //    local_index_type neighbors_needed = GMLS::getNP(_parameters->get<Teuchos::ParameterList>("remap").get<int>("porder"), 2);
+            //    _particles->getNeighborhood()->constructAllNeighborLists(_particles->getCoordsConst()->getHaloSize(), 
+            //            _parameters->get<Teuchos::ParameterList>("neighborhood").get<std::string>("search type"), 
+            //            neighbors_needed,
+            //            _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("cutoff multiplier"),
+            //            _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("size"),
+            //            _parameters->get<Teuchos::ParameterList>("neighborhood").get<bool>("uniform radii"),
+            //            _parameters->get<Teuchos::ParameterList>("neighborhood").get<double>("radii post search scaling"));
+            //}
 
         }
     }
@@ -1031,6 +1061,329 @@ void ProblemExplicitTransientT::solve(local_index_type rk_order, scalar_type t_0
 //            break;
 //        }
 //    }
+}
+
+void ProblemExplicitTransientT::solveNewmark(Teuchos::ParameterList& parameters_time, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename) {
+
+    // only support explicit methods, i.e. beta=0
+    scalar_type gamma = parameters_time.get<double>("gamma");
+    scalar_type beta = parameters_time.get<double>("beta");
+    TEUCHOS_TEST_FOR_EXCEPT_MSG(beta != 0, "Currently only support for beta==0");
+
+    // check that any field having an interaction as source (is a member of the fields being time-integrated) 
+    // also has a given *_velocity as a field
+    //
+    // e.g. if "v" is a field that is registered for interaction (a solution variable)
+    //      then "v_velocity" should be a field for the particle set (not registered for interaction)
+    std::vector<local_index_type> displacement_to_velocity_map(_particles->getFieldManagerConst()->getVectorOfFields().size());
+    for (InteractingFields field_interaction : _field_interactions) {
+        auto this_src_field_name = _particles->getFieldManagerConst()->getFieldByID(field_interaction.src_fieldnum)->getName();
+        // this_src_field_name holds * in *_velocity field name we are looking for
+        try {
+            displacement_to_velocity_map[field_interaction.src_fieldnum] = 
+                _particles->getFieldManagerConst()->getIDOfFieldFromName(this_src_field_name+"_velocity");
+        } catch (...) {
+            std::string msg = "Field " + this_src_field_name + " involved in field interactions, but field " 
+                + this_src_field_name + "_velocity not found.";
+            TEUCHOS_TEST_FOR_EXCEPT_MSG(true, msg.c_str());
+        }
+    }
+
+    // location *_acceleration for any registered field interaction on * (for populating particles at end of simulation)
+    std::vector<local_index_type> displacement_to_acceleration_map(_particles->getFieldManagerConst()->getVectorOfFields().size(), -1);
+    for (InteractingFields field_interaction : _field_interactions) {
+        auto this_src_field_name = _particles->getFieldManagerConst()->getFieldByID(field_interaction.src_fieldnum)->getName();
+        // this_src_field_name holds * in *_velocity field name we are looking for
+        try {
+            displacement_to_acceleration_map[field_interaction.src_fieldnum] = 
+                _particles->getFieldManagerConst()->getIDOfFieldFromName(this_src_field_name+"_acceleration");
+        } catch (...) {
+        }
+    }
+
+    // details for writing to files every nth timestep
+    Compadre::FileManager fm;
+    std::string base, extension;
+
+    if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") >= 0) {
+        // parse by removing extension of filename
+
+        // get extension
+        size_t pos = filename.rfind('.', filename.length());
+
+        // verify there was an extension extension
+        TEUCHOS_TEST_FOR_EXCEPT_MSG(pos <= 0, "Filename specified to solve(...) is missing an extension.");
+
+        base = filename.substr(0, pos);
+        extension = filename.substr(pos+1, filename.length() - pos);
+    }
+
+    std::vector<Teuchos::RCP<mvec_type> > displacement_t_solution(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
+    std::vector<Teuchos::RCP<mvec_type> > velocity_t_solution(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
+    std::vector<Teuchos::RCP<mvec_type> > acceleration_tm1_solution(_particles->getFieldManagerConst()->getVectorOfFields().size(), Teuchos::null);
+
+    // allocate displacement, velocity, and acceleration multivectors and copy initial conditions to these vectors
+    for (InteractingFields field_interaction : _field_interactions) {
+
+        local_index_type field_one = field_interaction.src_fieldnum;
+        local_index_type row_block = (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) ? _field_to_block_row_map[field_one] : 0;
+
+        // this allows us to overwrite the fields in _particles for each RK step and use
+        // existing tools to distribute halo data
+        // get all the vectors set up
+        if (_parameters->get<Teuchos::ParameterList>("solver").get<bool>("blocked")==true) {
+            if (displacement_t_solution[row_block].is_null()) {
+                auto field_one_velocity = displacement_to_velocity_map[field_one];
+                bool setToZero = true;
+                displacement_t_solution[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+                velocity_t_solution[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+                acceleration_tm1_solution[row_block] = Teuchos::rcp(new mvec_type(row_map[row_block], 1, setToZero));
+
+                // get solution from _particles and put it in displacements
+                _particles->getFieldManagerConst()->updateVectorFromFields(displacement_t_solution[row_block], field_one, _problem_dof_data);
+
+                // get velocity from _particles (use mapping we created above)
+                _particles->getFieldManagerConst()->updateVectorFromFields(velocity_t_solution[row_block], field_one_velocity, _problem_dof_data);
+            }
+        } else {
+            // unblocked system is incompatible with the displacement/velocity design
+            std::string msg = "In the solver parameter list, blocked must be set to true.";
+            TEUCHOS_TEST_FOR_EXCEPT_MSG(true, msg.c_str());
+        }
+        _particles->getCoordsConst()->getComm()->barrier();
+    }
+
+
+    // TODO: check parameter list for if operator is lumped
+    bool LUMPED=true;
+
+    // solve acceleration at t0 (NO DAMPING!)
+    for (InteractingFields field_interaction : _field_interactions) {
+
+        local_index_type field_one = field_interaction.src_fieldnum;
+        local_index_type field_two = field_interaction.trg_fieldnum;
+
+        for (op_needing_interaction op : field_interaction.ops_needing) {
+            // (all store into _b), so _b holds stage solution
+            if (op == op_needing_interaction::bc) {
+                assembleBCS(field_one, field_two, t_0, 0 /*internal_dt*/);
+            }
+            else if (op == op_needing_interaction::source) {
+                assembleRHS(field_one, field_two, t_0, 0 /*internal_dt*/);
+            }
+            else if (op == op_needing_interaction::physics) {
+                if (LUMPED) {
+                    assembleOperatorToVector(field_one, field_two, t_0, 0 /*internal_dt*/);
+                } else {
+                    // assembleOperator to a matrix
+                }
+            }
+        }
+        _particles->getCoordsConst()->getComm()->barrier();
+    }
+
+    // a solve could go here to support implicit aspects
+    if (!LUMPED) {
+        // solve would go here, solution in _x needs extracted
+    }
+
+    // extract acceleration solution at time t0 from particles
+    for (InteractingFields field_interaction : _field_interactions) {
+        local_index_type field_one = field_interaction.src_fieldnum;
+        local_index_type row_block = _field_to_block_row_map[field_one];
+
+        host_view_type solution_data = _b[row_block]->getLocalView<host_view_type>();
+        host_view_type acceleration_data = acceleration_tm1_solution[row_block]->getLocalView<host_view_type>();
+        // diagnostic only
+        //host_view_type velocity_data = velocity_t_solution[row_block]->getLocalView<host_view_type>();
+        //host_view_type displacement_data = displacement_t_solution[row_block]->getLocalView<host_view_type>();
+
+        for (size_t k=0; k<acceleration_data.extent(0); ++k) {
+            acceleration_data(k,0) = solution_data(k,0);
+            // diagnostic only
+            //printf("acceleration data(%d): %f\n", k, acceleration_data(k,0));
+            //printf("velocity data(%d): %f\n", k, velocity_data(k,0));
+            //printf("displacement data(%d): %f\n", k, displacement_data(k,0));
+        }
+        _particles->getCoordsConst()->getComm()->barrier();
+    }
+
+    
+    scalar_type old_t = t_0;
+    scalar_type internal_dt = std::min(dt, t_end-t_0);
+    scalar_type t = t_0 + internal_dt;
+
+    int timestep_count = 0;
+    int write_count = 0;
+    while ( t<(t_end+1e-15) && internal_dt>1e-15) {
+        //printf("t: %f, dt: %f\n", t, internal_dt);
+
+        // move displacement to t-dt to t
+        for (InteractingFields field_interaction : _field_interactions) {
+            local_index_type field_one = field_interaction.src_fieldnum;
+            local_index_type row_block = _field_to_block_row_map[field_one];
+
+            host_view_type displacement_data = displacement_t_solution[row_block]->getLocalView<host_view_type>();
+            host_view_type velocity_data = velocity_t_solution[row_block]->getLocalView<host_view_type>();
+            host_view_type acceleration_data = acceleration_tm1_solution[row_block]->getLocalView<host_view_type>();
+
+            // time integrate solution
+            host_view_local_index_type bc_id = _particles->getFlags()->getLocalView<host_view_local_index_type>();
+            for (size_t k=0; k<acceleration_data.extent(0); ++k) {
+                displacement_data(k,0) += internal_dt*velocity_data(k,0) + 0.5*(1-2.0*beta)*internal_dt*internal_dt*acceleration_data(k,0);
+            }
+            _particles->getCoordsConst()->getComm()->barrier();
+        }
+
+        // move the updated displacements back onto the particles
+        for (InteractingFields field_interaction : _field_interactions) {
+            local_index_type field_one = field_interaction.src_fieldnum;
+            local_index_type row_block = _field_to_block_row_map[field_one];
+            _particles->getFieldManager()->updateFieldsFromVector(displacement_t_solution[row_block], field_one, _problem_dof_data);
+            _particles->getCoordsConst()->getComm()->barrier();
+        }
+
+        // solve acceleration (NO DAMPING!)
+        for (InteractingFields field_interaction : _field_interactions) {
+
+            local_index_type field_one = field_interaction.src_fieldnum;
+            local_index_type field_two = field_interaction.trg_fieldnum;
+
+            for (op_needing_interaction op : field_interaction.ops_needing) {
+                // (all store into _b), so _b holds solution
+                if (op == op_needing_interaction::bc) {
+                    assembleBCS(field_one, field_two, t, internal_dt);
+                }
+                else if (op == op_needing_interaction::source) {
+                    assembleRHS(field_one, field_two, t, internal_dt);
+                }
+                else if (op == op_needing_interaction::physics) {
+                    if (LUMPED) {
+                        assembleOperatorToVector(field_one, field_two, t, internal_dt);
+                    } else {
+                        // assembleOperator to a matrix
+                    }
+                }
+            }
+            //// TODO: REMOVE THIS!
+            //local_index_type row_block = _field_to_block_row_map[field_one];
+            //host_view_type solution_data = _b[row_block]->getLocalView<host_view_type>();
+            //for (size_t k=0; k<solution_data.extent(0); ++k) {
+            //    solution_data(k,0) = 1.0;
+            //}
+            _particles->getCoordsConst()->getComm()->barrier();
+        }
+
+        // a solve could go here to support implicit aspects
+        if (!LUMPED) {
+            // solve would go here, solution in _x extracted later
+        } 
+
+        for (InteractingFields field_interaction : _field_interactions) {
+
+            local_index_type field_one = field_interaction.src_fieldnum;
+            local_index_type row_block = _field_to_block_row_map[field_one];
+
+            host_view_type solution_data;
+            if (!LUMPED) {
+                // solution in _x needs extracted
+            } else {
+                // extract solution from _b
+                solution_data = _b[row_block]->getLocalView<host_view_type>();
+            }
+
+            // update _particles
+            host_view_type velocity_data = velocity_t_solution[row_block]->getLocalView<host_view_type>();
+            host_view_type acceleration_data = acceleration_tm1_solution[row_block]->getLocalView<host_view_type>();
+
+            // time integrate solution
+            host_view_local_index_type bc_id = _particles->getFlags()->getLocalView<host_view_local_index_type>();
+            for (size_t k=0; k<acceleration_data.extent(0); ++k) {
+                if (bc_id(k,0)==0) {
+                    //printf("nb:vel before: %f, a_before: %f, a_new: %f\n", velocity_data(k,0), acceleration_data(k,0), solution_data(k,0));
+                    velocity_data(k,0) += (1-gamma)*internal_dt*acceleration_data(k,0) + gamma*internal_dt*solution_data(k,0);
+                    acceleration_data(k,0) = solution_data(k,0);
+                } else {
+                    //printf("ib:vel before: %f, a_before: %f, a_new: %f\n", velocity_data(k,0), acceleration_data(k,0), solution_data(k,0));
+                    velocity_data(k,0) += (1-gamma)*internal_dt*acceleration_data(k,0) + gamma*internal_dt*solution_data(k,0);
+                    acceleration_data(k,0) = solution_data(k,0);
+                }
+            }
+            _particles->getCoordsConst()->getComm()->barrier();
+        }
+        
+        old_t = t;
+        internal_dt = std::min(dt, t_end-t);
+        t += internal_dt; // advance the time
+        timestep_count++;
+
+        if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") > 0) {
+
+            // check if this is a timestep to write at
+            if (timestep_count % _parameters->get<Teuchos::ParameterList>("io").get<int>("write every") == 0) {
+                write_count++;
+
+                // add in the write_count
+                filename = _parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file prefix") + base + "_" + std::to_string(write_count) + "." + extension;
+
+                fm.setWriter(filename, _particles);
+                if (_comm->getRank()==0)
+                    std::cout << "Wrote " << filename << " to disk for simulation time t=" << t << "." << std::endl;
+
+                // requires mapping solution back in order to write particles to disk
+                for (InteractingFields field_interaction : _field_interactions) {
+                    local_index_type field_one = field_interaction.src_fieldnum;
+                    local_index_type row_block = _field_to_block_row_map[field_one];
+                    auto field_one_velocity = displacement_to_velocity_map[field_one];
+                    _particles->getFieldManager()->updateFieldsFromVector(displacement_t_solution[row_block], field_one, _problem_dof_data);
+                    _particles->getFieldManager()->updateFieldsFromVector(velocity_t_solution[row_block], field_one_velocity, _problem_dof_data);
+                    auto field_one_acceleration = displacement_to_acceleration_map[field_one];
+                    if (field_one_acceleration > -1) {
+                        _particles->getFieldManager()->updateFieldsFromVector(acceleration_tm1_solution[row_block], field_one_acceleration, _problem_dof_data);
+                    }
+                    _particles->getCoordsConst()->getComm()->barrier();
+                }
+
+                fm.write();
+            }
+        }
+    }
+
+
+    // get solution back from vector onto particles (only at last time step)
+    for (InteractingFields field_interaction : _field_interactions) {
+        local_index_type field_one = field_interaction.src_fieldnum;
+        local_index_type row_block = _field_to_block_row_map[field_one];
+        auto field_one_velocity = displacement_to_velocity_map[field_one];
+        _particles->getFieldManager()->updateFieldsFromVector(displacement_t_solution[row_block], field_one, _problem_dof_data);
+        _particles->getFieldManager()->updateFieldsFromVector(velocity_t_solution[row_block], field_one_velocity, _problem_dof_data);
+        auto field_one_acceleration = displacement_to_acceleration_map[field_one];
+        if (field_one_acceleration > -1) {
+            _particles->getFieldManager()->updateFieldsFromVector(acceleration_tm1_solution[row_block], field_one_acceleration, _problem_dof_data);
+        }
+        _particles->getCoordsConst()->getComm()->barrier();
+    }
+
+    // refresh fields' halo data
+    _particles->getFieldManager()->updateFieldsHaloData();
+
+    // user selected to only output as last time step
+    if (_parameters->get<Teuchos::ParameterList>("io").get<int>("write every") == 0) {
+        // only write last timestep data
+
+        filename = _parameters->get<Teuchos::ParameterList>("io").get<std::string>("output file prefix") + base + "." + extension;
+        if (_particles->getCoordsConst()->getComm()->getRank()==0)
+            printf("filename: %s\n", filename.c_str());
+
+        fm.setWriter(filename, _particles);
+
+        fm.write();
+    }
+
+    if (_comm->getRank()==0) {
+        printf("%d timestep%s taken.\n", timestep_count, (timestep_count==1) ? "" : "s");
+        printf("final time: %.16f\n", t);
+    }
 }
 
 void ProblemExplicitTransientT::buildMaps(local_index_type field_one, local_index_type field_two) {

--- a/src/Compadre_ProblemExplicitTransientT.hpp
+++ b/src/Compadre_ProblemExplicitTransientT.hpp
@@ -103,7 +103,7 @@ class ProblemExplicitTransientT {
 		Teuchos::RCP<const mvec_type> getb(local_index_type row_block = -1) const;
 
 		void initialize();
-		void solve(local_index_type rk_order, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename);
+		void solve(Teuchos::ParameterList& parameters_time, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename);
 
 	private:
 
@@ -115,6 +115,9 @@ class ProblemExplicitTransientT {
 		void assembleRHS(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0);
 		void assembleBCS(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0);
 		void registerFieldInteractions(const std::vector<InteractingFields>& ops_to_register);
+
+		void solveRK(Teuchos::ParameterList& parameters_time, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename);
+		void solveNewmark(Teuchos::ParameterList& parameters_time, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename);
 
 };
 

--- a/src/Compadre_ProblemExplicitTransientT.hpp
+++ b/src/Compadre_ProblemExplicitTransientT.hpp
@@ -111,9 +111,9 @@ class ProblemExplicitTransientT {
 //		void buildGraphs(local_index_type field_one, local_index_type field_two);
 //		void buildSolver();
 //		void assembleOperator(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0);
-		void assembleOperatorToVector(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0);
-		void assembleRHS(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0);
-		void assembleBCS(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0);
+		void assembleOperatorToVector(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0, scalar_type previous_delta_time = -1.0);
+		void assembleRHS(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0, scalar_type previous_delta_time = -1.0);
+		void assembleBCS(local_index_type field_one = 0, local_index_type field_two = -1, scalar_type simulation_time = 0, scalar_type delta_time = 0, scalar_type previous_delta_time = -1.0);
 		void registerFieldInteractions(const std::vector<InteractingFields>& ops_to_register);
 
 		void solveRK(Teuchos::ParameterList& parameters_time, scalar_type t_0, scalar_type t_end, scalar_type dt, std::string filename);

--- a/src/Compadre_SourcesT.hpp
+++ b/src/Compadre_SourcesT.hpp
@@ -47,7 +47,7 @@ class SourcesT {
 			_dof_data = dof_data;
 		}
 
-		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0) = 0;
+		virtual void evaluateRHS(local_index_type field_one, local_index_type field_two = -1, scalar_type time = 0.0, scalar_type current_timestep_size = 0.0, scalar_type previous_timestep_size = -1.0) = 0;
 
 		virtual std::vector<InteractingFields> gatherFieldInteractions() = 0;
 };

--- a/test_data/parameter_lists/explicit/parameters_newmark_exact.xml
+++ b/test_data/parameter_lists/explicit/parameters_newmark_exact.xml
@@ -1,6 +1,6 @@
 <ParameterList name="Compadre">
-  <Parameter name="simulation type" type="string" value="lagrangian"/>
-  <Parameter name="shallow water test case" type="int" value="2"/>
+  <Parameter name="simulation type" type="string" value="eulerian"/>
+  <Parameter name="solution type" type="string" value="polynomial time"/>
   <ParameterList name="solver">
     <Parameter name="blocked" type="bool" value="true"/>
   </ParameterList>
@@ -8,7 +8,7 @@
     <Parameter name="porder" type="int" value="2"/>
     <Parameter name="curvature porder" type="int" value="2"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
-    <Parameter name="problem type" type="string" value="MANIFOLD"/>
+    <Parameter name="problem type" type="string" value="STANDARD"/>
     <Parameter name="constraint type" type="string" value="NONE"/>
   </ParameterList>
   <ParameterList name="neighborhood">
@@ -21,24 +21,21 @@
     <Parameter name="multiplier" type="double" value="32.0"/>
   </ParameterList>
   <ParameterList name="time">
-    <Parameter name="order" type="int" value="4"/>
+    <Parameter name="type" type="string" value="newmark"/>
+    <Parameter name="gamma" type="double" value="0.5"/>
+    <Parameter name="beta" type="double" value="0.0"/>
     <Parameter name="t0" type="double" value="0"/>
-    <Parameter name="t_end" type="double" value="20000.0"/>
-    <Parameter name="dt" type="double" value="500"/>
-    <Parameter name="dt multiplier" type="double" value="0.7"/>
+    <Parameter name="t_end" type="double" value="2.0"/>
+    <Parameter name="dt" type="double" value="0.15"/>
   </ParameterList>
   <ParameterList name="io">
     <Parameter name="input dimensions" type="int" value="3"/>
     <Parameter name="input file prefix" type="string" value="../test_data/grids/"/>
-    <Parameter name="input file" type="string" value="shallow_1.nc"/>
-    <Parameter name="coordinates layout" type="string" value="lat_lon_separate"/>
+    <Parameter name="input file" type="string" value="output_12.nc"/>
+    <Parameter name="coordinates layout" type="string" value="xyz_separate"/>
     <Parameter name="output file prefix" type="string" value="../test_data/"/>
-    <Parameter name="output file" type="string" value="shallow_water.nc"/>
-    <Parameter name="write every" type="int" value="20"/>
-    <Parameter name="keep original lat lon" type="bool" value="true"/>
-    <Parameter name="coordinate 0 name" type="string" value="grid_center_lat"/>
-    <Parameter name="coordinate 1 name" type="string" value="grid_center_lon"/>
-    <Parameter name="particles number dimension name" type="string" value="grid_size"/>
+    <Parameter name="output file" type="string" value="explicit_exact.nc"/>
+    <Parameter name="write every" type="int" value="100"/>
   </ParameterList>
   <ParameterList name="physics">
     <Parameter name="artificial viscosity" type="double" value="0e-8"/>

--- a/test_data/parameter_lists/explicit/parameters_newmark_nonpolynomial.xml
+++ b/test_data/parameter_lists/explicit/parameters_newmark_nonpolynomial.xml
@@ -1,6 +1,6 @@
 <ParameterList name="Compadre">
   <Parameter name="simulation type" type="string" value="eulerian"/>
-  <Parameter name="solution type" type="string" value="polynomial time"/>
+  <Parameter name="solution type" type="string" value="nonpolynomial time"/>
   <ParameterList name="solver">
     <Parameter name="blocked" type="bool" value="true"/>
   </ParameterList>
@@ -21,10 +21,12 @@
     <Parameter name="multiplier" type="double" value="32.0"/>
   </ParameterList>
   <ParameterList name="time">
-    <Parameter name="rk order" type="int" value="4"/>
+    <Parameter name="type" type="string" value="newmark"/>
+    <Parameter name="gamma" type="double" value="0.5"/>
+    <Parameter name="beta" type="double" value="0.0"/>
     <Parameter name="t0" type="double" value="0"/>
     <Parameter name="t_end" type="double" value="1.0"/>
-    <Parameter name="dt" type="double" value=".06"/>
+    <Parameter name="dt" type="double" value=".015"/>
   </ParameterList>
   <ParameterList name="io">
     <Parameter name="input dimensions" type="int" value="3"/>

--- a/test_data/parameter_lists/explicit/parameters_rk_exact.xml
+++ b/test_data/parameter_lists/explicit/parameters_rk_exact.xml
@@ -1,6 +1,6 @@
 <ParameterList name="Compadre">
   <Parameter name="simulation type" type="string" value="eulerian"/>
-  <Parameter name="solution type" type="string" value="nonpolynomial time"/>
+  <Parameter name="solution type" type="string" value="polynomial time"/>
   <ParameterList name="solver">
     <Parameter name="blocked" type="bool" value="true"/>
   </ParameterList>
@@ -21,7 +21,7 @@
     <Parameter name="multiplier" type="double" value="32.0"/>
   </ParameterList>
   <ParameterList name="time">
-    <Parameter name="rk order" type="int" value="4"/>
+    <Parameter name="order" type="int" value="4"/>
     <Parameter name="t0" type="double" value="0"/>
     <Parameter name="t_end" type="double" value="1.0"/>
     <Parameter name="dt" type="double" value=".06"/>

--- a/test_data/parameter_lists/explicit/parameters_rk_nonpolynomial.xml
+++ b/test_data/parameter_lists/explicit/parameters_rk_nonpolynomial.xml
@@ -1,6 +1,6 @@
 <ParameterList name="Compadre">
-  <Parameter name="simulation type" type="string" value="lagrangian"/>
-  <Parameter name="shallow water test case" type="int" value="2"/>
+  <Parameter name="simulation type" type="string" value="eulerian"/>
+  <Parameter name="solution type" type="string" value="nonpolynomial time"/>
   <ParameterList name="solver">
     <Parameter name="blocked" type="bool" value="true"/>
   </ParameterList>
@@ -8,7 +8,7 @@
     <Parameter name="porder" type="int" value="2"/>
     <Parameter name="curvature porder" type="int" value="2"/>
     <Parameter name="dense solver type" type="string" value="QR"/>
-    <Parameter name="problem type" type="string" value="MANIFOLD"/>
+    <Parameter name="problem type" type="string" value="STANDARD"/>
     <Parameter name="constraint type" type="string" value="NONE"/>
   </ParameterList>
   <ParameterList name="neighborhood">
@@ -23,22 +23,17 @@
   <ParameterList name="time">
     <Parameter name="order" type="int" value="4"/>
     <Parameter name="t0" type="double" value="0"/>
-    <Parameter name="t_end" type="double" value="20000.0"/>
-    <Parameter name="dt" type="double" value="500"/>
-    <Parameter name="dt multiplier" type="double" value="0.7"/>
+    <Parameter name="t_end" type="double" value="1.0"/>
+    <Parameter name="dt" type="double" value=".06"/>
   </ParameterList>
   <ParameterList name="io">
     <Parameter name="input dimensions" type="int" value="3"/>
     <Parameter name="input file prefix" type="string" value="../test_data/grids/"/>
-    <Parameter name="input file" type="string" value="shallow_1.nc"/>
-    <Parameter name="coordinates layout" type="string" value="lat_lon_separate"/>
+    <Parameter name="input file" type="string" value="output_12.nc"/>
+    <Parameter name="coordinates layout" type="string" value="xyz_separate"/>
     <Parameter name="output file prefix" type="string" value="../test_data/"/>
-    <Parameter name="output file" type="string" value="shallow_water.nc"/>
-    <Parameter name="write every" type="int" value="20"/>
-    <Parameter name="keep original lat lon" type="bool" value="true"/>
-    <Parameter name="coordinate 0 name" type="string" value="grid_center_lat"/>
-    <Parameter name="coordinate 1 name" type="string" value="grid_center_lon"/>
-    <Parameter name="particles number dimension name" type="string" value="grid_size"/>
+    <Parameter name="output file" type="string" value="explicit_exact.nc"/>
+    <Parameter name="write every" type="int" value="100"/>
   </ParameterList>
   <ParameterList name="physics">
     <Parameter name="artificial viscosity" type="double" value="0e-8"/>

--- a/test_data/parameter_lists/shallow_water/parameters_case5.xml
+++ b/test_data/parameter_lists/shallow_water/parameters_case5.xml
@@ -22,7 +22,7 @@
     <Parameter name="multiplier" type="double" value="8.0"/>
   </ParameterList>
   <ParameterList name="time">
-    <Parameter name="rk order" type="int" value="4"/>
+    <Parameter name="order" type="int" value="4"/>
     <Parameter name="t0" type="double" value="0"/>
     <Parameter name="t_end" type="double" value="1723282"/>
     <!--Parameter name="dt" type="double" value="1795.08541666666667"/-->


### PR DESCRIPTION
Previously, all time integration handled by ProblemExplicitTransientT
was for explicit Runge-Kutta. Now, setting 'type' in the 'time'
parameter list to 'rk' will give explicit Runge-Kutta and 'newmark'
will give Newmark.

This still only supports explicit methods with Newmark, i.e. beta=0.

Tests are added for gamma=0.5, i.e. explicit second centered difference.

- [ ] A test should be added for gamma!=0.5