### PR TITLE
Made additional evaluation data consistent with neighbor lists in GMLS class

### DIFF
--- a/src/Compadre_GMLS.hpp
+++ b/src/Compadre_GMLS.hpp
@@ -105,7 +105,7 @@ protected:
     //! (OPTIONAL) user provided additional coordinates for target operation evaluation (device)
     Kokkos::View<double**, layout_right> _additional_evaluation_coordinates; 
 
-    //! (OPTIONAL) Accessor to get additioanl evaluation list data, offset data, and number of sites
+    //! (OPTIONAL) Accessor to get additional evaluation list data, offset data, and number of sites
     NeighborLists<Kokkos::View<int*> > _additional_evaluation_indices; 
 
     //! (OPTIONAL) contains the # of additional evaluation sites per target site


### PR DESCRIPTION
- Neighbor lists use the NeighborLists class in the GMLS class and additional_evaluation_indices were still using the rank 2 vector style storage of additional evaluation site indices.
- Now GMLS class supports both styles of neighbor lists for the additional evaluation indices.
- Add applyStencilAllTargetsAllAdditionalEvaluationSites for pycompadre.