### PR TITLE
Add getAlpha and setAdditionalEvaluationSitesData to pycompadre

### DIFF
--- a/src/Compadre_NeighborLists.hpp
+++ b/src/Compadre_NeighborLists.hpp
@@ -234,9 +234,9 @@ public:
     int getNeighborHost(int target_index, int neighbor_num) const {
         compadre_assert_debug((!_needs_sync_to_host) 
                 && "Stale information in host_cr_neighbor_lists. Call CopyDeviceDataToHost() to refresh.");
-        compadre_assert_debug((neighbor_num<_number_of_neighbors_list(target_index))
+        compadre_assert_debug((neighbor_num<_host_number_of_neighbors_list(target_index))
                 && "neighor_num exceeds number of neighbors for this target_index.");
-        return _host_cr_neighbor_lists(_row_offsets(target_index)+neighbor_num);
+        return _host_cr_neighbor_lists(_host_row_offsets(target_index)+neighbor_num);
     }
 
     //! Offers N(i,j) indexing where N(i,j) is the index of the jth neighbor of i (device)


### PR DESCRIPTION
Exposed getAlpha from the GMLS class, which allows for access to
the individual alpha values generated by GMLS.

setAdditionalEvaluationSitesData allows for the evaluation at
locations other than just target sites.